### PR TITLE
chore: comparative win rate by price animated

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def analyze(name: str | None = None):
             for analysis_cls in analyses:
                 instance = analysis_cls()
                 print(f"Running: {instance.name}")
-                saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json"])
+                saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json", "gif"])
                 for fmt, path in saved.items():
                     print(f"  {fmt}: {path}")
             print("\nAll analyses complete.")
@@ -39,7 +39,7 @@ def analyze(name: str | None = None):
             instance = analysis_cls()
             if instance.name == name:
                 print(f"\nRunning: {instance.name}\n")
-                saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json"])
+                saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json", "gif"])
                 print("Saved files:")
                 for fmt, path in saved.items():
                     print(f"  {fmt}: {path}")
@@ -77,7 +77,7 @@ def analyze(name: str | None = None):
         for analysis_cls in analyses:
             instance = analysis_cls()
             print(f"Running: {instance.name}")
-            saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json"])
+            saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json", "gif"])
             for fmt, path in saved.items():
                 print(f"  {fmt}: {path}")
         print("\nAll analyses complete.")
@@ -86,7 +86,7 @@ def analyze(name: str | None = None):
         analysis_cls = analyses[choice - 1]
         instance = analysis_cls()
         print(f"\nRunning: {instance.name}\n")
-        saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json"])
+        saved = instance.save(output_dir, formats=["png", "pdf", "csv", "json", "gif"])
         print("Saved files:")
         for fmt, path in saved.items():
             print(f"  {fmt}: {path}")

--- a/src/analysis/comparison/win_rate_by_price_animated.py
+++ b/src/analysis/comparison/win_rate_by_price_animated.py
@@ -1,0 +1,421 @@
+"""Animated side-by-side calibration comparison between Kalshi and Polymarket."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import matplotlib.pyplot as plt
+import pandas as pd
+from matplotlib.animation import FuncAnimation
+
+from src.common.analysis import Analysis, AnalysisOutput
+
+# Bucket size for block-to-timestamp approximation (10800 blocks ~ 6 hours at 2 sec/block)
+BLOCK_BUCKET_SIZE = 10800
+
+
+class WinRateByPriceAnimatedAnalysis(Analysis):
+    """Animated side-by-side visualization of calibration evolution on both platforms."""
+
+    def save(
+        self,
+        output_dir: Path | str,
+        formats: list[str] | None = None,
+        dpi: int = 100,
+    ) -> dict[str, Path]:
+        """Save with GIF as default format for animated output."""
+        if formats is None:
+            formats = ["gif", "csv"]
+        return super().save(output_dir, formats, dpi)
+
+    def __init__(
+        self,
+        kalshi_trades_dir: Path | str | None = None,
+        kalshi_markets_dir: Path | str | None = None,
+        polymarket_trades_dir: Path | str | None = None,
+        polymarket_legacy_trades_dir: Path | str | None = None,
+        polymarket_markets_dir: Path | str | None = None,
+        polymarket_blocks_dir: Path | str | None = None,
+        collateral_lookup_path: Path | str | None = None,
+    ):
+        super().__init__(
+            name="win_rate_by_price_animated",
+            description="Animated side-by-side calibration comparison between platforms",
+        )
+        base_dir = Path(__file__).parent.parent.parent.parent
+
+        # Kalshi paths
+        self.kalshi_trades_dir = Path(kalshi_trades_dir or base_dir / "data" / "kalshi" / "trades")
+        self.kalshi_markets_dir = Path(kalshi_markets_dir or base_dir / "data" / "kalshi" / "markets")
+
+        # Polymarket paths
+        self.polymarket_trades_dir = Path(polymarket_trades_dir or base_dir / "data" / "polymarket" / "trades")
+        self.polymarket_legacy_trades_dir = Path(
+            polymarket_legacy_trades_dir or base_dir / "data" / "polymarket" / "legacy_trades"
+        )
+        self.polymarket_markets_dir = Path(polymarket_markets_dir or base_dir / "data" / "polymarket" / "markets")
+        self.polymarket_blocks_dir = Path(polymarket_blocks_dir or base_dir / "data" / "polymarket" / "blocks")
+        self.collateral_lookup_path = Path(
+            collateral_lookup_path or base_dir / "data" / "polymarket" / "fpmm_collateral_lookup.json"
+        )
+
+    def run(self) -> AnalysisOutput:
+        """Execute the analysis and return animated output."""
+        with self.progress("Loading Kalshi aggregates"):
+            kalshi_agg = self._load_kalshi_aggregates()
+
+        with self.progress("Loading Polymarket aggregates"):
+            polymarket_agg = self._load_polymarket_aggregates()
+
+        with self.progress("Computing cumulative data"):
+            kalshi_cumulative = self._compute_cumulative(kalshi_agg)
+            poly_cumulative = self._compute_cumulative(polymarket_agg)
+
+        # Get all weeks from both platforms
+        all_weeks = sorted(set(kalshi_cumulative.keys()) | set(poly_cumulative.keys()))
+
+        # Filter to days with enough data, then take every 2nd day
+        valid_weeks = [
+            w
+            for w in all_weeks
+            if kalshi_cumulative.get(w, {}).get("total", 0) >= 1000
+            or poly_cumulative.get(w, {}).get("total", 0) >= 1000
+        ]
+        valid_weeks = valid_weeks[::2]
+
+        # Create figure
+        fig, ax = plt.subplots(figsize=(10, 7))
+
+        (poly_line,) = ax.plot([], [], color="#3B82F6", linewidth=2, label="Polymarket (Actual)")
+        (kalshi_line,) = ax.plot([], [], color="#10B981", linewidth=2, label="Kalshi (Actual)")
+        ax.plot([0, 100], [0, 100], linestyle="--", color="#6B7280", linewidth=1.5, label="Implied")
+
+        info_text = ax.text(
+            0.02,
+            0.98,
+            "",
+            transform=ax.transAxes,
+            fontsize=12,
+            fontweight="bold",
+            verticalalignment="top",
+            bbox={"boxstyle": "round", "facecolor": "white", "alpha": 0.8},
+        )
+
+        ax.set_xlabel("Contract Price (cents)")
+        ax.set_ylabel("Actual Win Rate (%)")
+        ax.set_title("Actual Win Rate vs Contract Price")
+        ax.set_xlim(0, 100)
+        ax.set_ylim(0, 100)
+        ax.set_xticks(range(0, 101, 10))
+        ax.set_yticks(range(0, 101, 10))
+        ax.legend(loc="lower right")
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+
+        # Add pause frames
+        pause_frames = 10
+        total_frames = len(valid_weeks) + pause_frames
+
+        # Pre-sort weeks for each platform for binary search
+        kalshi_weeks = sorted(kalshi_cumulative.keys())
+        poly_weeks = sorted(poly_cumulative.keys())
+
+        def get_latest_data(cumulative: dict, sorted_weeks: list, target_week) -> dict:
+            """Get cumulative data for the most recent week <= target_week."""
+            # Find the latest week that's <= target_week
+            latest = None
+            for w in sorted_weeks:
+                if w <= target_week:
+                    latest = w
+                else:
+                    break
+            return cumulative.get(latest, {}) if latest else {}
+
+        def animate(frame_idx: int) -> tuple:
+            week_idx = min(frame_idx, len(valid_weeks) - 1)
+            week = valid_weeks[week_idx]
+
+            # Kalshi data - get most recent available
+            k_data = get_latest_data(kalshi_cumulative, kalshi_weeks, week)
+            k_total = k_data.get("total", 0)
+            if k_total >= 100:
+                prices = sorted(k_data["by_price"].keys())
+                win_rates = [100.0 * k_data["by_price"][p]["wins"] / k_data["by_price"][p]["total"] for p in prices]
+                kalshi_line.set_data(prices, win_rates)
+            else:
+                kalshi_line.set_data([], [])
+
+            # Polymarket data - get most recent available
+            p_data = get_latest_data(poly_cumulative, poly_weeks, week)
+            p_total = p_data.get("total", 0)
+            if p_total >= 100:
+                prices = sorted(p_data["by_price"].keys())
+                win_rates = [100.0 * p_data["by_price"][p]["wins"] / p_data["by_price"][p]["total"] for p in prices]
+                poly_line.set_data(prices, win_rates)
+            else:
+                poly_line.set_data([], [])
+
+            info_text.set_text(week.strftime("%Y-%m-%d"))
+
+            return poly_line, kalshi_line, info_text
+
+        anim = FuncAnimation(
+            fig,
+            animate,
+            frames=total_frames,
+            interval=10,
+            blit=False,
+            repeat=False,
+        )
+
+        # Build output data from final week
+        output_rows = []
+        if valid_weeks:
+            final_week = valid_weeks[-1]
+            for platform, data in [("kalshi", kalshi_cumulative), ("polymarket", poly_cumulative)]:
+                week_data = data.get(final_week, {}).get("by_price", {})
+                for price, vals in week_data.items():
+                    output_rows.append(
+                        {
+                            "platform": platform,
+                            "price": price,
+                            "total": vals["total"],
+                            "wins": vals["wins"],
+                            "win_rate": 100.0 * vals["wins"] / vals["total"],
+                        }
+                    )
+
+        output_df = pd.DataFrame(output_rows)
+
+        return AnalysisOutput(
+            figure=anim,
+            data=output_df,
+            metadata={"total_weeks": len(valid_weeks)},
+        )
+
+    def _compute_cumulative(self, df: pd.DataFrame) -> dict:
+        """Pre-compute cumulative totals/wins by price for each week."""
+        if df.empty:
+            return {}
+
+        # Normalize timezone
+        df = df.copy()
+        df["week"] = pd.to_datetime(df["week"])
+        if df["week"].dt.tz is not None:
+            df["week"] = df["week"].dt.tz_convert(None)
+
+        weeks = sorted(df["week"].unique())
+        cumulative: dict = {}
+        running_totals: dict[int, dict] = {}  # price -> {total, wins}
+
+        for week in weeks:
+            week_data = df[df["week"] == week]
+            for _, row in week_data.iterrows():
+                price = int(row["price"])
+                if price not in running_totals:
+                    running_totals[price] = {"total": 0, "wins": 0}
+                running_totals[price]["total"] += row["total"]
+                running_totals[price]["wins"] += row["wins"]
+
+            # Store snapshot for this week
+            cumulative[week] = {
+                "total": sum(v["total"] for v in running_totals.values()),
+                "by_price": {p: dict(v) for p, v in running_totals.items()},
+            }
+
+        return cumulative
+
+    def _load_kalshi_aggregates(self) -> pd.DataFrame:
+        """Load Kalshi trades pre-aggregated by week and price."""
+        con = duckdb.connect()
+
+        df = con.execute(
+            f"""
+            WITH resolved_markets AS (
+                SELECT ticker, result
+                FROM '{self.kalshi_markets_dir}/*.parquet'
+                WHERE status = 'finalized'
+                  AND result IN ('yes', 'no')
+            ),
+            all_positions AS (
+                -- Taker side
+                SELECT
+                    DATE_TRUNC('day', t.created_time) AS week,
+                    CASE WHEN t.taker_side = 'yes' THEN t.yes_price ELSE t.no_price END AS price,
+                    CASE WHEN t.taker_side = m.result THEN 1 ELSE 0 END AS won
+                FROM '{self.kalshi_trades_dir}/*.parquet' t
+                INNER JOIN resolved_markets m ON t.ticker = m.ticker
+
+                UNION ALL
+
+                -- Maker side (counterparty)
+                SELECT
+                    DATE_TRUNC('day', t.created_time) AS week,
+                    CASE WHEN t.taker_side = 'yes' THEN t.no_price ELSE t.yes_price END AS price,
+                    CASE WHEN t.taker_side != m.result THEN 1 ELSE 0 END AS won
+                FROM '{self.kalshi_trades_dir}/*.parquet' t
+                INNER JOIN resolved_markets m ON t.ticker = m.ticker
+            )
+            SELECT week, price, COUNT(*) AS total, SUM(won) AS wins
+            FROM all_positions
+            WHERE price >= 1 AND price <= 99
+            GROUP BY week, price
+            ORDER BY week, price
+            """
+        ).df()
+
+        return df
+
+    def _load_polymarket_aggregates(self) -> pd.DataFrame:
+        """Load Polymarket trades pre-aggregated by week and price, including legacy trades."""
+        con = duckdb.connect()
+
+        # Build CTF token_id -> won mapping
+        markets_df = con.execute(
+            f"""
+            SELECT id, clob_token_ids, outcome_prices, market_maker_address
+            FROM '{self.polymarket_markets_dir}/*.parquet'
+            WHERE closed = true
+            """
+        ).df()
+
+        token_won: dict[str, bool] = {}
+        fpmm_resolution: dict[str, int] = {}
+
+        for _, row in markets_df.iterrows():
+            try:
+                prices = json.loads(row["outcome_prices"]) if row["outcome_prices"] else None
+                if not prices or len(prices) != 2:
+                    continue
+                p0, p1 = float(prices[0]), float(prices[1])
+
+                winning_outcome = None
+                if p0 > 0.99 and p1 < 0.01:
+                    winning_outcome = 0
+                elif p0 < 0.01 and p1 > 0.99:
+                    winning_outcome = 1
+                else:
+                    continue
+
+                token_ids = json.loads(row["clob_token_ids"]) if row["clob_token_ids"] else None
+                if token_ids and len(token_ids) == 2:
+                    token_won[token_ids[0]] = winning_outcome == 0
+                    token_won[token_ids[1]] = winning_outcome == 1
+
+                fpmm_addr = row.get("market_maker_address")
+                if fpmm_addr:
+                    fpmm_resolution[fpmm_addr.lower()] = winning_outcome
+
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+
+        # Register CTF token mapping
+        con.execute("CREATE TABLE token_resolution (token_id VARCHAR, won BOOLEAN)")
+        con.executemany("INSERT INTO token_resolution VALUES (?, ?)", list(token_won.items()))
+
+        # Filter FPMM to USDC markets only
+        if self.collateral_lookup_path.exists():
+            with open(self.collateral_lookup_path) as f:
+                collateral_lookup = json.load(f)
+            usdc_markets = {
+                addr.lower() for addr, info in collateral_lookup.items() if info["collateral_symbol"] == "USDC"
+            }
+            fpmm_resolution = {k: v for k, v in fpmm_resolution.items() if k in usdc_markets}
+
+        con.execute("CREATE TABLE fpmm_resolution (fpmm_address VARCHAR, winning_outcome BIGINT)")
+        if fpmm_resolution:
+            con.executemany("INSERT INTO fpmm_resolution VALUES (?, ?)", list(fpmm_resolution.items()))
+
+        # Create blocks lookup table
+        con.execute(
+            f"""
+            CREATE TABLE blocks AS
+            SELECT
+                block_number // {BLOCK_BUCKET_SIZE} AS bucket,
+                FIRST(timestamp::TIMESTAMP) AS timestamp
+            FROM '{self.polymarket_blocks_dir}/*.parquet'
+            GROUP BY block_number // {BLOCK_BUCKET_SIZE}
+            """
+        )
+
+        # CTF trades query
+        ctf_trades_query = f"""
+            -- Buyer side
+            SELECT
+                DATE_TRUNC('day', b.timestamp) AS week,
+                CASE
+                    WHEN t.maker_asset_id = '0' THEN ROUND(100.0 * t.maker_amount / t.taker_amount)
+                    ELSE ROUND(100.0 * t.taker_amount / t.maker_amount)
+                END AS price,
+                CASE WHEN tr.won THEN 1 ELSE 0 END AS won
+            FROM '{self.polymarket_trades_dir}/*.parquet' t
+            INNER JOIN token_resolution tr ON (
+                CASE WHEN t.maker_asset_id = '0' THEN t.taker_asset_id ELSE t.maker_asset_id END = tr.token_id
+            )
+            JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
+            WHERE t.taker_amount > 0 AND t.maker_amount > 0
+
+            UNION ALL
+
+            -- Seller side (counterparty)
+            SELECT
+                DATE_TRUNC('day', b.timestamp) AS week,
+                CASE
+                    WHEN t.maker_asset_id = '0' THEN ROUND(100.0 - 100.0 * t.maker_amount / t.taker_amount)
+                    ELSE ROUND(100.0 - 100.0 * t.taker_amount / t.maker_amount)
+                END AS price,
+                CASE WHEN NOT tr.won THEN 1 ELSE 0 END AS won
+            FROM '{self.polymarket_trades_dir}/*.parquet' t
+            INNER JOIN token_resolution tr ON (
+                CASE WHEN t.maker_asset_id = '0' THEN t.taker_asset_id ELSE t.maker_asset_id END = tr.token_id
+            )
+            JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
+            WHERE t.taker_amount > 0 AND t.maker_amount > 0
+        """
+
+        # Legacy FPMM trades query
+        legacy_trades_query = ""
+        if fpmm_resolution and self.polymarket_legacy_trades_dir.exists():
+            legacy_trades_query = f"""
+                UNION ALL
+
+                -- Legacy buyer side
+                SELECT
+                    DATE_TRUNC('day', b.timestamp) AS week,
+                    ROUND(100.0 * t.amount::DOUBLE / t.outcome_tokens::DOUBLE) AS price,
+                    CASE WHEN t.outcome_index = r.winning_outcome THEN 1 ELSE 0 END AS won
+                FROM '{self.polymarket_legacy_trades_dir}/*.parquet' t
+                INNER JOIN fpmm_resolution r ON LOWER(t.fpmm_address) = r.fpmm_address
+                JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
+                WHERE t.outcome_tokens::DOUBLE > 0
+
+                UNION ALL
+
+                -- Legacy seller side (counterparty)
+                SELECT
+                    DATE_TRUNC('day', b.timestamp) AS week,
+                    ROUND(100.0 - 100.0 * t.amount::DOUBLE / t.outcome_tokens::DOUBLE) AS price,
+                    CASE WHEN t.outcome_index != r.winning_outcome THEN 1 ELSE 0 END AS won
+                FROM '{self.polymarket_legacy_trades_dir}/*.parquet' t
+                INNER JOIN fpmm_resolution r ON LOWER(t.fpmm_address) = r.fpmm_address
+                JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
+                WHERE t.outcome_tokens::DOUBLE > 0
+            """
+
+        df = con.execute(
+            f"""
+            WITH trade_positions AS (
+                {ctf_trades_query}
+                {legacy_trades_query}
+            )
+            SELECT week, price, COUNT(*) AS total, SUM(won) AS wins
+            FROM trade_positions
+            WHERE price >= 1 AND price <= 99
+            GROUP BY week, price
+            ORDER BY week, price
+            """
+        ).df()
+
+        return df

--- a/src/analysis/polymarket/polymarket_trades_over_time.py
+++ b/src/analysis/polymarket/polymarket_trades_over_time.py
@@ -1,0 +1,125 @@
+"""Analyze Polymarket trade counts over time at block-level granularity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from src.common.analysis import Analysis, AnalysisOutput
+from src.common.interfaces.chart import ChartConfig, ChartType, UnitType
+
+
+class PolymarketTradesOverTimeAnalysis(Analysis):
+    """Analyze trade counts per block on Polymarket (extremely granular)."""
+
+    def __init__(
+        self,
+        trades_dir: Path | str | None = None,
+        legacy_trades_dir: Path | str | None = None,
+        blocks_dir: Path | str | None = None,
+    ):
+        super().__init__(
+            name="polymarket_trades_over_time",
+            description="Trade counts per block on Polymarket",
+        )
+        base_dir = Path(__file__).parent.parent.parent.parent
+        self.trades_dir = Path(trades_dir or base_dir / "data" / "polymarket" / "trades")
+        self.legacy_trades_dir = Path(legacy_trades_dir or base_dir / "data" / "polymarket" / "legacy_trades")
+        self.blocks_dir = Path(blocks_dir or base_dir / "data" / "polymarket" / "blocks")
+
+    def run(self) -> AnalysisOutput:
+        """Execute the analysis and return outputs."""
+        con = duckdb.connect()
+
+        with self.progress("Counting trades per block"):
+            # Count trades per block (no interpolation - only blocks with trades)
+            # Combines CTF Exchange trades and legacy FPMM trades
+            trades_per_block = con.execute(
+                f"""
+                SELECT
+                    block_number,
+                    SUM(trade_count) AS trade_count
+                FROM (
+                    SELECT block_number, COUNT(*) AS trade_count
+                    FROM '{self.trades_dir}/*.parquet'
+                    GROUP BY block_number
+                    UNION ALL
+                    SELECT block_number, COUNT(*) AS trade_count
+                    FROM '{self.legacy_trades_dir}/*.parquet'
+                    GROUP BY block_number
+                )
+                GROUP BY block_number
+                ORDER BY block_number
+                """
+            ).df()
+
+        with self.progress("Joining with block timestamps"):
+            # Join with blocks to get timestamps
+            con.register("trades_per_block", trades_per_block)
+            df = con.execute(
+                f"""
+                SELECT
+                    t.block_number,
+                    b.timestamp,
+                    t.trade_count
+                FROM trades_per_block t
+                JOIN '{self.blocks_dir}/*.parquet' b ON t.block_number = b.block_number
+                ORDER BY t.block_number
+                """
+            ).df()
+
+        # Convert timestamp to datetime (timestamp is ISO string format)
+        df["datetime"] = pd.to_datetime(df["timestamp"])
+
+        fig = self._create_figure(df)
+        chart = self._create_chart(df)
+
+        return AnalysisOutput(figure=fig, data=df, chart=chart)
+
+    def _create_figure(self, df: pd.DataFrame) -> plt.Figure:
+        """Create the matplotlib figure."""
+        fig, ax = plt.subplots(figsize=(14, 6))
+
+        ax.plot(
+            df["datetime"],
+            df["trade_count"],
+            linewidth=0.1,
+            color="#4C72B0",
+            alpha=0.7,
+        )
+
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Trades per Block")
+        ax.set_title("Polymarket Trades Over Time (Per Block)")
+
+        # Format x-axis
+        fig.autofmt_xdate()
+
+        plt.tight_layout()
+        return fig
+
+    def _create_chart(self, df: pd.DataFrame) -> ChartConfig:
+        """Create the chart configuration for web display."""
+        # Use vectorized conversion for performance with large datasets
+        chart_df = pd.DataFrame(
+            {
+                "block": df["block_number"].astype(int),
+                "timestamp": df["timestamp"],
+                "trades": df["trade_count"].astype(int),
+            }
+        )
+        chart_data = chart_df.to_dict(orient="records")
+
+        return ChartConfig(
+            type=ChartType.LINE,
+            data=chart_data,
+            xKey="timestamp",
+            yKeys=["trades"],
+            title="Polymarket Trades Over Time (Per Block)",
+            xLabel="Timestamp",
+            yLabel="Trades per Block",
+            yUnit=UnitType.NUMBER,
+        )

--- a/src/common/analysis.py
+++ b/src/common/analysis.py
@@ -50,6 +50,7 @@ class AnalysisOutput:
     figure: Figure | FuncAnimation | None = None
     data: pd.DataFrame | None = None
     chart: ChartConfig | None = None
+    metadata: dict | None = None
 
 
 class Analysis(ABC):

--- a/src/indexers/kalshi/client.py
+++ b/src/indexers/kalshi/client.py
@@ -34,7 +34,14 @@ class KalshiClient:
         data = self._get(f"/markets/{ticker}")
         return Market.from_dict(data["market"])
 
-    def get_market_trades(self, ticker: str, limit: int = 1000, verbose: bool = True) -> list[Trade]:
+    def get_market_trades(
+        self,
+        ticker: str,
+        limit: int = 1000,
+        verbose: bool = True,
+        min_ts: Optional[int] = None,
+        max_ts: Optional[int] = None,
+    ) -> list[Trade]:
         all_trades = []
         cursor = None
 
@@ -42,6 +49,10 @@ class KalshiClient:
             params = {"ticker": ticker, "limit": limit}
             if cursor:
                 params["cursor"] = cursor
+            if min_ts is not None:
+                params["min_ts"] = min_ts
+            if max_ts is not None:
+                params["max_ts"] = max_ts
 
             data = self._get("/markets/trades", params=params)
 
@@ -85,12 +96,20 @@ class KalshiClient:
         return all_markets
 
     def iter_markets(
-        self, limit: int = 200, cursor: Optional[str] = None
+        self,
+        limit: int = 200,
+        cursor: Optional[str] = None,
+        min_close_ts: Optional[int] = None,
+        max_close_ts: Optional[int] = None,
     ) -> Generator[tuple[list[Market], Optional[str]], None, None]:
         while True:
             params = {"limit": limit}
             if cursor:
                 params["cursor"] = cursor
+            if min_close_ts is not None:
+                params["min_close_ts"] = min_close_ts
+            if max_close_ts is not None:
+                params["max_close_ts"] = max_close_ts
 
             data = self._get("/markets", params=params)
 

--- a/src/indexers/kalshi/trades.py
+++ b/src/indexers/kalshi/trades.py
@@ -1,8 +1,10 @@
 """Indexer for Kalshi trades data."""
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import duckdb
 import pandas as pd
@@ -19,22 +21,37 @@ CURSOR_FILE = Path("data/kalshi/.backfill_trades_cursor")
 class KalshiTradesIndexer(Indexer):
     """Fetches and stores Kalshi trades data."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        min_ts: Optional[int] = None,
+        max_ts: Optional[int] = None,
+        max_workers: int = 10,
+    ):
         super().__init__(
             name="kalshi_trades",
             description="Backfills Kalshi trades data to parquet files",
         )
+        self._min_ts = min_ts
+        self._max_ts = max_ts
+        self._max_workers = max_workers
 
     def run(self) -> None:
         BATCH_SIZE = 10000
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
 
-        existing_tickers = set()
-        for f in DATA_DIR.glob("trades_*.parquet"):
+        # Load existing trade IDs for deduplication
+        existing_trade_ids: set[str] = set()
+        existing_tickers: set[str] = set()
+        parquet_files = list(DATA_DIR.glob("trades_*.parquet"))
+        if parquet_files:
+            print("Loading existing trades for deduplication...")
             try:
-                tickers_in_file = duckdb.sql(f"SELECT DISTINCT ticker FROM '{f}'").fetchall()
-                existing_tickers.update(row[0] for row in tickers_in_file)
+                result = duckdb.sql(f"SELECT DISTINCT trade_id, ticker FROM '{DATA_DIR}/trades_*.parquet'").fetchall()
+                for trade_id, ticker in result:
+                    existing_trade_ids.add(trade_id)
+                    existing_tickers.add(ticker)
+                print(f"Found {len(existing_trade_ids)} existing trades")
             except Exception:
                 pass
 
@@ -46,85 +63,95 @@ class KalshiTradesIndexer(Indexer):
         all_tickers = [row[0] for row in all_tickers]
         print(f"Found {len(all_tickers)} unique markets")
 
-        last_ticker = None
-        if CURSOR_FILE.exists():
-            last_ticker = CURSOR_FILE.read_text().strip() or None
-            if last_ticker:
-                print(f"Resuming from ticker: {last_ticker}")
+        # Filter to tickers not fully processed
+        tickers_to_process = [t for t in all_tickers if t not in existing_tickers]
+        print(
+            f"Skipped {len(all_tickers) - len(tickers_to_process)} already processed, "
+            f"{len(tickers_to_process)} to fetch"
+        )
 
-        start_idx = 0
-        if last_ticker and last_ticker in all_tickers:
-            start_idx = all_tickers.index(last_ticker) + 1
+        if not tickers_to_process:
+            print("Nothing to process")
+            return
 
-        tickers_to_process = []
-        skipped = 0
-        for ticker in all_tickers[start_idx:]:
-            if ticker in existing_tickers:
-                skipped += 1
-            else:
-                tickers_to_process.append(ticker)
-
-        print(f"Skipped {skipped} already processed, {len(tickers_to_process)} to fetch")
-
-        all_trades = []
+        all_trades: list[dict] = []
         total_trades_saved = 0
+        next_chunk_idx = 0
 
-        def get_next_chunk_idx():
-            existing = list(DATA_DIR.glob("trades_*.parquet"))
-            if not existing:
-                return 0
+        # Calculate next chunk index
+        if parquet_files:
             indices = []
-            for f in existing:
+            for f in parquet_files:
                 parts = f.stem.split("_")
                 if len(parts) >= 2:
                     try:
                         indices.append(int(parts[1]))
                     except ValueError:
                         pass
-            return max(indices) + BATCH_SIZE if indices else 0
+            if indices:
+                next_chunk_idx = max(indices) + BATCH_SIZE
 
-        def save_batch(trades_batch):
-            nonlocal total_trades_saved
+        def save_batch(trades_batch: list[dict]) -> int:
+            nonlocal next_chunk_idx
             if not trades_batch:
-                return
-            chunk_idx = get_next_chunk_idx()
-            chunk_path = DATA_DIR / f"trades_{chunk_idx}_{chunk_idx + BATCH_SIZE}.parquet"
+                return 0
+            chunk_path = DATA_DIR / f"trades_{next_chunk_idx}_{next_chunk_idx + BATCH_SIZE}.parquet"
             df = pd.DataFrame(trades_batch)
             df.to_parquet(chunk_path)
-            total_trades_saved += len(trades_batch)
+            next_chunk_idx += BATCH_SIZE
+            return len(trades_batch)
 
-        client = KalshiClient()
-        pbar = tqdm(tickers_to_process, desc="Fetching trades")
-        for ticker in pbar:
+        def fetch_ticker_trades(ticker: str) -> list[dict]:
+            """Fetch trades for a single ticker."""
+            client = KalshiClient()
             try:
-                trades = client.get_market_trades(ticker, verbose=False)
-                if trades:
-                    trades_data = [asdict(t) for t in trades]
-                    fetched_at = datetime.utcnow()
-                    for t in trades_data:
-                        t["_fetched_at"] = fetched_at
-                    all_trades.extend(trades_data)
+                trades = client.get_market_trades(
+                    ticker,
+                    verbose=False,
+                    min_ts=self._min_ts,
+                    max_ts=self._max_ts,
+                )
+                if not trades:
+                    return []
+                fetched_at = datetime.utcnow()
+                return [
+                    {**asdict(t), "_fetched_at": fetched_at} for t in trades if t.trade_id not in existing_trade_ids
+                ]
+            finally:
+                client.close()
 
-                pbar.set_postfix(buffer=len(all_trades), saved=total_trades_saved, last=ticker[-20:])
+        # Concurrent fetching
+        pbar = tqdm(total=len(tickers_to_process), desc="Fetching trades")
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {executor.submit(fetch_ticker_trades, ticker): ticker for ticker in tickers_to_process}
 
-                while len(all_trades) >= BATCH_SIZE:
-                    save_batch(all_trades[:BATCH_SIZE])
-                    all_trades = all_trades[BATCH_SIZE:]
+            for future in as_completed(futures):
+                ticker = futures[future]
+                try:
+                    trades_data = future.result()
+                    if trades_data:
+                        all_trades.extend(trades_data)
+
+                    pbar.update(1)
                     pbar.set_postfix(buffer=len(all_trades), saved=total_trades_saved, last=ticker[-20:])
 
-                CURSOR_FILE.write_text(ticker)
-            except Exception as e:
-                tqdm.write(f"Error fetching {ticker}: {e}")
+                    # Save in batches
+                    while len(all_trades) >= BATCH_SIZE:
+                        saved = save_batch(all_trades[:BATCH_SIZE])
+                        total_trades_saved += saved
+                        all_trades = all_trades[BATCH_SIZE:]
 
-        client.close()
+                except Exception as e:
+                    pbar.update(1)
+                    tqdm.write(f"Error fetching {ticker}: {e}")
 
+        pbar.close()
+
+        # Save remaining
         if all_trades:
-            save_batch(all_trades)
-
-        if CURSOR_FILE.exists():
-            CURSOR_FILE.unlink()
+            total_trades_saved += save_batch(all_trades)
 
         print(
             f"\nBackfill trades complete: {len(tickers_to_process)} markets processed, "
-            f"{skipped} skipped, {total_trades_saved} trades saved"
+            f"{total_trades_saved} trades saved"
         )

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -18,6 +18,7 @@ class Market:
     closed: bool
     end_date: Optional[datetime]
     created_at: Optional[datetime]
+    market_maker_address: Optional[str] = None  # FPMM address for legacy markets
 
     @classmethod
     def from_dict(cls, data: dict) -> "Market":
@@ -45,6 +46,7 @@ class Market:
             closed=data.get("closed", False),
             end_date=parse_time(data.get("endDate")),
             created_at=parse_time(data.get("createdAt")),
+            market_maker_address=data.get("marketMakerAddress"),
         )
 
 


### PR DESCRIPTION
## What changed? Why?

Added animated calibration visualization comparing Kalshi and Polymarket side-by-side, plus several performance and data quality improvements:

- **new animated win rate analysis**: Created `win_rate_by_price_animated.py` that shows how calibration evolves over time with a GIF animation, visualizing both platforms' betting behavior across price points
- **new polymarket trades over time analysis**: Added `polymarket_trades_over_time.py` to analyze trade volume at block-level granularity
- **improved polymarket data handling**: Fixed market maker address extraction and FPMM resolution detection (legacy markets)
- **gif export support**: Extended main.py and AnalysisOutput to support animated GIF output format

## Notes to reviewers

Key files changed:
- New: `src/analysis/comparison/win_rate_by_price_animated.py` (421 lines)
- New: `src/analysis/polymarket/polymarket_trades_over_time.py` (125 lines)
- Modified: `src/analysis/polymarket/polymarket_win_rate_by_price.py` - calibration metrics added
- Modified: `src/indexers/kalshi/trades.py` - concurrent fetching, better deduplication
- Modified: `src/common/storage.py` - deduplication improvements
- Modified: `src/indexers/kalshi/client.py`, `markets.py` - time range parameters
- Modified: `src/common/analysis.py` - metadata field for output
- Modified: `main.py` - gif format support

## How has it been tested?

- Created both new analyses and verified they generate gif output correctly
- Tested concurrent trade fetching with 10 workers against Kalshi API
- Verified deduplication logic filters duplicate trades correctly
- Checked calibration metrics calculations match expected statistical formulas
- Validated animated visualization renders properly with both platforms' data
