### PR TITLE
chore: use cloudflare r2 s3 for cheaper egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Download and extract the pre-collected dataset (33.3GiB compressed):
 make setup
 ```
 
-This downloads `data.tar.zst` from [Google Cloud Storage](https://storage.googleapis.com/prediction-market-analysis) and extracts it to `data/`.
+This downloads `data.tar.zst` from [Cloudflare R2 Storage](https://s3.jbecker.dev/data.tar.zst) and extracts it to `data/`.
 
 ### Data Collection
 

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL="https://storage.googleapis.com/prediction-market-analysis/data.tar.zst"
+URL="https://s3.jbecker.dev/data.tar.zst"
 OUTPUT_FILE="data.tar.zst"
 DATA_DIR="data"
 


### PR DESCRIPTION
## What changed? Why?

migrated data source from google cloud storage to cloudflare r2 for more cost-effective egress. updated the download script and readme to point to the new s3 endpoint at `s3.jbecker.dev`.

## Notes to reviewers

- `scripts/download.sh`: updated url to cloudflare r2 s3 endpoint
- `README.md`: updated documentation to reflect new storage location

## How has it been tested?

manual verification that the new s3 endpoint is accessible and serves the data file correctly.
