### PR TITLE
feat: add quantitative trading pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "web3>=6.0.0",
     "simple-term-menu>=1.6.0",
     "python-dotenv>=1.2.1",
+    "numpy>=1.26.0",
+    "scikit-learn>=1.4.0",
+    "lightgbm>=4.0.0",
+    "xgboost>=2.0.0",
 ]
 
 [dependency-groups]

--- a/src/quant/__init__.py
+++ b/src/quant/__init__.py
@@ -1,0 +1,1 @@
+"""Quantitative trading pipeline for prediction market data."""

--- a/src/quant/backtest.py
+++ b/src/quant/backtest.py
@@ -1,0 +1,289 @@
+"""Backtesting framework for prediction market trading strategies.
+
+Implements rolling-window walk-forward backtesting with realistic
+transaction costs and position sizing for prediction markets.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BacktestResult:
+    """Results from a backtest run."""
+
+    total_return: float
+    annualized_return: float
+    sharpe_ratio: float
+    sortino_ratio: float
+    max_drawdown: float
+    win_rate: float
+    profit_factor: float
+    total_trades: int
+    avg_trade_return: float
+    trade_log: pd.DataFrame
+    equity_curve: pd.DataFrame
+    rolling_sharpe: pd.Series
+
+
+class Backtester:
+    """Walk-forward backtester for prediction market strategies."""
+
+    def __init__(
+        self,
+        transaction_cost_bps: float = 100.0,
+        max_position_usd: float = 100.0,
+        min_edge_threshold: float = 0.5,
+    ):
+        self.transaction_cost = transaction_cost_bps / 10_000
+        self.max_position_usd = max_position_usd
+        self.min_edge = min_edge_threshold  # minimum predicted return to trade
+
+    def run(
+        self,
+        df: pd.DataFrame,
+        predictions: np.ndarray,
+        target_col: str = "target_return",
+    ) -> BacktestResult:
+        """Run backtest on predictions vs realized returns.
+
+        Args:
+            df: DataFrame with at least yes_price, target_return, created_time.
+            predictions: Model predictions aligned with df rows.
+            target_col: Column with realized returns.
+
+        Returns:
+            BacktestResult with performance metrics.
+        """
+        df = df.copy()
+        df["prediction"] = predictions
+        df = df.dropna(subset=[target_col, "prediction"]).reset_index(drop=True)
+
+        trades = []
+        equity = [0.0]
+
+        for i in range(len(df)):
+            pred = df.loc[i, "prediction"]
+            price = df.loc[i, "yes_price"]
+            realized = df.loc[i, target_col]
+
+            # Only trade if predicted edge exceeds threshold + costs
+            cost_pct = self.transaction_cost * 100  # in same units as prediction
+            net_pred = abs(pred) - cost_pct
+
+            if net_pred <= self.min_edge:
+                continue
+
+            # Position sizing: proportional to conviction, capped
+            position_size = min(
+                self.max_position_usd,
+                self.max_position_usd * (net_pred / 10.0),  # scale by edge
+            )
+
+            # Direction: if prediction > 0, go long (buy YES); if < 0, go short (buy NO)
+            direction = 1 if pred > 0 else -1
+
+            # PnL: direction * realized_return * position_size / 100 - costs
+            pnl = direction * realized * position_size / 100.0
+            cost = position_size * self.transaction_cost
+            net_pnl = pnl - cost
+
+            trades.append({
+                "index": i,
+                "time": df.loc[i, "created_time"] if "created_time" in df.columns else i,
+                "price": price,
+                "prediction": pred,
+                "direction": direction,
+                "position_size": position_size,
+                "realized_return": realized,
+                "gross_pnl": pnl,
+                "cost": cost,
+                "net_pnl": net_pnl,
+            })
+
+            equity.append(equity[-1] + net_pnl)
+
+        if not trades:
+            return self._empty_result()
+
+        trade_df = pd.DataFrame(trades)
+        equity_df = pd.DataFrame({
+            "trade_number": range(len(equity)),
+            "equity": equity,
+        })
+
+        return self._compute_metrics(trade_df, equity_df)
+
+    def run_rolling(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        trainer_cls,
+        model_method: str = "train_lightgbm",
+        window_size: int = 50_000,
+        step_size: int = 10_000,
+    ) -> BacktestResult:
+        """Walk-forward rolling window backtest with model retraining.
+
+        Trains a new model on each window, then predicts the next step_size trades.
+        This is the most realistic backtest as it avoids look-ahead bias.
+        """
+        all_trades = []
+        equity = [0.0]
+        n = len(df)
+
+        for start in range(0, n - window_size - step_size, step_size):
+            train_end = start + window_size
+            test_end = min(train_end + step_size, n)
+
+            train_slice = df.iloc[start:train_end]
+            test_slice = df.iloc[train_end:test_end]
+
+            # Skip if insufficient data
+            valid_train = train_slice.dropna(subset=feature_cols + ["target_return"])
+            valid_test = test_slice.dropna(subset=feature_cols + ["target_return"])
+            if len(valid_train) < 1000 or len(valid_test) < 100:
+                continue
+
+            # Train model
+            trainer = trainer_cls(feature_cols)
+            train_split, val_split, _ = trainer.prepare_splits(
+                valid_train, train_frac=0.8, val_frac=0.2
+            )
+
+            train_fn = getattr(trainer, model_method)
+            result = train_fn(train_split, val_split)
+
+            # Predict on test window
+            predictions = trainer.predict(result, valid_test)
+
+            # Execute trades
+            for i in range(len(valid_test)):
+                pred = predictions[i]
+                price = valid_test.iloc[i]["yes_price"]
+                realized = valid_test.iloc[i]["target_return"]
+
+                cost_pct = self.transaction_cost * 100
+                net_pred = abs(pred) - cost_pct
+
+                if net_pred <= self.min_edge:
+                    continue
+
+                position_size = min(
+                    self.max_position_usd,
+                    self.max_position_usd * (net_pred / 10.0),
+                )
+                direction = 1 if pred > 0 else -1
+                pnl = direction * realized * position_size / 100.0
+                cost = position_size * self.transaction_cost
+                net_pnl = pnl - cost
+
+                all_trades.append({
+                    "window_start": start,
+                    "price": price,
+                    "prediction": pred,
+                    "direction": direction,
+                    "position_size": position_size,
+                    "realized_return": realized,
+                    "gross_pnl": pnl,
+                    "cost": cost,
+                    "net_pnl": net_pnl,
+                })
+                equity.append(equity[-1] + net_pnl)
+
+            logger.info(
+                "Window %d-%d: %d trades, equity: $%.2f",
+                start, train_end, len(all_trades), equity[-1],
+            )
+
+        if not all_trades:
+            return self._empty_result()
+
+        trade_df = pd.DataFrame(all_trades)
+        equity_df = pd.DataFrame({
+            "trade_number": range(len(equity)),
+            "equity": equity,
+        })
+
+        return self._compute_metrics(trade_df, equity_df)
+
+    def _compute_metrics(
+        self, trade_df: pd.DataFrame, equity_df: pd.DataFrame
+    ) -> BacktestResult:
+        """Compute performance metrics from trade log."""
+        pnls = trade_df["net_pnl"].values
+        total_return = pnls.sum()
+        n_trades = len(pnls)
+
+        # Win rate and profit factor
+        wins = pnls[pnls > 0]
+        losses = pnls[pnls <= 0]
+        win_rate = len(wins) / n_trades if n_trades > 0 else 0
+        profit_factor = wins.sum() / abs(losses.sum()) if len(losses) > 0 and losses.sum() != 0 else float("inf")
+
+        # Drawdown from equity curve
+        equity = equity_df["equity"].values
+        peak = np.maximum.accumulate(equity)
+        drawdown = equity - peak
+        max_drawdown = abs(drawdown.min()) if len(drawdown) > 0 else 0
+
+        # Sharpe and Sortino (annualized assuming ~250 trading days, ~100 trades/day)
+        mean_pnl = pnls.mean()
+        std_pnl = pnls.std() if len(pnls) > 1 else 1e-6
+        trades_per_year = 250 * 100  # rough estimate
+        sharpe = (mean_pnl / max(std_pnl, 1e-6)) * np.sqrt(trades_per_year)
+
+        downside = pnls[pnls < 0]
+        downside_std = downside.std() if len(downside) > 1 else 1e-6
+        sortino = (mean_pnl / max(downside_std, 1e-6)) * np.sqrt(trades_per_year)
+
+        # Annualized return (rough)
+        annualized_return = mean_pnl * trades_per_year
+
+        # Rolling Sharpe (over 1000-trade windows)
+        rolling_window = min(1000, len(pnls) // 3)
+        if rolling_window > 10:
+            rolling_mean = pd.Series(pnls).rolling(rolling_window).mean()
+            rolling_std = pd.Series(pnls).rolling(rolling_window).std()
+            rolling_sharpe = (rolling_mean / rolling_std.clip(lower=1e-6)) * np.sqrt(trades_per_year)
+        else:
+            rolling_sharpe = pd.Series([sharpe] * len(pnls))
+
+        return BacktestResult(
+            total_return=float(total_return),
+            annualized_return=float(annualized_return),
+            sharpe_ratio=float(sharpe),
+            sortino_ratio=float(sortino),
+            max_drawdown=float(max_drawdown),
+            win_rate=float(win_rate),
+            profit_factor=float(profit_factor),
+            total_trades=n_trades,
+            avg_trade_return=float(mean_pnl),
+            trade_log=trade_df,
+            equity_curve=equity_df,
+            rolling_sharpe=rolling_sharpe,
+        )
+
+    def _empty_result(self) -> BacktestResult:
+        """Return an empty result when no trades were generated."""
+        return BacktestResult(
+            total_return=0.0,
+            annualized_return=0.0,
+            sharpe_ratio=0.0,
+            sortino_ratio=0.0,
+            max_drawdown=0.0,
+            win_rate=0.0,
+            profit_factor=0.0,
+            total_trades=0,
+            avg_trade_return=0.0,
+            trade_log=pd.DataFrame(),
+            equity_curve=pd.DataFrame({"trade_number": [0], "equity": [0.0]}),
+            rolling_sharpe=pd.Series([0.0]),
+        )

--- a/src/quant/config.py
+++ b/src/quant/config.py
@@ -37,6 +37,20 @@ class PipelineConfig:
     min_sharpe_ratio: float = 0.5
     min_observations: int = 1000
 
+    # Validation
+    validation_n_permutations: int = 100
+    validation_n_random_baselines: int = 50
+    validation_embargo_multiplier: float = 1.0
+    validation_slippage_base_pct: float = 0.5  # base slippage as % of notional
+    validation_slippage_size_pct: float = 0.1  # additional slippage per $10 notional
+    validation_slippage_size_unit: float = 10.0
+    validation_latency_trades: int = 3  # execute N trades later than signal
+    validation_liquidity_volume_percentile: float = 20.0  # skip bottom 20% by rolling volume
+    validation_liquidity_window: int = 100
+    validation_stress_cost_multipliers: list[float] = field(default_factory=lambda: [2.0, 3.0, 5.0])
+    validation_stress_max_position_fractions: list[float] = field(default_factory=lambda: [0.5, 0.25])
+    validation_sample_size: int = 50_000  # subsample for expensive validation steps
+
     @property
     def test_fraction(self) -> float:
         return 1.0 - self.train_fraction - self.validation_fraction

--- a/src/quant/config.py
+++ b/src/quant/config.py
@@ -1,0 +1,42 @@
+"""Configuration for the quant trading pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class PipelineConfig:
+    """Central configuration for the entire quant pipeline."""
+
+    # Data paths
+    trades_dir: Path = field(default_factory=lambda: Path("data/kalshi/trades"))
+    markets_dir: Path = field(default_factory=lambda: Path("data/kalshi/markets"))
+
+    # Feature engineering
+    rolling_windows: list[int] = field(default_factory=lambda: [10, 50, 200, 1000])
+    ema_spans: list[int] = field(default_factory=lambda: [10, 50, 200])
+    imbalance_windows: list[int] = field(default_factory=lambda: [20, 100, 500])
+
+    # Model training
+    train_fraction: float = 0.6
+    validation_fraction: float = 0.2
+    # test_fraction is implicitly 1 - train - validation
+    target_horizon: int = 50  # predict price move N trades ahead
+    min_trades_per_ticker: int = 200
+
+    # Backtesting
+    backtest_rolling_window: int = 50_000
+    backtest_step_size: int = 10_000
+    transaction_cost_bps: float = 100.0  # 1% round-trip (prediction markets have wide spreads)
+    max_position_size: float = 100.0  # max dollars per position
+
+    # Statistical thresholds
+    significance_level: float = 0.05
+    min_sharpe_ratio: float = 0.5
+    min_observations: int = 1000
+
+    @property
+    def test_fraction(self) -> float:
+        return 1.0 - self.train_fraction - self.validation_fraction

--- a/src/quant/evaluation.py
+++ b/src/quant/evaluation.py
@@ -1,0 +1,245 @@
+"""Edge verification and robustness testing.
+
+Validates that discovered signals are real and not artifacts of overfitting,
+data snooping, or market microstructure noise.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from src.quant.backtest import BacktestResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EdgeVerification:
+    """Results from edge verification tests."""
+
+    is_significant: bool
+    sharpe_pvalue: float  # probability that Sharpe > 0 by chance
+    deflated_sharpe: float  # Sharpe adjusted for multiple testing
+    return_ttest_pvalue: float
+    bootstrap_ci_lower: float  # 95% CI lower bound of mean return
+    bootstrap_ci_upper: float
+    stability_score: float  # fraction of sub-periods with positive returns
+    regime_robustness: float  # min Sharpe across time regimes
+    sensitivity_results: pd.DataFrame
+
+
+class EdgeVerifier:
+    """Comprehensive edge verification and robustness testing."""
+
+    def __init__(self, n_bootstrap: int = 1000, significance_level: float = 0.05):
+        self.n_bootstrap = n_bootstrap
+        self.significance_level = significance_level
+
+    def verify(
+        self,
+        backtest: BacktestResult,
+        n_trials: int = 1,
+    ) -> EdgeVerification:
+        """Run full edge verification suite."""
+        pnls = backtest.trade_log["net_pnl"].values if len(backtest.trade_log) > 0 else np.array([])
+
+        if len(pnls) < 30:
+            return self._inconclusive_result()
+
+        # 1. T-test: is mean return significantly different from zero?
+        t_stat, t_pval = stats.ttest_1samp(pnls, 0)
+
+        # 2. Bootstrap confidence interval
+        ci_lower, ci_upper = self._bootstrap_ci(pnls)
+
+        # 3. Sharpe ratio significance (Lo, 2002)
+        sharpe_pval = self._sharpe_pvalue(backtest.sharpe_ratio, len(pnls))
+
+        # 4. Deflated Sharpe Ratio (Bailey & Lopez de Prado, 2014)
+        deflated = self._deflated_sharpe(
+            backtest.sharpe_ratio, len(pnls), n_trials=n_trials
+        )
+
+        # 5. Time stability: split into sub-periods
+        stability = self._time_stability(pnls)
+
+        # 6. Regime robustness
+        regime_rob = self._regime_robustness(pnls)
+
+        # 7. Sensitivity analysis
+        sensitivity = self._sensitivity_analysis(backtest)
+
+        is_sig = (
+            t_pval < self.significance_level
+            and ci_lower > 0
+            and stability >= 0.5
+        )
+
+        return EdgeVerification(
+            is_significant=is_sig,
+            sharpe_pvalue=float(sharpe_pval),
+            deflated_sharpe=float(deflated),
+            return_ttest_pvalue=float(t_pval),
+            bootstrap_ci_lower=float(ci_lower),
+            bootstrap_ci_upper=float(ci_upper),
+            stability_score=float(stability),
+            regime_robustness=float(regime_rob),
+            sensitivity_results=sensitivity,
+        )
+
+    def _bootstrap_ci(
+        self, pnls: np.ndarray, alpha: float = 0.05
+    ) -> tuple[float, float]:
+        """Non-parametric bootstrap 95% CI for mean PnL."""
+        rng = np.random.default_rng(42)
+        means = np.array([
+            rng.choice(pnls, size=len(pnls), replace=True).mean()
+            for _ in range(self.n_bootstrap)
+        ])
+        return float(np.percentile(means, 100 * alpha / 2)), float(
+            np.percentile(means, 100 * (1 - alpha / 2))
+        )
+
+    def _sharpe_pvalue(self, sharpe: float, n: int) -> float:
+        """P-value for Sharpe ratio under null of SR=0 (Lo, 2002).
+
+        SE(SR) ~ 1/sqrt(n) for IID returns (conservative).
+        """
+        se = 1.0 / np.sqrt(n)
+        z = sharpe / max(se, 1e-10)
+        return float(2 * (1 - stats.norm.cdf(abs(z))))
+
+    def _deflated_sharpe(
+        self, sharpe: float, n: int, n_trials: int = 1
+    ) -> float:
+        """Deflated Sharpe Ratio accounting for multiple testing.
+
+        Based on Bailey & Lopez de Prado (2014).
+        Adjusts for the expected maximum Sharpe from n_trials independent tests.
+        """
+        if n_trials <= 1:
+            return sharpe
+
+        # Expected max Sharpe under null (n_trials independent tests)
+        # E[max(Z_1,...,Z_k)] ~ sqrt(2 * ln(k)) for standard normals
+        expected_max_sr = np.sqrt(2 * np.log(n_trials)) * (1.0 / np.sqrt(n))
+
+        # Deflated SR: test if observed SR exceeds expected max under null
+        se = 1.0 / np.sqrt(n)
+        z = (sharpe - expected_max_sr) / max(se, 1e-10)
+        return float(stats.norm.cdf(z))  # probability of observing this SR
+
+    def _time_stability(self, pnls: np.ndarray, n_splits: int = 5) -> float:
+        """Fraction of time sub-periods with positive mean return."""
+        if len(pnls) < n_splits * 10:
+            return 0.0
+
+        splits = np.array_split(pnls, n_splits)
+        positive = sum(1 for s in splits if s.mean() > 0)
+        return positive / n_splits
+
+    def _regime_robustness(self, pnls: np.ndarray, n_regimes: int = 4) -> float:
+        """Minimum Sharpe ratio across time regimes (quartiles)."""
+        if len(pnls) < n_regimes * 30:
+            return 0.0
+
+        splits = np.array_split(pnls, n_regimes)
+        sharpes = []
+        for s in splits:
+            if len(s) < 10 or s.std() < 1e-10:
+                sharpes.append(0.0)
+            else:
+                sharpes.append(s.mean() / s.std())
+        return min(sharpes)
+
+    def _sensitivity_analysis(self, backtest: BacktestResult) -> pd.DataFrame:
+        """Test sensitivity to transaction costs and position sizing."""
+        if len(backtest.trade_log) == 0:
+            return pd.DataFrame()
+
+        gross_pnls = backtest.trade_log["gross_pnl"].values
+        costs = backtest.trade_log["cost"].values
+
+        results = []
+
+        # Sensitivity to transaction cost multiplier
+        for cost_mult in [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]:
+            adjusted_pnl = gross_pnls - costs * cost_mult
+            mean_ret = adjusted_pnl.mean()
+            std_ret = adjusted_pnl.std() if len(adjusted_pnl) > 1 else 1e-6
+            sr = (mean_ret / max(std_ret, 1e-6)) * np.sqrt(25000)
+
+            results.append({
+                "parameter": "cost_multiplier",
+                "value": cost_mult,
+                "mean_pnl": float(mean_ret),
+                "sharpe": float(sr),
+                "total_pnl": float(adjusted_pnl.sum()),
+                "win_rate": float((adjusted_pnl > 0).mean()),
+            })
+
+        return pd.DataFrame(results)
+
+    def _inconclusive_result(self) -> EdgeVerification:
+        return EdgeVerification(
+            is_significant=False,
+            sharpe_pvalue=1.0,
+            deflated_sharpe=0.0,
+            return_ttest_pvalue=1.0,
+            bootstrap_ci_lower=0.0,
+            bootstrap_ci_upper=0.0,
+            stability_score=0.0,
+            regime_robustness=0.0,
+            sensitivity_results=pd.DataFrame(),
+        )
+
+
+def format_backtest_report(
+    backtest: BacktestResult, verification: EdgeVerification
+) -> str:
+    """Format a human-readable report of backtest and verification results."""
+    lines = [
+        "=" * 60,
+        "BACKTEST & EDGE VERIFICATION REPORT",
+        "=" * 60,
+        "",
+        "--- Performance Metrics ---",
+        f"Total Return:        ${backtest.total_return:,.2f}",
+        f"Annualized Return:   ${backtest.annualized_return:,.2f}",
+        f"Sharpe Ratio:        {backtest.sharpe_ratio:.3f}",
+        f"Sortino Ratio:       {backtest.sortino_ratio:.3f}",
+        f"Max Drawdown:        ${backtest.max_drawdown:,.2f}",
+        f"Win Rate:            {backtest.win_rate:.1%}",
+        f"Profit Factor:       {backtest.profit_factor:.2f}",
+        f"Total Trades:        {backtest.total_trades:,}",
+        f"Avg Trade PnL:       ${backtest.avg_trade_return:.4f}",
+        "",
+        "--- Edge Verification ---",
+        f"Significant Edge:    {'YES' if verification.is_significant else 'NO'}",
+        f"Return t-test p:     {verification.return_ttest_pvalue:.6f}",
+        f"Sharpe p-value:      {verification.sharpe_pvalue:.6f}",
+        f"Deflated Sharpe:     {verification.deflated_sharpe:.4f}",
+        f"Bootstrap 95% CI:    [${verification.bootstrap_ci_lower:.4f}, ${verification.bootstrap_ci_upper:.4f}]",
+        f"Time Stability:      {verification.stability_score:.1%} of periods profitable",
+        f"Regime Robustness:   {verification.regime_robustness:.4f} (min sub-period Sharpe)",
+        "",
+    ]
+
+    if not verification.sensitivity_results.empty:
+        lines.append("--- Cost Sensitivity ---")
+        for _, row in verification.sensitivity_results.iterrows():
+            lines.append(
+                f"  Cost x{row['value']:.2f}: "
+                f"Sharpe={row['sharpe']:.3f}, "
+                f"Total=${row['total_pnl']:,.2f}, "
+                f"WR={row['win_rate']:.1%}"
+            )
+
+    lines.append("")
+    lines.append("=" * 60)
+    return "\n".join(lines)

--- a/src/quant/evaluation.py
+++ b/src/quant/evaluation.py
@@ -74,7 +74,7 @@ class EdgeVerifier:
         # 7. Sensitivity analysis
         sensitivity = self._sensitivity_analysis(backtest)
 
-        is_sig = (
+        is_sig = bool(
             t_pval < self.significance_level
             and ci_lower > 0
             and stability >= 0.5

--- a/src/quant/features.py
+++ b/src/quant/features.py
@@ -166,41 +166,37 @@ class FeatureEngine:
             return df
 
         ts = pd.to_datetime(df["created_time"])
+        time_delta = ts.diff().dt.total_seconds()
 
-        # Time of day features
-        df["hour"] = ts.dt.hour
-        df["hour_sin"] = np.sin(2 * np.pi * ts.dt.hour / 24)
-        df["hour_cos"] = np.cos(2 * np.pi * ts.dt.hour / 24)
-        df["is_weekend"] = ts.dt.dayofweek.isin([5, 6]).astype(int)
+        new_cols: dict[str, pd.Series] = {
+            "hour": ts.dt.hour,
+            "hour_sin": np.sin(2 * np.pi * ts.dt.hour / 24),
+            "hour_cos": np.cos(2 * np.pi * ts.dt.hour / 24),
+            "is_weekend": ts.dt.dayofweek.isin([5, 6]).astype(int),
+            "time_delta_seconds": time_delta,
+            "log_time_delta": np.log1p(time_delta.clip(lower=0)),
+        }
 
-        # Inter-trade duration
-        df["time_delta_seconds"] = ts.diff().dt.total_seconds()
-        df["log_time_delta"] = np.log1p(df["time_delta_seconds"].clip(lower=0))
-
-        # Trade velocity (trades per minute, rolling)
         for w in [20, 100]:
-            time_span = ts.diff().dt.total_seconds().rolling(w, min_periods=1).sum()
-            df[f"trade_velocity_{w}"] = w / time_span.clip(lower=1) * 60  # trades per minute
+            time_span = time_delta.rolling(w, min_periods=1).sum()
+            new_cols[f"trade_velocity_{w}"] = w / time_span.clip(lower=1) * 60
 
-        return df
+        return pd.concat([df, pd.DataFrame(new_cols, index=df.index)], axis=1)
 
     def _target_variable(self, df: pd.DataFrame) -> pd.DataFrame:
         """Create the prediction target: future price movement."""
         horizon = self.config.target_horizon
+        future_price = df["yes_price"].shift(-horizon)
+        future_return = future_price - df["yes_price"]
 
-        # Future price (N trades ahead)
-        df["future_price"] = df["yes_price"].shift(-horizon)
-        df["future_return"] = df["future_price"] - df["yes_price"]
+        new_cols = pd.DataFrame({
+            "future_price": future_price,
+            "future_return": future_return,
+            "target_up": (future_return > 0).astype(int),
+            "target_return": future_return / df["yes_price"].clip(lower=1) * 100,
+        }, index=df.index)
 
-        # Binary target: price goes up
-        df["target_up"] = (df["future_return"] > 0).astype(int)
-
-        # Regression target: excess return for a yes-taker
-        # If we buy YES at yes_price, we get $1 if outcome is yes, else $0
-        # But we don't know the outcome during trading -- so we use future price as proxy
-        df["target_return"] = df["future_return"] / df["yes_price"].clip(lower=1) * 100
-
-        return df
+        return pd.concat([df, new_cols], axis=1)
 
     @staticmethod
     def get_feature_names(df: pd.DataFrame) -> list[str]:

--- a/src/quant/features.py
+++ b/src/quant/features.py
@@ -1,0 +1,214 @@
+"""Feature engineering for prediction market trade data.
+
+Generates alpha factors from price, volume, and order flow signals.
+Designed to work on per-ticker trade sequences (time-ordered).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.quant.config import PipelineConfig
+
+
+class FeatureEngine:
+    """Builds features from time-ordered trade sequences."""
+
+    def __init__(self, config: PipelineConfig):
+        self.config = config
+
+    def build_trade_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Build all features for a time-ordered trade DataFrame.
+
+        Input must have columns: yes_price, no_price, count, taker_side,
+        created_time, taker_price, taker_won.
+
+        Returns DataFrame with original columns plus all computed features.
+        """
+        df = df.copy()
+        df = df.sort_values("created_time").reset_index(drop=True)
+
+        df = self._price_features(df)
+        df = self._volume_features(df)
+        df = self._imbalance_features(df)
+        df = self._rolling_features(df)
+        df = self._volatility_features(df)
+        df = self._time_features(df)
+        df = self._target_variable(df)
+
+        return df
+
+    def _price_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Price-based features."""
+        # Price changes
+        df["price_change"] = df["yes_price"].diff()
+        df["price_change_abs"] = df["price_change"].abs()
+        df["price_return"] = df["yes_price"].pct_change()
+
+        # Distance from extremes
+        df["dist_from_50"] = (df["yes_price"] - 50).abs()
+        df["dist_from_boundary"] = df[["yes_price", "no_price"]].min(axis=1)
+
+        # Price level buckets (non-linear zones in prediction markets)
+        df["price_zone"] = pd.cut(
+            df["yes_price"],
+            bins=[0, 10, 25, 40, 60, 75, 90, 100],
+            labels=[1, 2, 3, 4, 5, 6, 7],
+        ).astype(float)
+
+        # Lagged prices
+        for lag in [1, 5, 10, 20]:
+            df[f"price_lag_{lag}"] = df["yes_price"].shift(lag)
+            df[f"price_diff_{lag}"] = df["yes_price"] - df["yes_price"].shift(lag)
+
+        return df
+
+    def _volume_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Volume and trade size features."""
+        df["log_count"] = np.log1p(df["count"])
+        df["notional"] = df["count"] * df["taker_price"] / 100.0
+
+        # Relative size vs recent trades
+        for w in self.config.rolling_windows:
+            roll = df["count"].rolling(w, min_periods=1)
+            df[f"count_zscore_{w}"] = (df["count"] - roll.mean()) / roll.std().clip(lower=1e-6)
+            df[f"notional_ma_{w}"] = df["notional"].rolling(w, min_periods=1).mean()
+
+        return df
+
+    def _imbalance_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Order flow imbalance signals from taker_side and count."""
+        # Binary taker direction
+        df["taker_is_yes"] = (df["taker_side"] == "yes").astype(int)
+
+        # Signed volume: positive for yes-taker, negative for no-taker
+        df["signed_volume"] = df["count"] * np.where(df["taker_is_yes"] == 1, 1, -1)
+
+        for w in self.config.imbalance_windows:
+            # Volume imbalance ratio: net yes volume / total volume
+            yes_vol = (df["count"] * df["taker_is_yes"]).rolling(w, min_periods=1).sum()
+            total_vol = df["count"].rolling(w, min_periods=1).sum()
+            df[f"volume_imbalance_{w}"] = (2 * yes_vol / total_vol.clip(lower=1)) - 1  # [-1, 1]
+
+            # Trade count imbalance
+            yes_count = df["taker_is_yes"].rolling(w, min_periods=1).sum()
+            df[f"trade_imbalance_{w}"] = (2 * yes_count / w) - 1  # [-1, 1]
+
+            # Cumulative signed volume
+            df[f"cum_signed_vol_{w}"] = df["signed_volume"].rolling(w, min_periods=1).sum()
+
+            # Tick imbalance (Kyle/Easley-style): signed trade direction
+            df[f"tick_imbalance_{w}"] = df["signed_volume"].rolling(w, min_periods=1).mean()
+
+        # VPIN-style: absolute imbalance over volume
+        for w in self.config.imbalance_windows:
+            abs_imbalance = df["signed_volume"].abs().rolling(w, min_periods=1).sum()
+            total_vol = df["count"].rolling(w, min_periods=1).sum()
+            df[f"vpin_{w}"] = abs_imbalance / total_vol.clip(lower=1)
+
+        return df
+
+    def _rolling_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Rolling window statistics."""
+        for w in self.config.rolling_windows:
+            roll = df["yes_price"].rolling(w, min_periods=1)
+
+            # Moving averages
+            df[f"sma_{w}"] = roll.mean()
+            df[f"price_vs_sma_{w}"] = df["yes_price"] - df[f"sma_{w}"]
+
+            # Min/max
+            df[f"roll_min_{w}"] = roll.min()
+            df[f"roll_max_{w}"] = roll.max()
+            df[f"roll_range_{w}"] = df[f"roll_max_{w}"] - df[f"roll_min_{w}"]
+
+            # Position within range (0 = at min, 1 = at max)
+            range_val = df[f"roll_range_{w}"].clip(lower=1)
+            df[f"roll_position_{w}"] = (df["yes_price"] - df[f"roll_min_{w}"]) / range_val
+
+        # EMA features
+        for span in self.config.ema_spans:
+            df[f"ema_{span}"] = df["yes_price"].ewm(span=span, min_periods=1).mean()
+            df[f"price_vs_ema_{span}"] = df["yes_price"] - df[f"ema_{span}"]
+
+        # VWAP (volume-weighted average price)
+        for w in self.config.rolling_windows:
+            pv = (df["yes_price"] * df["count"]).rolling(w, min_periods=1).sum()
+            vol = df["count"].rolling(w, min_periods=1).sum()
+            df[f"vwap_{w}"] = pv / vol.clip(lower=1)
+            df[f"price_vs_vwap_{w}"] = df["yes_price"] - df[f"vwap_{w}"]
+
+        return df
+
+    def _volatility_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Volatility and dispersion features."""
+        for w in self.config.rolling_windows:
+            # Realized volatility (std of price changes)
+            df[f"volatility_{w}"] = df["price_change"].rolling(w, min_periods=2).std()
+
+            # Mean absolute deviation
+            roll = df["yes_price"].rolling(w, min_periods=2)
+            df[f"mad_{w}"] = roll.apply(lambda x: np.mean(np.abs(x - x.mean())), raw=True)
+
+            # Parkinson volatility (high-low range estimator)
+            roll_range = df[f"roll_range_{w}"] if f"roll_range_{w}" in df.columns else (
+                df["yes_price"].rolling(w, min_periods=1).max()
+                - df["yes_price"].rolling(w, min_periods=1).min()
+            )
+            df[f"parkinson_vol_{w}"] = roll_range / (2 * np.sqrt(np.log(2)))
+
+        return df
+
+    def _time_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Temporal features from trade timestamps."""
+        if "created_time" not in df.columns:
+            return df
+
+        ts = pd.to_datetime(df["created_time"])
+
+        # Time of day features
+        df["hour"] = ts.dt.hour
+        df["hour_sin"] = np.sin(2 * np.pi * ts.dt.hour / 24)
+        df["hour_cos"] = np.cos(2 * np.pi * ts.dt.hour / 24)
+        df["is_weekend"] = ts.dt.dayofweek.isin([5, 6]).astype(int)
+
+        # Inter-trade duration
+        df["time_delta_seconds"] = ts.diff().dt.total_seconds()
+        df["log_time_delta"] = np.log1p(df["time_delta_seconds"].clip(lower=0))
+
+        # Trade velocity (trades per minute, rolling)
+        for w in [20, 100]:
+            time_span = ts.diff().dt.total_seconds().rolling(w, min_periods=1).sum()
+            df[f"trade_velocity_{w}"] = w / time_span.clip(lower=1) * 60  # trades per minute
+
+        return df
+
+    def _target_variable(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Create the prediction target: future price movement."""
+        horizon = self.config.target_horizon
+
+        # Future price (N trades ahead)
+        df["future_price"] = df["yes_price"].shift(-horizon)
+        df["future_return"] = df["future_price"] - df["yes_price"]
+
+        # Binary target: price goes up
+        df["target_up"] = (df["future_return"] > 0).astype(int)
+
+        # Regression target: excess return for a yes-taker
+        # If we buy YES at yes_price, we get $1 if outcome is yes, else $0
+        # But we don't know the outcome during trading -- so we use future price as proxy
+        df["target_return"] = df["future_return"] / df["yes_price"].clip(lower=1) * 100
+
+        return df
+
+    @staticmethod
+    def get_feature_names(df: pd.DataFrame) -> list[str]:
+        """Extract feature column names from a featurized DataFrame."""
+        exclude = {
+            "trade_id", "ticker", "count", "yes_price", "no_price", "taker_side",
+            "created_time", "result", "taker_price", "taker_won", "taker_notional",
+            "_fetched_at", "future_price", "future_return", "target_up",
+            "target_return", "notional",
+        }
+        return [c for c in df.columns if c not in exclude and not c.startswith("target_")]

--- a/src/quant/models.py
+++ b/src/quant/models.py
@@ -1,0 +1,274 @@
+"""Model training for alpha prediction.
+
+Supports multiple model types with a unified interface:
+- Ridge regression (fast baseline)
+- LightGBM (gradient boosting, handles large datasets well)
+- XGBoost (alternative gradient boosting)
+
+All models predict future_return (regression) or target_up (classification).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import Ridge
+from sklearn.metrics import (
+    mean_squared_error,
+    r2_score,
+    roc_auc_score,
+)
+from sklearn.preprocessing import StandardScaler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelResult:
+    """Results from training and evaluating a model."""
+
+    model_name: str
+    train_r2: float
+    val_r2: float
+    val_mse: float
+    val_ic: float  # rank correlation on validation set
+    val_auc: float | None  # AUC for classification target
+    feature_importance: pd.DataFrame
+    model: object  # the fitted model
+    scaler: StandardScaler | None
+
+
+class ModelTrainer:
+    """Train and evaluate predictive models."""
+
+    def __init__(self, feature_cols: list[str]):
+        self.feature_cols = feature_cols
+
+    def prepare_splits(
+        self,
+        df: pd.DataFrame,
+        train_frac: float = 0.6,
+        val_frac: float = 0.2,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """Split data chronologically (no shuffle — time series discipline)."""
+        df = df.dropna(subset=self.feature_cols + ["target_return"]).reset_index(drop=True)
+        n = len(df)
+        train_end = int(n * train_frac)
+        val_end = int(n * (train_frac + val_frac))
+
+        train = df.iloc[:train_end]
+        val = df.iloc[train_end:val_end]
+        test = df.iloc[val_end:]
+
+        logger.info("Split sizes — train: %d, val: %d, test: %d", len(train), len(val), len(test))
+        return train, val, test
+
+    def train_ridge(
+        self,
+        train: pd.DataFrame,
+        val: pd.DataFrame,
+        alpha: float = 1.0,
+    ) -> ModelResult:
+        """Train a Ridge regression model (fast, interpretable baseline)."""
+        scaler = StandardScaler()
+        X_train = scaler.fit_transform(train[self.feature_cols].values)
+        X_val = scaler.transform(val[self.feature_cols].values)
+        y_train = train["target_return"].values
+        y_val = val["target_return"].values
+
+        model = Ridge(alpha=alpha)
+        model.fit(X_train, y_train)
+
+        train_pred = model.predict(X_train)
+        val_pred = model.predict(X_val)
+
+        importance = pd.DataFrame({
+            "feature": self.feature_cols,
+            "importance": np.abs(model.coef_),
+        }).sort_values("importance", ascending=False)
+
+        # Classification AUC if binary target available
+        val_auc = None
+        if "target_up" in val.columns:
+            val_auc = _safe_auc(val["target_up"].values, val_pred)
+
+        from scipy.stats import spearmanr
+        ic, _ = spearmanr(y_val, val_pred)
+
+        return ModelResult(
+            model_name="Ridge",
+            train_r2=r2_score(y_train, train_pred),
+            val_r2=r2_score(y_val, val_pred),
+            val_mse=mean_squared_error(y_val, val_pred),
+            val_ic=float(ic),
+            val_auc=val_auc,
+            feature_importance=importance,
+            model=model,
+            scaler=scaler,
+        )
+
+    def train_lightgbm(
+        self,
+        train: pd.DataFrame,
+        val: pd.DataFrame,
+        params: dict | None = None,
+    ) -> ModelResult:
+        """Train a LightGBM model (best for large datasets with many features)."""
+        import lightgbm as lgb
+
+        X_train = train[self.feature_cols].values
+        X_val = val[self.feature_cols].values
+        y_train = train["target_return"].values
+        y_val = val["target_return"].values
+
+        default_params = {
+            "objective": "regression",
+            "metric": "mse",
+            "learning_rate": 0.05,
+            "num_leaves": 63,
+            "max_depth": 8,
+            "min_child_samples": 100,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "reg_alpha": 0.1,
+            "reg_lambda": 1.0,
+            "verbose": -1,
+            "n_jobs": 4,
+        }
+        if params:
+            default_params.update(params)
+
+        dtrain = lgb.Dataset(X_train, label=y_train, feature_name=self.feature_cols)
+        dval = lgb.Dataset(X_val, label=y_val, feature_name=self.feature_cols, reference=dtrain)
+
+        model = lgb.train(
+            default_params,
+            dtrain,
+            num_boost_round=500,
+            valid_sets=[dval],
+            callbacks=[lgb.early_stopping(50), lgb.log_evaluation(100)],
+        )
+
+        train_pred = model.predict(X_train)
+        val_pred = model.predict(X_val)
+
+        importance = pd.DataFrame({
+            "feature": self.feature_cols,
+            "importance": model.feature_importance(importance_type="gain"),
+        }).sort_values("importance", ascending=False)
+
+        val_auc = None
+        if "target_up" in val.columns:
+            val_auc = _safe_auc(val["target_up"].values, val_pred)
+
+        from scipy.stats import spearmanr
+        ic, _ = spearmanr(y_val, val_pred)
+
+        return ModelResult(
+            model_name="LightGBM",
+            train_r2=r2_score(y_train, train_pred),
+            val_r2=r2_score(y_val, val_pred),
+            val_mse=mean_squared_error(y_val, val_pred),
+            val_ic=float(ic),
+            val_auc=val_auc,
+            feature_importance=importance,
+            model=model,
+            scaler=None,
+        )
+
+    def train_xgboost(
+        self,
+        train: pd.DataFrame,
+        val: pd.DataFrame,
+        params: dict | None = None,
+    ) -> ModelResult:
+        """Train an XGBoost model (alternative to LightGBM)."""
+        import xgboost as xgb
+
+        X_train = train[self.feature_cols].values
+        X_val = val[self.feature_cols].values
+        y_train = train["target_return"].values
+        y_val = val["target_return"].values
+
+        default_params = {
+            "objective": "reg:squarederror",
+            "eval_metric": "rmse",
+            "learning_rate": 0.05,
+            "max_depth": 8,
+            "min_child_weight": 100,
+            "subsample": 0.8,
+            "colsample_bytree": 0.8,
+            "reg_alpha": 0.1,
+            "reg_lambda": 1.0,
+            "tree_method": "hist",
+            "verbosity": 0,
+            "nthread": 4,
+        }
+        if params:
+            default_params.update(params)
+
+        dtrain = xgb.DMatrix(X_train, label=y_train, feature_names=self.feature_cols)
+        dval = xgb.DMatrix(X_val, label=y_val, feature_names=self.feature_cols)
+
+        model = xgb.train(
+            default_params,
+            dtrain,
+            num_boost_round=500,
+            evals=[(dval, "val")],
+            early_stopping_rounds=50,
+            verbose_eval=100,
+        )
+
+        train_pred = model.predict(dtrain)
+        val_pred = model.predict(dval)
+
+        importance = pd.DataFrame({
+            "feature": self.feature_cols,
+            "importance": [model.get_score(importance_type="gain").get(f, 0) for f in self.feature_cols],
+        }).sort_values("importance", ascending=False)
+
+        val_auc = None
+        if "target_up" in val.columns:
+            val_auc = _safe_auc(val["target_up"].values, val_pred)
+
+        from scipy.stats import spearmanr
+        ic, _ = spearmanr(y_val, val_pred)
+
+        return ModelResult(
+            model_name="XGBoost",
+            train_r2=r2_score(y_train, train_pred),
+            val_r2=r2_score(y_val, val_pred),
+            val_mse=mean_squared_error(y_val, val_pred),
+            val_ic=float(ic),
+            val_auc=val_auc,
+            feature_importance=importance,
+            model=model,
+            scaler=None,
+        )
+
+    def predict(self, result: ModelResult, df: pd.DataFrame) -> np.ndarray:
+        """Generate predictions from a trained ModelResult."""
+        X = df[self.feature_cols].values
+
+        if result.scaler is not None:
+            X = result.scaler.transform(X)
+
+        model = result.model
+        if result.model_name == "XGBoost":
+            import xgboost as xgb
+            X = xgb.DMatrix(X, feature_names=self.feature_cols)
+
+        return model.predict(X)
+
+
+def _safe_auc(y_true: np.ndarray, y_pred: np.ndarray) -> float | None:
+    """Compute AUC, returning None if it can't be calculated."""
+    try:
+        if len(np.unique(y_true)) < 2:
+            return None
+        return float(roc_auc_score(y_true, y_pred))
+    except ValueError:
+        return None

--- a/src/quant/pipeline.py
+++ b/src/quant/pipeline.py
@@ -1,0 +1,206 @@
+"""Data loading pipeline optimized for 33GB+ parquet datasets.
+
+Uses DuckDB for zero-copy reads and lazy SQL evaluation over parquet files,
+avoiding the need to load the entire dataset into memory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import duckdb
+import pandas as pd
+
+from src.quant.config import PipelineConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DataPipeline:
+    """Efficient data loading and preprocessing for large parquet datasets."""
+
+    def __init__(self, config: PipelineConfig):
+        self.config = config
+        self.con = duckdb.connect()
+        # Set memory limit to avoid OOM on large datasets
+        self.con.execute("SET memory_limit = '4GB'")
+        self.con.execute("SET threads = 4")
+
+    def close(self):
+        self.con.close()
+
+    def load_trades_with_outcomes(self) -> pd.DataFrame:
+        """Load trades joined with market outcomes for resolved markets.
+
+        Returns only trades from finalized markets with known results,
+        enriched with outcome information needed for feature engineering.
+        """
+        trades_glob = f"{self.config.trades_dir}/*.parquet"
+        markets_glob = f"{self.config.markets_dir}/*.parquet"
+
+        query = f"""
+            WITH resolved AS (
+                SELECT ticker, result
+                FROM '{markets_glob}'
+                WHERE status = 'finalized'
+                  AND result IN ('yes', 'no')
+            )
+            SELECT
+                t.trade_id,
+                t.ticker,
+                t.count,
+                t.yes_price,
+                t.no_price,
+                t.taker_side,
+                t.created_time,
+                m.result,
+                -- derived columns
+                CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                     ELSE t.no_price END AS taker_price,
+                CASE WHEN t.taker_side = m.result THEN 1 ELSE 0 END AS taker_won,
+                t.count * (CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                                ELSE t.no_price END) / 100.0 AS taker_notional
+            FROM '{trades_glob}' t
+            INNER JOIN resolved m ON t.ticker = m.ticker
+            ORDER BY t.created_time
+        """
+        logger.info("Loading trades with outcomes (this may take a few minutes for large datasets)...")
+        df = self.con.execute(query).df()
+        logger.info("Loaded %s trades across %s tickers", f"{len(df):,}", f"{df['ticker'].nunique():,}")
+        return df
+
+    def load_ticker_trades(self, ticker: str) -> pd.DataFrame:
+        """Load all trades for a single ticker, ordered by time."""
+        trades_glob = f"{self.config.trades_dir}/*.parquet"
+        markets_glob = f"{self.config.markets_dir}/*.parquet"
+
+        query = f"""
+            WITH resolved AS (
+                SELECT ticker, result
+                FROM '{markets_glob}'
+                WHERE ticker = '{ticker}'
+                  AND status = 'finalized'
+                  AND result IN ('yes', 'no')
+            )
+            SELECT
+                t.trade_id, t.ticker, t.count, t.yes_price, t.no_price,
+                t.taker_side, t.created_time, m.result,
+                CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                     ELSE t.no_price END AS taker_price,
+                CASE WHEN t.taker_side = m.result THEN 1 ELSE 0 END AS taker_won,
+                t.count * (CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                                ELSE t.no_price END) / 100.0 AS taker_notional
+            FROM '{trades_glob}' t
+            INNER JOIN resolved m ON t.ticker = m.ticker
+            WHERE t.ticker = '{ticker}'
+            ORDER BY t.created_time
+        """
+        return self.con.execute(query).df()
+
+    def get_active_tickers(self) -> pd.DataFrame:
+        """Get tickers with sufficient trade count for modeling."""
+        trades_glob = f"{self.config.trades_dir}/*.parquet"
+        markets_glob = f"{self.config.markets_dir}/*.parquet"
+
+        query = f"""
+            WITH resolved AS (
+                SELECT ticker, result
+                FROM '{markets_glob}'
+                WHERE status = 'finalized'
+                  AND result IN ('yes', 'no')
+            )
+            SELECT
+                t.ticker,
+                m.result,
+                COUNT(*) AS trade_count,
+                MIN(t.created_time) AS first_trade,
+                MAX(t.created_time) AS last_trade
+            FROM '{trades_glob}' t
+            INNER JOIN resolved m ON t.ticker = m.ticker
+            GROUP BY t.ticker, m.result
+            HAVING COUNT(*) >= {self.config.min_trades_per_ticker}
+            ORDER BY trade_count DESC
+        """
+        return self.con.execute(query).df()
+
+    def compute_ticker_features_sql(self) -> pd.DataFrame:
+        """Compute per-ticker aggregated features using pure SQL for speed.
+
+        This is the fast path: computes summary statistics per ticker
+        entirely inside DuckDB without loading raw trades into pandas.
+        """
+        trades_glob = f"{self.config.trades_dir}/*.parquet"
+        markets_glob = f"{self.config.markets_dir}/*.parquet"
+
+        query = f"""
+            WITH resolved AS (
+                SELECT ticker, result
+                FROM '{markets_glob}'
+                WHERE status = 'finalized'
+                  AND result IN ('yes', 'no')
+            ),
+            trades AS (
+                SELECT
+                    t.ticker,
+                    t.yes_price,
+                    t.no_price,
+                    t.count,
+                    t.taker_side,
+                    t.created_time,
+                    m.result,
+                    CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                         ELSE t.no_price END AS taker_price,
+                    CASE WHEN t.taker_side = m.result THEN 1 ELSE 0 END AS taker_won,
+                    t.count * (CASE WHEN t.taker_side = 'yes' THEN t.yes_price
+                                    ELSE t.no_price END) / 100.0 AS taker_notional
+                FROM '{trades_glob}' t
+                INNER JOIN resolved m ON t.ticker = m.ticker
+            )
+            SELECT
+                ticker,
+                result,
+
+                -- Price features
+                AVG(yes_price) AS mean_yes_price,
+                STDDEV(yes_price) AS std_yes_price,
+                MEDIAN(yes_price) AS median_yes_price,
+                MIN(yes_price) AS min_yes_price,
+                MAX(yes_price) AS max_yes_price,
+                MAX(yes_price) - MIN(yes_price) AS price_range,
+
+                -- Volume features
+                COUNT(*) AS trade_count,
+                SUM(count) AS total_contracts,
+                AVG(count) AS mean_contracts_per_trade,
+                MEDIAN(count) AS median_contracts_per_trade,
+                SUM(taker_notional) AS total_notional,
+
+                -- VWAP
+                SUM(yes_price * count) * 1.0 / NULLIF(SUM(count), 0) AS vwap,
+
+                -- Imbalance features
+                SUM(CASE WHEN taker_side = 'yes' THEN count ELSE 0 END) * 1.0
+                    / NULLIF(SUM(count), 0) AS yes_volume_share,
+                SUM(CASE WHEN taker_side = 'yes' THEN 1 ELSE 0 END) * 1.0
+                    / COUNT(*) AS yes_trade_share,
+                SUM(CASE WHEN taker_side = 'yes' THEN count ELSE 0 END)
+                    - SUM(CASE WHEN taker_side = 'no' THEN count ELSE 0 END)
+                    AS net_volume_imbalance,
+
+                -- Time features
+                MIN(created_time) AS first_trade_time,
+                MAX(created_time) AS last_trade_time,
+                EXTRACT(EPOCH FROM (MAX(created_time) - MIN(created_time))) AS duration_seconds,
+
+                -- Outcome
+                CASE WHEN result = 'yes' THEN 1 ELSE 0 END AS outcome_yes
+
+            FROM trades
+            GROUP BY ticker, result
+            HAVING COUNT(*) >= {self.config.min_trades_per_ticker}
+            ORDER BY trade_count DESC
+        """
+        logger.info("Computing per-ticker features via SQL...")
+        df = self.con.execute(query).df()
+        logger.info("Computed features for %s tickers", f"{len(df):,}")
+        return df

--- a/src/quant/run.py
+++ b/src/quant/run.py
@@ -7,11 +7,13 @@ Runs the full pipeline from data loading through edge verification:
 4. Train models (Ridge, LightGBM, XGBoost)
 5. Backtest with realistic transaction costs
 6. Verify edge statistical significance
+7. Real-world validation (purged CV, ticker holdout, permutation test, execution realism)
 
 Usage:
     uv run python -m src.quant.run                    # full pipeline
     uv run python -m src.quant.run --step signals      # only signal screening
     uv run python -m src.quant.run --step backtest     # only backtest
+    uv run python -m src.quant.run --step validate     # run validation suite
     uv run python -m src.quant.run --ticker PRES-2024-DJT  # single ticker
 """
 
@@ -50,7 +52,7 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
 
     try:
         # ── Step 1: Load Data ──────────────────────────────────────────
-        if step in (None, "load", "features", "signals", "train", "backtest"):
+        if step in (None, "load", "features", "signals", "train", "backtest", "validate"):
             logger.info("=" * 60)
             logger.info("STEP 1: Loading trade data")
             logger.info("=" * 60)
@@ -90,7 +92,7 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
                 return
 
         # ── Step 2: Feature Engineering ────────────────────────────────
-        if step in (None, "features", "signals", "train", "backtest"):
+        if step in (None, "features", "signals", "train", "backtest", "validate"):
             logger.info("=" * 60)
             logger.info("STEP 2: Feature engineering")
             logger.info("=" * 60)
@@ -123,7 +125,7 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
                 return
 
         # ── Step 3: Signal Screening ───────────────────────────────────
-        if step in (None, "signals", "train", "backtest"):
+        if step in (None, "signals", "train", "backtest", "validate"):
             logger.info("=" * 60)
             logger.info("STEP 3: Signal screening")
             logger.info("=" * 60)
@@ -168,7 +170,7 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
                 return
 
         # ── Step 4: Model Training ─────────────────────────────────────
-        if step in (None, "train", "backtest"):
+        if step in (None, "train", "backtest", "validate"):
             logger.info("=" * 60)
             logger.info("STEP 4: Model training")
             logger.info("=" * 60)
@@ -232,7 +234,7 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
                 return
 
         # ── Step 5: Backtesting ────────────────────────────────────────
-        if step in (None, "backtest"):
+        if step in (None, "backtest", "validate"):
             logger.info("=" * 60)
             logger.info("STEP 5: Backtesting")
             logger.info("=" * 60)
@@ -270,6 +272,34 @@ def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | 
 
             logger.info("All outputs saved to %s", output_dir)
 
+        # ── Step 7: Real-World Validation ──────────────────────────────
+        if step in (None, "validate"):
+            logger.info("=" * 60)
+            logger.info("STEP 7: Real-world validation suite")
+            logger.info("=" * 60)
+
+            from src.quant.validation import RealWorldValidator, format_validation_report
+
+            validator = RealWorldValidator(config)
+            validation_report = validator.run_validation_suite(
+                df=df_clean,
+                feature_cols=usable_features,
+                predictions=test_predictions,
+                model_method="train_ridge",
+            )
+
+            val_report_text = format_validation_report(validation_report)
+            print("\n" + val_report_text)
+
+            with open(output_dir / "validation_report.txt", "w") as f:
+                f.write(val_report_text)
+
+            logger.info(
+                "Validation %s", "PASSED" if validation_report.overall_pass else "FAILED"
+            )
+            for reason in validation_report.failure_reasons:
+                logger.warning("  FAIL: %s", reason)
+
     finally:
         pipeline.close()
 
@@ -281,7 +311,7 @@ def main():
     parser = argparse.ArgumentParser(description="Quant trading pipeline for prediction markets")
     parser.add_argument(
         "--step",
-        choices=["load", "features", "signals", "train", "backtest"],
+        choices=["load", "features", "signals", "train", "backtest", "validate"],
         default=None,
         help="Run only up to this step (default: full pipeline)",
     )

--- a/src/quant/run.py
+++ b/src/quant/run.py
@@ -1,0 +1,311 @@
+"""Main orchestration script for the quant trading pipeline.
+
+Runs the full pipeline from data loading through edge verification:
+1. Load & preprocess trade data via DuckDB
+2. Engineer features (price, volume, imbalance, volatility, time)
+3. Screen signals for predictive power
+4. Train models (Ridge, LightGBM, XGBoost)
+5. Backtest with realistic transaction costs
+6. Verify edge statistical significance
+
+Usage:
+    uv run python -m src.quant.run                    # full pipeline
+    uv run python -m src.quant.run --step signals      # only signal screening
+    uv run python -m src.quant.run --step backtest     # only backtest
+    uv run python -m src.quant.run --ticker PRES-2024-DJT  # single ticker
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import time
+from pathlib import Path
+
+import pandas as pd
+
+from src.quant.backtest import Backtester
+from src.quant.config import PipelineConfig
+from src.quant.evaluation import EdgeVerifier, format_backtest_report
+from src.quant.features import FeatureEngine
+from src.quant.models import ModelTrainer
+from src.quant.pipeline import DataPipeline
+from src.quant.signals import SignalAnalyzer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def run_pipeline(config: PipelineConfig, step: str | None = None, ticker: str | None = None):
+    """Execute the full quant pipeline or a specific step."""
+    output_dir = Path("output/quant")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pipeline = DataPipeline(config)
+    t0 = time.time()
+
+    try:
+        # ── Step 1: Load Data ──────────────────────────────────────────
+        if step in (None, "load", "features", "signals", "train", "backtest"):
+            logger.info("=" * 60)
+            logger.info("STEP 1: Loading trade data")
+            logger.info("=" * 60)
+
+            if ticker:
+                df_raw = pipeline.load_ticker_trades(ticker)
+                logger.info("Loaded %s trades for ticker %s", f"{len(df_raw):,}", ticker)
+            else:
+                # For the full dataset, use SQL-computed features first for overview
+                ticker_features = pipeline.compute_ticker_features_sql()
+                ticker_features.to_csv(output_dir / "ticker_features.csv", index=False)
+                logger.info("Saved ticker-level features to ticker_features.csv")
+
+                # Then load trade-level data (may be large — consider sampling)
+                active_tickers = pipeline.get_active_tickers()
+                logger.info("Found %s active tickers", f"{len(active_tickers):,}")
+
+                # For trade-level analysis, sample top tickers by volume
+                top_tickers = active_tickers.nlargest(50, "trade_count")["ticker"].tolist()
+                logger.info("Using top %d tickers by volume for trade-level analysis", len(top_tickers))
+
+                # Load trades for selected tickers
+                chunks = []
+                for t in top_tickers:
+                    chunk = pipeline.load_ticker_trades(t)
+                    if len(chunk) > 0:
+                        chunks.append(chunk)
+                df_raw = pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
+                logger.info("Loaded %s trades across %d tickers", f"{len(df_raw):,}", len(chunks))
+
+            if len(df_raw) == 0:
+                logger.error("No trades loaded. Check data paths.")
+                return
+
+            if step == "load":
+                logger.info("Step 'load' complete. Elapsed: %.1fs", time.time() - t0)
+                return
+
+        # ── Step 2: Feature Engineering ────────────────────────────────
+        if step in (None, "features", "signals", "train", "backtest"):
+            logger.info("=" * 60)
+            logger.info("STEP 2: Feature engineering")
+            logger.info("=" * 60)
+
+            engine = FeatureEngine(config)
+
+            if ticker:
+                df = engine.build_trade_features(df_raw)
+            else:
+                # Build features per ticker then concatenate
+                feature_chunks = []
+                for t in df_raw["ticker"].unique():
+                    chunk = df_raw[df_raw["ticker"] == t].copy()
+                    if len(chunk) >= config.min_trades_per_ticker:
+                        featured = engine.build_trade_features(chunk)
+                        feature_chunks.append(featured)
+
+                df = pd.concat(feature_chunks, ignore_index=True) if feature_chunks else pd.DataFrame()
+
+            feature_cols = FeatureEngine.get_feature_names(df)
+            logger.info("Generated %d features, %s rows", len(feature_cols), f"{len(df):,}")
+
+            # Drop rows with NaN targets (from look-ahead and rolling warmup)
+            df_clean = df.dropna(subset=["target_return"] + feature_cols[:5])
+            logger.info("After NaN cleanup: %s rows", f"{len(df_clean):,}")
+
+            if step == "features":
+                df_clean.head(1000).to_csv(output_dir / "features_sample.csv", index=False)
+                logger.info("Saved feature sample. Elapsed: %.1fs", time.time() - t0)
+                return
+
+        # ── Step 3: Signal Screening ───────────────────────────────────
+        if step in (None, "signals", "train", "backtest"):
+            logger.info("=" * 60)
+            logger.info("STEP 3: Signal screening")
+            logger.info("=" * 60)
+
+            analyzer = SignalAnalyzer(significance_level=config.significance_level)
+
+            # Screen all features
+            signal_report = analyzer.screen_all_features(df_clean, feature_cols)
+            signal_report.to_csv(output_dir / "signal_report.csv", index=False)
+            logger.info("Signal report saved (%d features screened)", len(signal_report))
+
+            # Filter to significant signals
+            significant = analyzer.find_significant_signals(signal_report)
+            significant.to_csv(output_dir / "significant_signals.csv", index=False)
+            logger.info("Found %d significant signals", len(significant))
+
+            if len(significant) > 0:
+                logger.info("\nTop 10 signals by IC:")
+                for _, row in significant.head(10).iterrows():
+                    logger.info(
+                        "  %-30s IC=%.4f  Spread=%.4f  Mono=%.2f  p=%.1e",
+                        row["feature"], row["ic"], row["long_short_spread"],
+                        row["monotonicity"], row["ic_pvalue"],
+                    )
+
+                # Signal decay for top signal
+                top_signal = significant.iloc[0]["feature"]
+                decay = analyzer.test_signal_decay(df_clean, top_signal)
+                decay.to_csv(output_dir / "signal_decay.csv", index=False)
+                logger.info("\nSignal decay for '%s':", top_signal)
+                for _, row in decay.iterrows():
+                    logger.info("  Horizon=%3d  IC=%.4f  p=%.2e", row["horizon"], row["ic"], row["ic_pvalue"])
+
+                # Use significant features for modeling
+                model_features = significant["feature"].tolist()[:30]  # cap at 30
+            else:
+                logger.warning("No significant signals found. Using top features by abs IC.")
+                model_features = signal_report["feature"].tolist()[:20]
+
+            if step == "signals":
+                logger.info("Step 'signals' complete. Elapsed: %.1fs", time.time() - t0)
+                return
+
+        # ── Step 4: Model Training ─────────────────────────────────────
+        if step in (None, "train", "backtest"):
+            logger.info("=" * 60)
+            logger.info("STEP 4: Model training")
+            logger.info("=" * 60)
+
+            # Filter to usable features (present in data)
+            usable_features = [f for f in model_features if f in df_clean.columns]
+            if len(usable_features) < 3:
+                logger.error("Too few usable features (%d). Aborting.", len(usable_features))
+                return
+
+            trainer = ModelTrainer(usable_features)
+            train, val, test = trainer.prepare_splits(
+                df_clean, config.train_fraction, config.validation_fraction
+            )
+
+            # Train Ridge (always available)
+            logger.info("Training Ridge regression...")
+            ridge_result = trainer.train_ridge(train, val)
+            logger.info(
+                "Ridge — Train R2: %.4f, Val R2: %.4f, Val IC: %.4f",
+                ridge_result.train_r2, ridge_result.val_r2, ridge_result.val_ic,
+            )
+
+            # Train LightGBM
+            best_result = ridge_result
+            try:
+                logger.info("Training LightGBM...")
+                lgb_result = trainer.train_lightgbm(train, val)
+                logger.info(
+                    "LightGBM — Train R2: %.4f, Val R2: %.4f, Val IC: %.4f",
+                    lgb_result.train_r2, lgb_result.val_r2, lgb_result.val_ic,
+                )
+                if abs(lgb_result.val_ic) > abs(best_result.val_ic):
+                    best_result = lgb_result
+            except ImportError:
+                logger.warning("LightGBM not installed, skipping.")
+
+            # Train XGBoost
+            try:
+                logger.info("Training XGBoost...")
+                xgb_result = trainer.train_xgboost(train, val)
+                logger.info(
+                    "XGBoost — Train R2: %.4f, Val R2: %.4f, Val IC: %.4f",
+                    xgb_result.train_r2, xgb_result.val_r2, xgb_result.val_ic,
+                )
+                if abs(xgb_result.val_ic) > abs(best_result.val_ic):
+                    best_result = xgb_result
+            except ImportError:
+                logger.warning("XGBoost not installed, skipping.")
+
+            logger.info("\nBest model: %s (Val IC: %.4f)", best_result.model_name, best_result.val_ic)
+
+            # Save feature importance
+            best_result.feature_importance.to_csv(output_dir / "feature_importance.csv", index=False)
+            logger.info("Top 10 features:")
+            for _, row in best_result.feature_importance.head(10).iterrows():
+                logger.info("  %-30s  importance=%.4f", row["feature"], row["importance"])
+
+            if step == "train":
+                logger.info("Step 'train' complete. Elapsed: %.1fs", time.time() - t0)
+                return
+
+        # ── Step 5: Backtesting ────────────────────────────────────────
+        if step in (None, "backtest"):
+            logger.info("=" * 60)
+            logger.info("STEP 5: Backtesting")
+            logger.info("=" * 60)
+
+            backtester = Backtester(
+                transaction_cost_bps=config.transaction_cost_bps,
+                max_position_usd=config.max_position_size,
+            )
+
+            # Generate predictions on test set
+            test_predictions = trainer.predict(best_result, test)
+
+            # Run backtest
+            bt_result = backtester.run(test, test_predictions)
+
+            # ── Step 6: Edge Verification ──────────────────────────────
+            logger.info("=" * 60)
+            logger.info("STEP 6: Edge verification")
+            logger.info("=" * 60)
+
+            verifier = EdgeVerifier()
+            n_models_tested = 3  # Ridge + LightGBM + XGBoost
+            verification = verifier.verify(bt_result, n_trials=n_models_tested)
+
+            # Print report
+            report = format_backtest_report(bt_result, verification)
+            print("\n" + report)
+
+            # Save outputs
+            bt_result.trade_log.to_csv(output_dir / "backtest_trades.csv", index=False)
+            bt_result.equity_curve.to_csv(output_dir / "equity_curve.csv", index=False)
+
+            with open(output_dir / "report.txt", "w") as f:
+                f.write(report)
+
+            logger.info("All outputs saved to %s", output_dir)
+
+    finally:
+        pipeline.close()
+
+    elapsed = time.time() - t0
+    logger.info("Pipeline complete. Total elapsed: %.1fs (%.1f min)", elapsed, elapsed / 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Quant trading pipeline for prediction markets")
+    parser.add_argument(
+        "--step",
+        choices=["load", "features", "signals", "train", "backtest"],
+        default=None,
+        help="Run only up to this step (default: full pipeline)",
+    )
+    parser.add_argument("--ticker", type=str, default=None, help="Analyze a single ticker")
+    parser.add_argument("--trades-dir", type=str, default=None, help="Override trades directory")
+    parser.add_argument("--markets-dir", type=str, default=None, help="Override markets directory")
+    parser.add_argument("--horizon", type=int, default=50, help="Prediction horizon (trades ahead)")
+    parser.add_argument("--min-trades", type=int, default=200, help="Minimum trades per ticker")
+    parser.add_argument("--cost-bps", type=float, default=100.0, help="Transaction cost in bps")
+
+    args = parser.parse_args()
+
+    config = PipelineConfig(
+        target_horizon=args.horizon,
+        min_trades_per_ticker=args.min_trades,
+        transaction_cost_bps=args.cost_bps,
+    )
+    if args.trades_dir:
+        config.trades_dir = Path(args.trades_dir)
+    if args.markets_dir:
+        config.markets_dir = Path(args.markets_dir)
+
+    run_pipeline(config, step=args.step, ticker=args.ticker)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/quant/signals.py
+++ b/src/quant/signals.py
@@ -1,0 +1,224 @@
+"""Signal identification and statistical testing for alpha discovery.
+
+Screens features for predictive power, tests statistical significance,
+and identifies exploitable patterns in prediction market trade data.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SignalReport:
+    """Results from signal analysis on a single feature."""
+
+    feature: str
+    ic: float  # information coefficient (Spearman rank correlation with target)
+    ic_pvalue: float
+    ic_t_stat: float
+    mean_return_long: float  # mean return of top quintile
+    mean_return_short: float  # mean return of bottom quintile
+    long_short_spread: float
+    spread_t_stat: float
+    spread_pvalue: float
+    monotonicity: float  # rank correlation of quintile returns (ideal = 1.0)
+    turnover: float  # mean absolute change in signal rank per period
+    n_obs: int
+
+
+class SignalAnalyzer:
+    """Discover and validate alpha signals from featurized trade data."""
+
+    def __init__(self, significance_level: float = 0.05):
+        self.significance_level = significance_level
+
+    def screen_all_features(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        target_col: str = "target_return",
+    ) -> pd.DataFrame:
+        """Screen all features for predictive power.
+
+        Returns a DataFrame of SignalReport rows, sorted by absolute IC.
+        """
+        reports = []
+        for feat in feature_cols:
+            report = self._analyze_single_signal(df, feat, target_col)
+            if report is not None:
+                reports.append(report)
+
+        if not reports:
+            return pd.DataFrame()
+
+        result = pd.DataFrame([r.__dict__ for r in reports])
+        result["abs_ic"] = result["ic"].abs()
+        result = result.sort_values("abs_ic", ascending=False).reset_index(drop=True)
+        return result
+
+    def _analyze_single_signal(
+        self,
+        df: pd.DataFrame,
+        feature: str,
+        target_col: str,
+    ) -> SignalReport | None:
+        """Analyze a single feature's predictive power."""
+        valid = df[[feature, target_col]].dropna()
+        if len(valid) < 100:
+            return None
+
+        x = valid[feature].values
+        y = valid[target_col].values
+
+        # Skip constant features
+        if np.std(x) < 1e-10:
+            return None
+
+        # Information Coefficient (Spearman rank correlation)
+        ic, ic_pval = stats.spearmanr(x, y)
+        n = len(valid)
+        ic_t = ic * np.sqrt((n - 2) / (1 - ic**2 + 1e-10))
+
+        # Quintile analysis
+        try:
+            quintiles = pd.qcut(valid[feature], q=5, labels=False, duplicates="drop")
+        except ValueError:
+            return None
+
+        if quintiles.nunique() < 3:
+            return None
+
+        quintile_returns = valid.groupby(quintiles)[target_col].mean()
+        top_q = quintile_returns.iloc[-1]
+        bottom_q = quintile_returns.iloc[0]
+        spread = top_q - bottom_q
+
+        # T-test on long-short spread
+        top_mask = quintiles == quintiles.max()
+        bottom_mask = quintiles == quintiles.min()
+        top_vals = y[top_mask]
+        bottom_vals = y[bottom_mask]
+
+        if len(top_vals) < 10 or len(bottom_vals) < 10:
+            return None
+
+        t_stat, t_pval = stats.ttest_ind(top_vals, bottom_vals, equal_var=False)
+
+        # Monotonicity: do quintile returns increase monotonically?
+        q_means = quintile_returns.values
+        mono_corr, _ = stats.spearmanr(range(len(q_means)), q_means)
+
+        # Turnover: how much does the signal rank change between consecutive obs
+        ranks = valid[feature].rank(pct=True)
+        turnover = ranks.diff().abs().mean()
+
+        return SignalReport(
+            feature=feature,
+            ic=float(ic),
+            ic_pvalue=float(ic_pval),
+            ic_t_stat=float(ic_t),
+            mean_return_long=float(top_q),
+            mean_return_short=float(bottom_q),
+            long_short_spread=float(spread),
+            spread_t_stat=float(t_stat),
+            spread_pvalue=float(t_pval),
+            monotonicity=float(mono_corr),
+            turnover=float(turnover),
+            n_obs=n,
+        )
+
+    def find_significant_signals(
+        self, report_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Filter signal report to only statistically significant signals."""
+        if report_df.empty:
+            return report_df
+
+        mask = (
+            (report_df["ic_pvalue"] < self.significance_level)
+            & (report_df["spread_pvalue"] < self.significance_level)
+            & (report_df["abs_ic"] > 0.01)  # minimum practical IC
+        )
+        return report_df[mask].reset_index(drop=True)
+
+    def detect_regime_clusters(
+        self,
+        df: pd.DataFrame,
+        feature: str = "volume_imbalance_100",
+        n_regimes: int = 3,
+    ) -> pd.DataFrame:
+        """Detect market regimes via simple quantile-based clustering.
+
+        Splits the feature into n_regimes quantile buckets and computes
+        statistics for each regime (mean return, volatility, trade count).
+        """
+        valid = df[[feature, "target_return", "yes_price"]].dropna()
+        if len(valid) < n_regimes * 50:
+            return pd.DataFrame()
+
+        valid = valid.copy()
+        valid["regime"] = pd.qcut(valid[feature], q=n_regimes, labels=False, duplicates="drop")
+
+        regime_stats = (
+            valid.groupby("regime")
+            .agg(
+                mean_return=("target_return", "mean"),
+                std_return=("target_return", "std"),
+                mean_price=("yes_price", "mean"),
+                mean_signal=(feature, "mean"),
+                count=("target_return", "count"),
+            )
+            .reset_index()
+        )
+
+        # Sharpe-like ratio per regime
+        regime_stats["sharpe"] = (
+            regime_stats["mean_return"] / regime_stats["std_return"].clip(lower=1e-6)
+        )
+
+        return regime_stats
+
+    def correlation_matrix(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        method: str = "spearman",
+    ) -> pd.DataFrame:
+        """Compute pairwise feature correlation matrix.
+
+        Useful for identifying redundant features before model training.
+        """
+        return df[feature_cols].corr(method=method)
+
+    def test_signal_decay(
+        self,
+        df: pd.DataFrame,
+        feature: str,
+        horizons: list[int] | None = None,
+    ) -> pd.DataFrame:
+        """Test how a signal's predictive power decays over different horizons.
+
+        Computes IC at each horizon to see if the signal is fast-decaying
+        (suitable for short-term) or persistent (suitable for longer holding).
+        """
+        if horizons is None:
+            horizons = [5, 10, 25, 50, 100, 200, 500]
+
+        results = []
+        for h in horizons:
+            future_ret = df["yes_price"].shift(-h) - df["yes_price"]
+            valid = pd.DataFrame({"signal": df[feature], "ret": future_ret}).dropna()
+            if len(valid) < 100:
+                continue
+            ic, pval = stats.spearmanr(valid["signal"], valid["ret"])
+            results.append({"horizon": h, "ic": ic, "ic_pvalue": pval, "n_obs": len(valid)})
+
+        return pd.DataFrame(results)

--- a/src/quant/validation.py
+++ b/src/quant/validation.py
@@ -1,0 +1,731 @@
+"""Real-world edge validation for prediction market trading strategies.
+
+Tests whether a discovered edge is genuine and executable by running:
+1. Purged walk-forward CV (eliminates feature leakage at train/test boundary)
+2. Ticker-level hold-out (tests generalization to unseen markets)
+3. Permutation test (tests if signal is distinguishable from noise)
+4. Realistic execution model (slippage, latency, liquidity constraints)
+5. Stress tests (adverse cost/sizing scenarios)
+6. Random baseline comparison (model vs random direction)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from src.quant.backtest import Backtester, BacktestResult
+from src.quant.config import PipelineConfig
+from src.quant.models import ModelTrainer
+
+logger = logging.getLogger(__name__)
+
+
+# ── Result dataclasses ─────────────────────────────────────────────────────
+
+
+@dataclass
+class PurgedCVResult:
+    """Results from purged walk-forward cross-validation."""
+
+    fold_sharpes: list[float]
+    fold_ics: list[float]
+    fold_n_trades: list[int]
+    mean_sharpe: float
+    std_sharpe: float
+    mean_ic: float
+    embargo_size: int
+    n_folds: int
+
+
+@dataclass
+class TickerHoldoutResult:
+    """Results from leave-one-ticker-out validation."""
+
+    ticker_sharpes: dict[str, float]
+    ticker_ics: dict[str, float]
+    ticker_n_trades: dict[str, int]
+    mean_sharpe: float
+    std_sharpe: float
+    mean_ic: float
+    n_tickers: int
+
+
+@dataclass
+class PermutationTestResult:
+    """Results from permutation test of model edge."""
+
+    observed_sharpe: float
+    permuted_sharpes: list[float]
+    p_value: float
+    n_permutations: int
+
+
+@dataclass
+class ExecutionModelResult:
+    """Results from realistic execution simulation."""
+
+    naive_sharpe: float
+    realistic_sharpe: float
+    sharpe_degradation_pct: float
+    trades_filtered_by_liquidity: int
+    trades_total: int
+    mean_slippage_pct: float
+    backtest_result: BacktestResult
+
+
+@dataclass
+class StressTestResult:
+    """Results from stress testing under adverse conditions."""
+
+    scenario_results: list[dict]
+
+
+@dataclass
+class RandomBaselineResult:
+    """Results comparing model to random trading."""
+
+    model_sharpe: float
+    random_sharpes: list[float]
+    random_mean_sharpe: float
+    random_std_sharpe: float
+    p_value: float
+    n_baselines: int
+
+
+@dataclass
+class ValidationReport:
+    """Consolidated results from the full validation suite."""
+
+    purged_cv: PurgedCVResult
+    ticker_holdout: TickerHoldoutResult
+    permutation_test: PermutationTestResult
+    execution_model: ExecutionModelResult
+    stress_tests: StressTestResult
+    random_baseline: RandomBaselineResult
+    overall_pass: bool
+    failure_reasons: list[str]
+
+
+# ── Validator ──────────────────────────────────────────────────────────────
+
+
+class RealWorldValidator:
+    """Comprehensive real-world validation of trading strategies."""
+
+    def __init__(self, config: PipelineConfig, seed: int = 42):
+        self.config = config
+        self.rng = np.random.default_rng(seed)
+
+    def run_validation_suite(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        predictions: np.ndarray,
+        model_method: str = "train_ridge",
+    ) -> ValidationReport:
+        """Run all validation tests and produce a consolidated report."""
+        cfg = self.config
+
+        # Subsample for expensive tests
+        sample_size = min(cfg.validation_sample_size, len(df))
+        df_sample = df.iloc[:sample_size].copy()
+
+        logger.info("Running purged walk-forward CV...")
+        purged_cv = self.purged_walk_forward_cv(df_sample, feature_cols, model_method)
+
+        logger.info("Running ticker hold-out CV...")
+        ticker_holdout = self.ticker_holdout_cv(df_sample, feature_cols, model_method)
+
+        logger.info("Running permutation test (%d permutations)...", cfg.validation_n_permutations)
+        perm_test = self.permutation_test(df_sample, feature_cols, model_method)
+
+        logger.info("Running realistic execution backtest...")
+        exec_model = self.realistic_execution_backtest(df, predictions)
+
+        logger.info("Running stress tests...")
+        stress = self.stress_test(df, predictions)
+
+        logger.info("Running random baseline comparison (%d baselines)...", cfg.validation_n_random_baselines)
+        random_bl = self.random_baseline_comparison(df, predictions)
+
+        # Determine overall pass/fail
+        failure_reasons: list[str] = []
+
+        if purged_cv.mean_sharpe < cfg.min_sharpe_ratio:
+            failure_reasons.append(
+                f"Purged CV Sharpe {purged_cv.mean_sharpe:.2f} < {cfg.min_sharpe_ratio}"
+            )
+        if ticker_holdout.mean_sharpe < 0:
+            failure_reasons.append(
+                f"Ticker holdout Sharpe {ticker_holdout.mean_sharpe:.2f} < 0"
+            )
+        if perm_test.p_value > cfg.significance_level:
+            failure_reasons.append(
+                f"Permutation p-value {perm_test.p_value:.3f} > {cfg.significance_level}"
+            )
+        if exec_model.realistic_sharpe < cfg.min_sharpe_ratio:
+            failure_reasons.append(
+                f"Realistic execution Sharpe {exec_model.realistic_sharpe:.2f} < {cfg.min_sharpe_ratio}"
+            )
+        if stress.scenario_results:
+            worst = min(s["sharpe"] for s in stress.scenario_results)
+            if worst < 0:
+                failure_reasons.append(f"Stress test worst Sharpe {worst:.2f} < 0")
+        if random_bl.p_value > cfg.significance_level:
+            failure_reasons.append(
+                f"Random baseline p-value {random_bl.p_value:.3f} > {cfg.significance_level}"
+            )
+
+        overall_pass = len(failure_reasons) == 0
+
+        return ValidationReport(
+            purged_cv=purged_cv,
+            ticker_holdout=ticker_holdout,
+            permutation_test=perm_test,
+            execution_model=exec_model,
+            stress_tests=stress,
+            random_baseline=random_bl,
+            overall_pass=overall_pass,
+            failure_reasons=failure_reasons,
+        )
+
+    # ── 1. Purged Walk-Forward CV ──────────────────────────────────────
+
+    def purged_walk_forward_cv(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        model_method: str = "train_ridge",
+        n_folds: int = 5,
+    ) -> PurgedCVResult:
+        """Walk-forward CV with embargo gap to prevent feature leakage."""
+        cfg = self.config
+        embargo = int(
+            cfg.validation_embargo_multiplier
+            * max(max(cfg.rolling_windows), cfg.target_horizon)
+        )
+
+        n = len(df)
+        fold_size = n // (n_folds + 1)
+
+        fold_sharpes = []
+        fold_ics = []
+        fold_n_trades = []
+
+        for k in range(1, n_folds + 1):
+            train_end = k * fold_size
+            test_start = train_end + embargo
+            test_end = min(test_start + fold_size, n)
+
+            if test_start >= n or test_end - test_start < 200:
+                continue
+
+            train_slice = df.iloc[:train_end]
+            test_slice = df.iloc[test_start:test_end]
+
+            result = self._train_and_backtest(
+                train_slice, test_slice, feature_cols, model_method
+            )
+            if result is not None:
+                sharpe, ic, n_trades = result
+                fold_sharpes.append(sharpe)
+                fold_ics.append(ic)
+                fold_n_trades.append(n_trades)
+
+        mean_sharpe = float(np.mean(fold_sharpes)) if fold_sharpes else 0.0
+        std_sharpe = float(np.std(fold_sharpes)) if len(fold_sharpes) > 1 else 0.0
+        mean_ic = float(np.mean(fold_ics)) if fold_ics else 0.0
+
+        return PurgedCVResult(
+            fold_sharpes=fold_sharpes,
+            fold_ics=fold_ics,
+            fold_n_trades=fold_n_trades,
+            mean_sharpe=mean_sharpe,
+            std_sharpe=std_sharpe,
+            mean_ic=mean_ic,
+            embargo_size=embargo,
+            n_folds=len(fold_sharpes),
+        )
+
+    # ── 2. Ticker Hold-Out CV ──────────────────────────────────────────
+
+    def ticker_holdout_cv(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        model_method: str = "train_ridge",
+    ) -> TickerHoldoutResult:
+        """Leave-one-ticker-out: tests generalization to unseen markets."""
+        tickers = df["ticker"].unique()
+
+        if len(tickers) < 2:
+            logger.warning("Only %d ticker(s) — ticker holdout not meaningful.", len(tickers))
+            return TickerHoldoutResult(
+                ticker_sharpes={}, ticker_ics={}, ticker_n_trades={},
+                mean_sharpe=0.0, std_sharpe=0.0, mean_ic=0.0, n_tickers=0,
+            )
+
+        ticker_sharpes: dict[str, float] = {}
+        ticker_ics: dict[str, float] = {}
+        ticker_n_trades: dict[str, int] = {}
+
+        for t in tickers:
+            train_df = df[df["ticker"] != t]
+            test_df = df[df["ticker"] == t]
+
+            if len(test_df) < self.config.min_trades_per_ticker:
+                continue
+
+            result = self._train_and_backtest(
+                train_df, test_df, feature_cols, model_method
+            )
+            if result is not None:
+                sharpe, ic, n_trades = result
+                ticker_sharpes[t] = sharpe
+                ticker_ics[t] = ic
+                ticker_n_trades[t] = n_trades
+
+        sharpe_vals = list(ticker_sharpes.values())
+        ic_vals = list(ticker_ics.values())
+
+        return TickerHoldoutResult(
+            ticker_sharpes=ticker_sharpes,
+            ticker_ics=ticker_ics,
+            ticker_n_trades=ticker_n_trades,
+            mean_sharpe=float(np.mean(sharpe_vals)) if sharpe_vals else 0.0,
+            std_sharpe=float(np.std(sharpe_vals)) if len(sharpe_vals) > 1 else 0.0,
+            mean_ic=float(np.mean(ic_vals)) if ic_vals else 0.0,
+            n_tickers=len(ticker_sharpes),
+        )
+
+    # ── 3. Permutation Test ────────────────────────────────────────────
+
+    def permutation_test(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        model_method: str = "train_ridge",
+        n_permutations: int | None = None,
+    ) -> PermutationTestResult:
+        """Shuffle targets within each ticker, retrain, and compare Sharpe."""
+        if n_permutations is None:
+            n_permutations = self.config.validation_n_permutations
+
+        # Observed (real) Sharpe
+        observed = self._train_and_backtest_full(df, feature_cols, model_method)
+        observed_sharpe = observed if observed is not None else 0.0
+
+        permuted_sharpes = []
+        target_cols = ["target_return", "future_return", "target_up", "future_price"]
+
+        for i in range(n_permutations):
+            df_perm = df.copy()
+            # Grouped shuffle within each ticker to preserve per-ticker distributions
+            for col in target_cols:
+                if col in df_perm.columns:
+                    df_perm[col] = df_perm.groupby("ticker")[col].transform(
+                        lambda x: self.rng.permutation(x.values)
+                    )
+
+            perm_sharpe = self._train_and_backtest_full(df_perm, feature_cols, model_method)
+            permuted_sharpes.append(perm_sharpe if perm_sharpe is not None else 0.0)
+
+            if (i + 1) % 20 == 0:
+                logger.info("  Permutation %d/%d done", i + 1, n_permutations)
+
+        # p-value: fraction of permuted Sharpes >= observed (with +1 correction)
+        n_ge = sum(1 for s in permuted_sharpes if s >= observed_sharpe)
+        p_value = (n_ge + 1) / (n_permutations + 1)
+
+        return PermutationTestResult(
+            observed_sharpe=observed_sharpe,
+            permuted_sharpes=permuted_sharpes,
+            p_value=float(p_value),
+            n_permutations=n_permutations,
+        )
+
+    # ── 4. Realistic Execution Model ───────────────────────────────────
+
+    def realistic_execution_backtest(
+        self,
+        df: pd.DataFrame,
+        predictions: np.ndarray,
+    ) -> ExecutionModelResult:
+        """Backtest with slippage, latency, and liquidity constraints."""
+        cfg = self.config
+        df = df.copy()
+        preds = predictions.copy()
+
+        # Naive backtest (baseline)
+        naive_bt = Backtester(
+            transaction_cost_bps=cfg.transaction_cost_bps,
+            max_position_usd=cfg.max_position_size,
+            min_edge_threshold=0.5,
+        )
+        naive_result = naive_bt.run(df, preds)
+        naive_sharpe = naive_result.sharpe_ratio
+
+        # --- Liquidity filter ---
+        rolling_vol = df["count"].rolling(cfg.validation_liquidity_window, min_periods=1).sum()
+        vol_threshold = rolling_vol.quantile(cfg.validation_liquidity_volume_percentile / 100)
+        illiquid_mask = rolling_vol < vol_threshold
+        trades_filtered = int(illiquid_mask.sum())
+        # Zero out predictions for illiquid periods (no trade)
+        preds_filtered = preds.copy()
+        preds_filtered[illiquid_mask.values[: len(preds_filtered)]] = 0.0
+
+        # --- Latency penalty ---
+        # Shift execution price: use price N trades later
+        latency = cfg.validation_latency_trades
+        df_exec = df.copy()
+        if latency > 0 and "yes_price" in df_exec.columns:
+            exec_price = df_exec["yes_price"].shift(-latency)
+            # Recompute target return based on delayed execution
+            future_price = df_exec["yes_price"].shift(-cfg.target_horizon)
+            df_exec["target_return"] = (
+                (future_price - exec_price) / exec_price.clip(lower=1) * 100
+            )
+
+        # --- Slippage via elevated transaction costs ---
+        # Average slippage: base + size-dependent (approximate as flat addition)
+        avg_position = cfg.max_position_size * 0.5  # rough average
+        avg_slippage_pct = (
+            cfg.validation_slippage_base_pct
+            + cfg.validation_slippage_size_pct * (avg_position / cfg.validation_slippage_size_unit)
+        )
+        # Convert to bps and add to base cost
+        slippage_bps = avg_slippage_pct * 100
+        total_cost_bps = cfg.transaction_cost_bps + slippage_bps
+
+        realistic_bt = Backtester(
+            transaction_cost_bps=total_cost_bps,
+            max_position_usd=cfg.max_position_size,
+            min_edge_threshold=0.5,
+        )
+        realistic_result = realistic_bt.run(df_exec, preds_filtered)
+        realistic_sharpe = realistic_result.sharpe_ratio
+
+        degradation = (
+            (naive_sharpe - realistic_sharpe) / max(abs(naive_sharpe), 1e-6) * 100
+        )
+
+        return ExecutionModelResult(
+            naive_sharpe=float(naive_sharpe),
+            realistic_sharpe=float(realistic_sharpe),
+            sharpe_degradation_pct=float(degradation),
+            trades_filtered_by_liquidity=trades_filtered,
+            trades_total=len(df),
+            mean_slippage_pct=float(avg_slippage_pct),
+            backtest_result=realistic_result,
+        )
+
+    # ── 5. Stress Tests ────────────────────────────────────────────────
+
+    def stress_test(
+        self,
+        df: pd.DataFrame,
+        predictions: np.ndarray,
+    ) -> StressTestResult:
+        """Run backtest under adverse conditions."""
+        cfg = self.config
+        scenarios: list[dict] = []
+
+        # High cost scenarios
+        for mult in cfg.validation_stress_cost_multipliers:
+            bt = Backtester(
+                transaction_cost_bps=cfg.transaction_cost_bps * mult,
+                max_position_usd=cfg.max_position_size,
+                min_edge_threshold=0.5,
+            )
+            result = bt.run(df, predictions)
+            scenarios.append({
+                "scenario": f"cost_{mult:.0f}x",
+                "sharpe": float(result.sharpe_ratio),
+                "total_return": float(result.total_return),
+                "n_trades": result.total_trades,
+                "win_rate": float(result.win_rate),
+            })
+
+        # Reduced position size scenarios
+        for frac in cfg.validation_stress_max_position_fractions:
+            bt = Backtester(
+                transaction_cost_bps=cfg.transaction_cost_bps,
+                max_position_usd=cfg.max_position_size * frac,
+                min_edge_threshold=0.5,
+            )
+            result = bt.run(df, predictions)
+            scenarios.append({
+                "scenario": f"position_{frac:.0%}",
+                "sharpe": float(result.sharpe_ratio),
+                "total_return": float(result.total_return),
+                "n_trades": result.total_trades,
+                "win_rate": float(result.win_rate),
+            })
+
+        # Low-liquidity only
+        rolling_vol = df["count"].rolling(cfg.validation_liquidity_window, min_periods=1).sum()
+        low_liq_mask = rolling_vol <= rolling_vol.quantile(0.25)
+        if low_liq_mask.sum() > 100:
+            df_low_liq = df[low_liq_mask].reset_index(drop=True)
+            preds_low_liq = predictions[low_liq_mask.values[: len(predictions)]]
+            if len(preds_low_liq) > 0:
+                bt = Backtester(
+                    transaction_cost_bps=cfg.transaction_cost_bps,
+                    max_position_usd=cfg.max_position_size,
+                    min_edge_threshold=0.5,
+                )
+                result = bt.run(df_low_liq, preds_low_liq)
+                scenarios.append({
+                    "scenario": "low_liquidity_only",
+                    "sharpe": float(result.sharpe_ratio),
+                    "total_return": float(result.total_return),
+                    "n_trades": result.total_trades,
+                    "win_rate": float(result.win_rate),
+                })
+
+        # Combined worst case: 5x cost + 25% position + low liquidity
+        if low_liq_mask.sum() > 100:
+            bt = Backtester(
+                transaction_cost_bps=cfg.transaction_cost_bps * 5,
+                max_position_usd=cfg.max_position_size * 0.25,
+                min_edge_threshold=0.5,
+            )
+            result = bt.run(df_low_liq, preds_low_liq)
+            scenarios.append({
+                "scenario": "worst_case_combined",
+                "sharpe": float(result.sharpe_ratio),
+                "total_return": float(result.total_return),
+                "n_trades": result.total_trades,
+                "win_rate": float(result.win_rate),
+            })
+
+        return StressTestResult(scenario_results=scenarios)
+
+    # ── 6. Random Baseline ─────────────────────────────────────────────
+
+    def random_baseline_comparison(
+        self,
+        df: pd.DataFrame,
+        predictions: np.ndarray,
+        n_baselines: int | None = None,
+    ) -> RandomBaselineResult:
+        """Compare model to random sign-flipped predictions."""
+        if n_baselines is None:
+            n_baselines = self.config.validation_n_random_baselines
+
+        bt = Backtester(
+            transaction_cost_bps=self.config.transaction_cost_bps,
+            max_position_usd=self.config.max_position_size,
+            min_edge_threshold=0.5,
+        )
+
+        model_result = bt.run(df, predictions)
+        model_sharpe = model_result.sharpe_ratio
+
+        random_sharpes = []
+        for _ in range(n_baselines):
+            # Sign-flip: preserves magnitude distribution, randomizes direction
+            signs = self.rng.choice([-1, 1], size=len(predictions))
+            random_preds = predictions * signs
+            result = bt.run(df, random_preds)
+            random_sharpes.append(float(result.sharpe_ratio))
+
+        n_ge = sum(1 for s in random_sharpes if s >= model_sharpe)
+        p_value = (n_ge + 1) / (n_baselines + 1)
+
+        return RandomBaselineResult(
+            model_sharpe=float(model_sharpe),
+            random_sharpes=random_sharpes,
+            random_mean_sharpe=float(np.mean(random_sharpes)),
+            random_std_sharpe=float(np.std(random_sharpes)),
+            p_value=float(p_value),
+            n_baselines=n_baselines,
+        )
+
+    # ── Helpers ────────────────────────────────────────────────────────
+
+    def _train_and_backtest(
+        self,
+        train_df: pd.DataFrame,
+        test_df: pd.DataFrame,
+        feature_cols: list[str],
+        model_method: str,
+    ) -> tuple[float, float, int] | None:
+        """Train model on train_df, backtest on test_df. Returns (sharpe, ic, n_trades)."""
+        valid_features = [f for f in feature_cols if f in train_df.columns and f in test_df.columns]
+        required_cols = valid_features + ["target_return"]
+
+        train_clean = train_df.dropna(subset=required_cols)
+        test_clean = test_df.dropna(subset=required_cols)
+
+        if len(train_clean) < 500 or len(test_clean) < 100:
+            return None
+
+        trainer = ModelTrainer(valid_features)
+        train_split, val_split, _ = trainer.prepare_splits(train_clean, train_frac=0.8, val_frac=0.2)
+
+        if len(train_split) < 200 or len(val_split) < 50:
+            return None
+
+        train_fn = getattr(trainer, model_method)
+        model_result = train_fn(train_split, val_split)
+
+        preds = trainer.predict(model_result, test_clean)
+
+        bt = Backtester(
+            transaction_cost_bps=self.config.transaction_cost_bps,
+            max_position_usd=self.config.max_position_size,
+            min_edge_threshold=0.5,
+        )
+        bt_result = bt.run(test_clean, preds)
+
+        # IC on test set
+        valid_mask = ~np.isnan(preds) & ~np.isnan(test_clean["target_return"].values)
+        if valid_mask.sum() < 30:
+            return None
+        ic, _ = stats.spearmanr(
+            preds[valid_mask], test_clean["target_return"].values[valid_mask]
+        )
+
+        return (float(bt_result.sharpe_ratio), float(ic), bt_result.total_trades)
+
+    def _train_and_backtest_full(
+        self,
+        df: pd.DataFrame,
+        feature_cols: list[str],
+        model_method: str,
+    ) -> float | None:
+        """Train/test on df with standard split, return Sharpe."""
+        valid_features = [f for f in feature_cols if f in df.columns]
+        required_cols = valid_features + ["target_return"]
+        df_clean = df.dropna(subset=required_cols)
+
+        if len(df_clean) < 1000:
+            return None
+
+        trainer = ModelTrainer(valid_features)
+        train, val, test = trainer.prepare_splits(df_clean)
+
+        if len(train) < 200 or len(val) < 50 or len(test) < 50:
+            return None
+
+        train_fn = getattr(trainer, model_method)
+        model_result = train_fn(train, val)
+        preds = trainer.predict(model_result, test)
+
+        bt = Backtester(
+            transaction_cost_bps=self.config.transaction_cost_bps,
+            max_position_usd=self.config.max_position_size,
+            min_edge_threshold=0.5,
+        )
+        bt_result = bt.run(test, preds)
+        return float(bt_result.sharpe_ratio)
+
+
+# ── Report Formatting ──────────────────────────────────────────────────────
+
+
+def format_validation_report(report: ValidationReport) -> str:
+    """Format a human-readable validation report."""
+    lines = [
+        "=" * 65,
+        "REAL-WORLD EDGE VALIDATION REPORT",
+        "=" * 65,
+        "",
+    ]
+
+    # 1. Purged CV
+    cv = report.purged_cv
+    lines += [
+        "--- 1. Purged Walk-Forward CV ---",
+        f"  Folds:          {cv.n_folds}",
+        f"  Embargo:        {cv.embargo_size} trades",
+        f"  Mean Sharpe:    {cv.mean_sharpe:.3f} +/- {cv.std_sharpe:.3f}",
+        f"  Mean IC:        {cv.mean_ic:.4f}",
+        f"  Fold Sharpes:   {[f'{s:.2f}' for s in cv.fold_sharpes]}",
+        "",
+    ]
+
+    # 2. Ticker Holdout
+    th = report.ticker_holdout
+    lines += [
+        "--- 2. Ticker Hold-Out CV ---",
+        f"  Tickers tested: {th.n_tickers}",
+        f"  Mean Sharpe:    {th.mean_sharpe:.3f} +/- {th.std_sharpe:.3f}",
+        f"  Mean IC:        {th.mean_ic:.4f}",
+    ]
+    if th.ticker_sharpes:
+        sorted_tickers = sorted(th.ticker_sharpes.items(), key=lambda x: x[1], reverse=True)
+        lines.append("  Top 5 tickers:")
+        for t, s in sorted_tickers[:5]:
+            lines.append(f"    {t:30s} Sharpe={s:.3f}  n={th.ticker_n_trades.get(t, 0):,}")
+        lines.append("  Bottom 5 tickers:")
+        for t, s in sorted_tickers[-5:]:
+            lines.append(f"    {t:30s} Sharpe={s:.3f}  n={th.ticker_n_trades.get(t, 0):,}")
+    lines.append("")
+
+    # 3. Permutation Test
+    pt = report.permutation_test
+    lines += [
+        "--- 3. Permutation Test ---",
+        f"  Observed Sharpe:  {pt.observed_sharpe:.3f}",
+        f"  Permuted mean:    {np.mean(pt.permuted_sharpes):.3f} +/- {np.std(pt.permuted_sharpes):.3f}",
+        f"  p-value:          {pt.p_value:.4f}",
+        f"  Permutations:     {pt.n_permutations}",
+        f"  Verdict:          {'SIGNIFICANT' if pt.p_value < 0.05 else 'NOT SIGNIFICANT'}",
+        "",
+    ]
+
+    # 4. Realistic Execution
+    em = report.execution_model
+    lines += [
+        "--- 4. Realistic Execution Model ---",
+        f"  Naive Sharpe:          {em.naive_sharpe:.3f}",
+        f"  Realistic Sharpe:      {em.realistic_sharpe:.3f}",
+        f"  Degradation:           {em.sharpe_degradation_pct:.1f}%",
+        f"  Mean slippage:         {em.mean_slippage_pct:.2f}%",
+        f"  Trades filtered (liq): {em.trades_filtered_by_liquidity:,} / {em.trades_total:,}",
+        "",
+    ]
+
+    # 5. Stress Tests
+    lines.append("--- 5. Stress Tests ---")
+    for s in report.stress_tests.scenario_results:
+        lines.append(
+            f"  {s['scenario']:25s} Sharpe={s['sharpe']:7.3f}  "
+            f"Return=${s['total_return']:12,.2f}  "
+            f"Trades={s['n_trades']:,}  WR={s['win_rate']:.1%}"
+        )
+    lines.append("")
+
+    # 6. Random Baseline
+    rb = report.random_baseline
+    lines += [
+        "--- 6. Random Baseline Comparison ---",
+        f"  Model Sharpe:     {rb.model_sharpe:.3f}",
+        f"  Random mean:      {rb.random_mean_sharpe:.3f} +/- {rb.random_std_sharpe:.3f}",
+        f"  p-value:          {rb.p_value:.4f}",
+        f"  Verdict:          {'BEATS RANDOM' if rb.p_value < 0.05 else 'NO BETTER THAN RANDOM'}",
+        "",
+    ]
+
+    # Verdict
+    lines += [
+        "=" * 65,
+        f"OVERALL VERDICT: {'PASS' if report.overall_pass else 'FAIL'}",
+        "=" * 65,
+    ]
+    if report.failure_reasons:
+        lines.append("Failure reasons:")
+        for r in report.failure_reasons:
+            lines.append(f"  - {r}")
+    else:
+        lines.append("All validation checks passed.")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_quant_pipeline.py
+++ b/tests/test_quant_pipeline.py
@@ -1,0 +1,457 @@
+"""End-to-end test of the quant pipeline using synthetic data.
+
+Generates realistic fake Kalshi trade + market parquet files,
+then runs every pipeline stage to catch bugs before the real 36GB run.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+
+@pytest.fixture
+def synthetic_data_dir():
+    """Create a temp directory with synthetic parquet files."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="quant_test_"))
+
+    trades_dir = tmpdir / "trades"
+    markets_dir = tmpdir / "markets"
+    trades_dir.mkdir()
+    markets_dir.mkdir()
+
+    rng = np.random.default_rng(42)
+    tickers = [f"TEST-MKT-{i}" for i in range(20)]
+    results = rng.choice(["yes", "no"], size=len(tickers))
+
+    # -- Markets parquet --
+    markets_rows = []
+    for i, ticker in enumerate(tickers):
+        markets_rows.append({
+            "ticker": ticker,
+            "event_ticker": f"EVENT-{i // 5}",
+            "market_type": "binary",
+            "title": f"Test Market {i}",
+            "yes_sub_title": "Yes",
+            "no_sub_title": "No",
+            "status": "finalized",
+            "yes_bid": None,
+            "yes_ask": None,
+            "no_bid": None,
+            "no_ask": None,
+            "last_price": rng.integers(10, 90),
+            "volume": rng.integers(500, 10000),
+            "volume_24h": rng.integers(10, 500),
+            "open_interest": rng.integers(100, 2000),
+            "result": results[i],
+            "created_time": pd.Timestamp("2024-01-01") + pd.Timedelta(days=int(rng.integers(0, 30))),
+            "open_time": pd.Timestamp("2024-01-01") + pd.Timedelta(days=int(rng.integers(0, 30))),
+            "close_time": pd.Timestamp("2024-06-01") + pd.Timedelta(days=int(rng.integers(0, 60))),
+            "_fetched_at": pd.Timestamp("2024-08-01"),
+        })
+
+    markets_df = pd.DataFrame(markets_rows)
+    pq.write_table(pa.Table.from_pandas(markets_df), markets_dir / "markets_0_20.parquet")
+
+    # -- Trades parquet --
+    # Generate ~500 trades per ticker = 10,000 total
+    all_trades = []
+    trade_id_counter = 0
+
+    for _i, ticker in enumerate(tickers):
+        n_trades = rng.integers(300, 700)
+        # Simulate a price path (mean-reverting around a level)
+        base_price = rng.integers(20, 80)
+        prices = np.clip(
+            base_price + np.cumsum(rng.normal(0, 1.5, size=n_trades)),
+            1, 99,
+        ).astype(int)
+
+        base_time = pd.Timestamp("2024-01-15")
+        for j in range(n_trades):
+            yes_price = int(prices[j])
+            no_price = 100 - yes_price
+            taker_side = rng.choice(["yes", "no"])
+            count = int(rng.integers(1, 50))
+
+            all_trades.append({
+                "trade_id": f"trade_{trade_id_counter}",
+                "ticker": ticker,
+                "count": count,
+                "yes_price": yes_price,
+                "no_price": no_price,
+                "taker_side": taker_side,
+                "created_time": base_time + pd.Timedelta(seconds=int(j * rng.integers(10, 300))),
+                "_fetched_at": pd.Timestamp("2024-08-01"),
+            })
+            trade_id_counter += 1
+
+    trades_df = pd.DataFrame(all_trades)
+    pq.write_table(pa.Table.from_pandas(trades_df), trades_dir / "trades_0_10000.parquet")
+
+    yield tmpdir
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestDataPipeline:
+    """Test the DuckDB data loading pipeline."""
+
+    def test_load_trades_with_outcomes(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_trades_with_outcomes()
+            assert len(df) > 0
+            assert "taker_price" in df.columns
+            assert "taker_won" in df.columns
+            assert "taker_notional" in df.columns
+            assert df["taker_won"].isin([0, 1]).all()
+            assert (df["yes_price"] + df["no_price"] == 100).all()
+        finally:
+            pipeline.close()
+
+    def test_get_active_tickers(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            tickers = pipeline.get_active_tickers()
+            assert len(tickers) > 0
+            assert "ticker" in tickers.columns
+            assert "trade_count" in tickers.columns
+        finally:
+            pipeline.close()
+
+    def test_compute_ticker_features_sql(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            features = pipeline.compute_ticker_features_sql()
+            assert len(features) > 0
+            assert "vwap" in features.columns
+            assert "yes_volume_share" in features.columns
+            assert "net_volume_imbalance" in features.columns
+        finally:
+            pipeline.close()
+
+
+class TestFeatureEngine:
+    """Test feature engineering."""
+
+    def test_build_trade_features(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+            target_horizon=10,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+
+        # Check key feature groups exist
+        assert "price_change" in featured.columns
+        assert "signed_volume" in featured.columns
+        assert "volume_imbalance_100" in featured.columns
+        assert "sma_50" in featured.columns
+        assert "volatility_50" in featured.columns
+        assert "hour_sin" in featured.columns
+        assert "target_return" in featured.columns
+        assert "future_price" in featured.columns
+
+        # Check feature values are reasonable
+        assert featured["volume_imbalance_100"].between(-1, 1).all()
+        assert featured["vpin_100"].between(0, 2).all()
+
+    def test_get_feature_names(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+        feature_names = FeatureEngine.get_feature_names(featured)
+
+        assert len(feature_names) > 30
+        assert "trade_id" not in feature_names
+        assert "ticker" not in feature_names
+        assert "target_return" not in feature_names
+
+
+class TestSignalAnalyzer:
+    """Test signal screening and statistical tests."""
+
+    def test_screen_features(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.pipeline import DataPipeline
+        from src.quant.signals import SignalAnalyzer
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+            target_horizon=10,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+        feature_names = FeatureEngine.get_feature_names(featured)
+
+        analyzer = SignalAnalyzer()
+        report = analyzer.screen_all_features(featured, feature_names)
+
+        assert len(report) > 0
+        assert "ic" in report.columns
+        assert "long_short_spread" in report.columns
+        assert "monotonicity" in report.columns
+
+    def test_signal_decay(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.pipeline import DataPipeline
+        from src.quant.signals import SignalAnalyzer
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+
+        analyzer = SignalAnalyzer()
+        decay = analyzer.test_signal_decay(featured, "volume_imbalance_100", horizons=[5, 10, 25])
+
+        assert len(decay) > 0
+        assert "horizon" in decay.columns
+        assert "ic" in decay.columns
+
+
+class TestModelTrainer:
+    """Test model training."""
+
+    def test_ridge_training(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.models import ModelTrainer
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+            target_horizon=10,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+        feature_names = FeatureEngine.get_feature_names(featured)
+
+        trainer = ModelTrainer(feature_names)
+        train, val, test = trainer.prepare_splits(featured)
+
+        result = trainer.train_ridge(train, val)
+        assert result.model_name == "Ridge"
+        assert result.val_mse >= 0
+        assert len(result.feature_importance) == len(feature_names)
+
+        # Test prediction
+        preds = trainer.predict(result, test)
+        assert len(preds) == len(test)
+
+    def test_lightgbm_training(self, synthetic_data_dir):
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.models import ModelTrainer
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+            target_horizon=10,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+        feature_names = FeatureEngine.get_feature_names(featured)
+
+        trainer = ModelTrainer(feature_names)
+        train, val, test = trainer.prepare_splits(featured)
+
+        result = trainer.train_lightgbm(train, val)
+        assert result.model_name == "LightGBM"
+        assert result.val_mse >= 0
+
+        preds = trainer.predict(result, test)
+        assert len(preds) == len(test)
+
+
+class TestBacktester:
+    """Test backtesting framework."""
+
+    def test_backtest_run(self, synthetic_data_dir):
+        from src.quant.backtest import Backtester
+        from src.quant.config import PipelineConfig
+        from src.quant.features import FeatureEngine
+        from src.quant.models import ModelTrainer
+        from src.quant.pipeline import DataPipeline
+
+        config = PipelineConfig(
+            trades_dir=synthetic_data_dir / "trades",
+            markets_dir=synthetic_data_dir / "markets",
+            min_trades_per_ticker=50,
+            target_horizon=10,
+        )
+        pipeline = DataPipeline(config)
+        try:
+            df = pipeline.load_ticker_trades("TEST-MKT-0")
+        finally:
+            pipeline.close()
+
+        engine = FeatureEngine(config)
+        featured = engine.build_trade_features(df)
+        feature_names = FeatureEngine.get_feature_names(featured)
+
+        trainer = ModelTrainer(feature_names)
+        train, val, test = trainer.prepare_splits(featured)
+        result = trainer.train_ridge(train, val)
+        preds = trainer.predict(result, test)
+
+        backtester = Backtester(transaction_cost_bps=100.0, min_edge_threshold=0.0)
+        bt = backtester.run(test, preds)
+
+        assert bt.total_trades >= 0
+        assert len(bt.equity_curve) > 0
+        assert "net_pnl" in bt.trade_log.columns or bt.total_trades == 0
+
+    def test_empty_backtest(self):
+        from src.quant.backtest import Backtester
+
+        backtester = Backtester(min_edge_threshold=9999.0)  # threshold so high nothing trades
+        df = pd.DataFrame({
+            "yes_price": [50, 60],
+            "target_return": [1.0, -1.0],
+            "prediction": [0.1, -0.1],
+            "created_time": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+        })
+        bt = backtester.run(df, np.array([0.1, -0.1]))
+        assert bt.total_trades == 0
+        assert bt.sharpe_ratio == 0.0
+
+
+class TestEdgeVerifier:
+    """Test edge verification."""
+
+    def test_verify_with_trades(self):
+        from src.quant.backtest import BacktestResult
+        from src.quant.evaluation import EdgeVerifier
+
+        rng = np.random.default_rng(42)
+        n = 500
+        pnls = rng.normal(0.01, 0.5, size=n)
+
+        trade_log = pd.DataFrame({
+            "net_pnl": pnls,
+            "gross_pnl": pnls + 0.01,
+            "cost": np.full(n, 0.01),
+            "prediction": rng.normal(0, 1, n),
+            "direction": rng.choice([1, -1], n),
+            "position_size": np.full(n, 10.0),
+            "realized_return": pnls * 10,
+            "price": rng.integers(20, 80, n),
+        })
+        equity = np.cumsum(np.concatenate([[0], pnls]))
+
+        bt = BacktestResult(
+            total_return=float(pnls.sum()),
+            annualized_return=float(pnls.mean() * 25000),
+            sharpe_ratio=float(pnls.mean() / pnls.std() * np.sqrt(25000)),
+            sortino_ratio=1.0,
+            max_drawdown=10.0,
+            win_rate=float((pnls > 0).mean()),
+            profit_factor=float(pnls[pnls > 0].sum() / abs(pnls[pnls < 0].sum())),
+            total_trades=n,
+            avg_trade_return=float(pnls.mean()),
+            trade_log=trade_log,
+            equity_curve=pd.DataFrame({"trade_number": range(len(equity)), "equity": equity}),
+            rolling_sharpe=pd.Series([1.0] * n),
+        )
+
+        verifier = EdgeVerifier(n_bootstrap=200)
+        result = verifier.verify(bt, n_trials=3)
+
+        assert isinstance(result.is_significant, bool)
+        assert 0 <= result.sharpe_pvalue <= 1
+        assert 0 <= result.stability_score <= 1
+        assert not result.sensitivity_results.empty

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,247 @@
+"""Tests for the real-world validation module."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from src.quant.config import PipelineConfig
+from src.quant.features import FeatureEngine
+from src.quant.pipeline import DataPipeline
+from src.quant.validation import RealWorldValidator
+
+
+@pytest.fixture
+def synthetic_data_dir():
+    """Create temp directory with synthetic parquet files (multiple tickers)."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="val_test_"))
+    trades_dir = tmpdir / "trades"
+    markets_dir = tmpdir / "markets"
+    trades_dir.mkdir()
+    markets_dir.mkdir()
+
+    rng = np.random.default_rng(42)
+    tickers = [f"TEST-MKT-{i}" for i in range(10)]
+    results = rng.choice(["yes", "no"], size=len(tickers))
+
+    # Markets
+    markets_rows = []
+    for i, ticker in enumerate(tickers):
+        markets_rows.append({
+            "ticker": ticker,
+            "event_ticker": f"EVENT-{i // 3}",
+            "market_type": "binary",
+            "title": f"Test Market {i}",
+            "yes_sub_title": "Yes",
+            "no_sub_title": "No",
+            "status": "finalized",
+            "yes_bid": None,
+            "yes_ask": None,
+            "no_bid": None,
+            "no_ask": None,
+            "last_price": rng.integers(10, 90),
+            "volume": rng.integers(500, 10000),
+            "volume_24h": rng.integers(10, 500),
+            "open_interest": rng.integers(100, 2000),
+            "result": results[i],
+            "created_time": pd.Timestamp("2024-01-01"),
+            "open_time": pd.Timestamp("2024-01-01"),
+            "close_time": pd.Timestamp("2024-06-01"),
+            "_fetched_at": pd.Timestamp("2024-08-01"),
+        })
+    pq.write_table(pa.Table.from_pandas(pd.DataFrame(markets_rows)), markets_dir / "markets_0_10.parquet")
+
+    # Trades: 800 per ticker = 8000 total
+    all_trades = []
+    trade_id = 0
+    for _i, ticker in enumerate(tickers):
+        n_trades = 800
+        base_price = rng.integers(25, 75)
+        prices = np.clip(base_price + np.cumsum(rng.normal(0, 1.5, size=n_trades)), 1, 99).astype(int)
+        base_time = pd.Timestamp("2024-01-15")
+
+        for j in range(n_trades):
+            yes_price = int(prices[j])
+            all_trades.append({
+                "trade_id": f"trade_{trade_id}",
+                "ticker": ticker,
+                "count": int(rng.integers(1, 30)),
+                "yes_price": yes_price,
+                "no_price": 100 - yes_price,
+                "taker_side": rng.choice(["yes", "no"]),
+                "created_time": base_time + pd.Timedelta(seconds=int(j * rng.integers(10, 120))),
+                "_fetched_at": pd.Timestamp("2024-08-01"),
+            })
+            trade_id += 1
+
+    pq.write_table(pa.Table.from_pandas(pd.DataFrame(all_trades)), trades_dir / "trades_0_8000.parquet")
+
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def featurized_df(synthetic_data_dir):
+    """Load and featurize synthetic data for validation tests."""
+    config = PipelineConfig(
+        trades_dir=synthetic_data_dir / "trades",
+        markets_dir=synthetic_data_dir / "markets",
+        min_trades_per_ticker=50,
+        target_horizon=10,
+        rolling_windows=[10, 50],
+        ema_spans=[10, 50],
+        imbalance_windows=[20, 50],
+    )
+    pipeline = DataPipeline(config)
+    try:
+        df_raw = pipeline.load_trades_with_outcomes()
+    finally:
+        pipeline.close()
+
+    engine = FeatureEngine(config)
+    chunks = []
+    for t in df_raw["ticker"].unique():
+        chunk = df_raw[df_raw["ticker"] == t].copy()
+        if len(chunk) >= 50:
+            chunks.append(engine.build_trade_features(chunk))
+    df = pd.concat(chunks, ignore_index=True)
+    feature_cols = FeatureEngine.get_feature_names(df)
+
+    return df, feature_cols, config
+
+
+class TestPurgedWalkForwardCV:
+    def test_produces_folds(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        validator = RealWorldValidator(config)
+        result = validator.purged_walk_forward_cv(df, feature_cols, n_folds=3)
+
+        assert result.n_folds > 0
+        assert len(result.fold_sharpes) == result.n_folds
+        assert result.embargo_size > 0
+
+    def test_embargo_prevents_overlap(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        validator = RealWorldValidator(config)
+        result = validator.purged_walk_forward_cv(df, feature_cols, n_folds=3)
+
+        # Embargo should be at least max(rolling_windows)
+        assert result.embargo_size >= max(config.rolling_windows)
+
+
+class TestTickerHoldoutCV:
+    def test_tests_multiple_tickers(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        validator = RealWorldValidator(config)
+        result = validator.ticker_holdout_cv(df, feature_cols)
+
+        assert result.n_tickers > 0
+        assert len(result.ticker_sharpes) == result.n_tickers
+
+    def test_single_ticker_handled(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        # Filter to single ticker
+        single = df[df["ticker"] == df["ticker"].unique()[0]].copy()
+        validator = RealWorldValidator(config)
+        result = validator.ticker_holdout_cv(single, feature_cols)
+
+        # Should return empty result (not crash)
+        assert result.n_tickers == 0
+
+
+class TestPermutationTest:
+    def test_produces_pvalue(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        # Use small sample and few permutations for speed
+        sample = df.head(2000)
+        validator = RealWorldValidator(config)
+        result = validator.permutation_test(sample, feature_cols, n_permutations=5)
+
+        assert 0 <= result.p_value <= 1
+        assert len(result.permuted_sharpes) == 5
+        assert result.n_permutations == 5
+
+
+class TestRealisticExecution:
+    def test_degrades_or_matches_naive(self, featurized_df):
+        df, feature_cols, config = featurized_df
+
+        # Train a model to get predictions
+        from src.quant.models import ModelTrainer
+
+        df_clean = df.dropna(subset=feature_cols + ["target_return"])
+        trainer = ModelTrainer(feature_cols)
+        train, val, test = trainer.prepare_splits(df_clean)
+        model = trainer.train_ridge(train, val)
+        preds = trainer.predict(model, test)
+
+        validator = RealWorldValidator(config)
+        result = validator.realistic_execution_backtest(test, preds)
+
+        # Realistic should be <= naive (adding friction only hurts)
+        assert result.realistic_sharpe <= result.naive_sharpe + 0.01  # small tolerance
+        assert result.mean_slippage_pct > 0
+
+    def test_liquidity_filter_counts(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        from src.quant.models import ModelTrainer
+
+        df_clean = df.dropna(subset=feature_cols + ["target_return"])
+        trainer = ModelTrainer(feature_cols)
+        train, val, test = trainer.prepare_splits(df_clean)
+        model = trainer.train_ridge(train, val)
+        preds = trainer.predict(model, test)
+
+        validator = RealWorldValidator(config)
+        result = validator.realistic_execution_backtest(test, preds)
+
+        assert result.trades_filtered_by_liquidity >= 0
+        assert result.trades_total > 0
+
+
+class TestStressTests:
+    def test_all_scenarios_run(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        from src.quant.models import ModelTrainer
+
+        df_clean = df.dropna(subset=feature_cols + ["target_return"])
+        trainer = ModelTrainer(feature_cols)
+        train, val, test = trainer.prepare_splits(df_clean)
+        model = trainer.train_ridge(train, val)
+        preds = trainer.predict(model, test)
+
+        validator = RealWorldValidator(config)
+        result = validator.stress_test(test, preds)
+
+        # Should have cost scenarios + position scenarios (+ possibly liquidity)
+        assert len(result.scenario_results) >= len(config.validation_stress_cost_multipliers)
+        for s in result.scenario_results:
+            assert "scenario" in s
+            assert "sharpe" in s
+            assert isinstance(s["sharpe"], float)
+
+
+class TestRandomBaseline:
+    def test_produces_valid_pvalue(self, featurized_df):
+        df, feature_cols, config = featurized_df
+        from src.quant.models import ModelTrainer
+
+        df_clean = df.dropna(subset=feature_cols + ["target_return"])
+        trainer = ModelTrainer(feature_cols)
+        train, val, test = trainer.prepare_splits(df_clean)
+        model = trainer.train_ridge(train, val)
+        preds = trainer.predict(model, test)
+
+        validator = RealWorldValidator(config)
+        result = validator.random_baseline_comparison(test, preds, n_baselines=10)
+
+        assert 0 <= result.p_value <= 1
+        assert len(result.random_sharpes) == 10
+        assert result.n_baselines == 10

--- a/uv.lock
+++ b/uv.lock
@@ -1620,6 +1620,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "kalshi-python"
 version = "2.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1858,6 +1867,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/cd/94bf4a69be8f2ffe5584562bb4f2adcbae8004ffe1803dba118750ae17d5/lazy_imports-1.1.0.tar.gz", hash = "sha256:e6ea5a1e4f09a861357e670b7aa61efcbce6fe29361785dd253df66f8ddbc36b", size = 24601, upload-time = "2025-10-31T19:06:41.948Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/9d/70a2d902d0d9530f36e60d6ef2f97a47363d2f20cac02999e29cc97b0756/lazy_imports-1.1.0-py3-none-any.whl", hash = "sha256:49fb1034ffe325fbec6e1f0e1e5b47eaaf43989b17be6c090added97c2b3ec24", size = 18964, upload-time = "2025-10-31T19:06:40.707Z" },
+]
+
+[[package]]
+name = "lightgbm"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/0b/a2e9f5c5da7ef047cc60cef37f86185088845e8433e54d2e7ed439cce8a3/lightgbm-4.6.0.tar.gz", hash = "sha256:cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe", size = 1703705, upload-time = "2025-02-15T04:03:03.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/75/cffc9962cca296bc5536896b7e65b4a7cdeb8db208e71b9c0133c08f8f7e/lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed", size = 2010151, upload-time = "2025-02-15T04:02:50.961Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/550ee378512b78847930f5d74228ca1fdba2a7fbdeaac9aeccc085b0e257/lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad", size = 1592172, upload-time = "2025-02-15T04:02:53.937Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
+    { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
 ]
 
 [[package]]
@@ -2365,6 +2395,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nccl-cu12"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/cc/f48875411d1f176bce58e6343fd5d4131fc1db5420719ff25944bdc006c6/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:0cf032ee22b560447daf0456108a75e32bd74a4de6c6b64725637a359fa48cd8", size = 293563644, upload-time = "2026-03-03T05:34:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1e/9e366f36efc550f07d6737f199e3f6bffafdf28795d007f10a77dd274f5c/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:ecd0a012051abc20c1aa87328841efa8cade3ced65803046e38c2f03c0891fea", size = 293633942, upload-time = "2026-03-03T05:37:05.625Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2708,13 +2747,20 @@ dependencies = [
     { name = "httpx" },
     { name = "imageio" },
     { name = "kalshi-python" },
+    { name = "lightgbm" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "matplotlib", version = "3.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
     { name = "polymarket-py" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dotenv" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2723,6 +2769,8 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
     { name = "web3" },
+    { name = "xgboost", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -2740,17 +2788,21 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "imageio", specifier = ">=2.36.0" },
     { name = "kalshi-python", specifier = ">=2.1.4" },
+    { name = "lightgbm", specifier = ">=4.0.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },
+    { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "polymarket-py", specifier = ">=0.1.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "scikit-learn", specifier = ">=1.4.0" },
     { name = "scipy", specifier = ">=1.13.1" },
     { name = "simple-term-menu", specifier = ">=1.6.0" },
     { name = "squarify", specifier = ">=0.4.4" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "web3", specifier = ">=6.0.0" },
+    { name = "xgboost", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3516,6 +3568,153 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/3a/f4597eb41049110b21ebcbb0bcb43e4035017545daa5eedcfeb45c08b9c5/scikit_learn-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d056391530ccd1e501056160e3c9673b4da4805eb67eb2bdf4e983e1f9c9204e", size = 12067702, upload-time = "2025-01-10T08:05:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/0423e5e1fd1c6ec5be2352ba05a537a473c1677f8188b9306097d684b327/scikit_learn-1.6.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0c8d036eb937dbb568c6242fa598d551d88fb4399c0344d95c001980ec1c7d36", size = 11112765, upload-time = "2025-01-10T08:06:00.272Z" },
+    { url = "https://files.pythonhosted.org/packages/70/95/d5cb2297a835b0f5fc9a77042b0a2d029866379091ab8b3f52cc62277808/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8634c4bd21a2a813e0a7e3900464e6d593162a29dd35d25bdf0103b3fce60ed5", size = 12643991, upload-time = "2025-01-10T08:06:04.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/91/ab3c697188f224d658969f678be86b0968ccc52774c8ab4a86a07be13c25/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:775da975a471c4f6f467725dff0ced5c7ac7bda5e9316b260225b48475279a1b", size = 13497182, upload-time = "2025-01-10T08:06:08.42Z" },
+    { url = "https://files.pythonhosted.org/packages/17/04/d5d556b6c88886c092cc989433b2bab62488e0f0dafe616a1d5c9cb0efb1/scikit_learn-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:8a600c31592bd7dab31e1c61b9bbd6dea1b3433e67d264d17ce1017dbdce8002", size = 11125517, upload-time = "2025-01-10T08:06:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2a/e291c29670795406a824567d1dfc91db7b699799a002fdaa452bceea8f6e/scikit_learn-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:72abc587c75234935e97d09aa4913a82f7b03ee0b74111dcc2881cba3c5a7b33", size = 12102620, upload-time = "2025-01-10T08:06:16.675Z" },
+    { url = "https://files.pythonhosted.org/packages/25/92/ee1d7a00bb6b8c55755d4984fd82608603a3cc59959245068ce32e7fb808/scikit_learn-1.6.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b3b00cdc8f1317b5f33191df1386c0befd16625f49d979fe77a8d44cae82410d", size = 11116234, upload-time = "2025-01-10T08:06:21.83Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cd/ed4399485ef364bb25f388ab438e3724e60dc218c547a407b6e90ccccaef/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc4765af3386811c3ca21638f63b9cf5ecf66261cc4815c1db3f1e7dc7b79db2", size = 12592155, upload-time = "2025-01-10T08:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/62fc9a5a659bb58a03cdd7e258956a5824bdc9b4bb3c5d932f55880be569/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25fc636bdaf1cc2f4a124a116312d837148b5e10872147bdaf4887926b8c03d8", size = 13497069, upload-time = "2025-01-10T08:06:32.515Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/c5b78606743a1f28eae8f11973de6613a5ee87366796583fb74c67d54939/scikit_learn-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:fa909b1a36e000a03c382aade0bd2063fd5680ff8b8e501660c0f59f021a6415", size = 11139809, upload-time = "2025-01-10T08:06:35.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/18/c797c9b8c10380d05616db3bfb48e2a3358c767affd0857d56c2eb501caa/scikit_learn-1.6.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:926f207c804104677af4857b2c609940b743d04c4c35ce0ddc8ff4f053cddc1b", size = 12104516, upload-time = "2025-01-10T08:06:40.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b7/2e35f8e289ab70108f8cbb2e7a2208f0575dc704749721286519dcf35f6f/scikit_learn-1.6.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2c2cae262064e6a9b77eee1c8e768fc46aa0b8338c6a8297b9b6759720ec0ff2", size = 11167837, upload-time = "2025-01-10T08:06:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/ff7beaeb644bcad72bcfd5a03ff36d32ee4e53a8b29a639f11bcb65d06cd/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1061b7c028a8663fb9a1a1baf9317b64a257fcb036dae5c8752b2abef31d136f", size = 12253728, upload-time = "2025-01-10T08:06:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7a/8bce8968883e9465de20be15542f4c7e221952441727c4dad24d534c6d99/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e69fab4ebfc9c9b580a7a80111b43d214ab06250f8a7ef590a4edf72464dd86", size = 13147700, upload-time = "2025-01-10T08:06:50.888Z" },
+    { url = "https://files.pythonhosted.org/packages/62/27/585859e72e117fe861c2079bcba35591a84f801e21bc1ab85bce6ce60305/scikit_learn-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:70b1d7e85b1c96383f872a519b3375f92f14731e279a7b4c6cfd650cf5dffc52", size = 11110613, upload-time = "2025-01-10T08:06:54.115Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/59/8eb1872ca87009bdcdb7f3cdc679ad557b992c12f4b61f9250659e592c63/scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322", size = 12010001, upload-time = "2025-01-10T08:06:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/05/f2fc4effc5b32e525408524c982c468c29d22f828834f0625c5ef3d601be/scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1", size = 11096360, upload-time = "2025-01-10T08:07:01.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e4/4195d52cf4f113573fb8ebc44ed5a81bd511a92c0228889125fac2f4c3d1/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348", size = 12209004, upload-time = "2025-01-10T08:07:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/94/be/47e16cdd1e7fcf97d95b3cb08bde1abb13e627861af427a3651fcb80b517/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97", size = 13171776, upload-time = "2025-01-10T08:07:11.715Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b0/ca92b90859070a1487827dbc672f998da95ce83edce1270fc23f96f1f61a/scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb", size = 11071865, upload-time = "2025-01-10T08:07:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ae/993b0fb24a356e71e9a894e42b8a9eec528d4c70217353a1cd7a48bc25d4/scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236", size = 11955804, upload-time = "2025-01-10T08:07:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/32fa2ee591af44507eac86406fa6bba968d1eb22831494470d0a2e4a1eb1/scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35", size = 11100530, upload-time = "2025-01-10T08:07:23.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/55856da1adec655bdce77b502e94a267bf40a8c0b89f8622837f89503b5a/scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691", size = 12433852, upload-time = "2025-01-10T08:07:26.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/c83853af13901a574f8f13b645467285a48940f185b690936bb700a50863/scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f", size = 11337256, upload-time = "2025-01-10T08:07:31.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/37/b305b759cc65829fe1b8853ff3e308b12cdd9d8884aa27840835560f2b42/scikit_learn-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6849dd3234e87f55dce1db34c89a810b489ead832aaf4d4550b7ea85628be6c1", size = 12101868, upload-time = "2025-01-10T08:07:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/83/74/f64379a4ed5879d9db744fe37cfe1978c07c66684d2439c3060d19a536d8/scikit_learn-1.6.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:e7be3fa5d2eb9be7d77c3734ff1d599151bb523674be9b834e8da6abe132f44e", size = 11144062, upload-time = "2025-01-10T08:07:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/dc/d5457e03dc9c971ce2b0d750e33148dd060fefb8b7dc71acd6054e4bb51b/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44a17798172df1d3c1065e8fcf9019183f06c87609b49a124ebdf57ae6cb0107", size = 12693173, upload-time = "2025-01-10T08:07:42.713Z" },
+    { url = "https://files.pythonhosted.org/packages/79/35/b1d2188967c3204c78fa79c9263668cf1b98060e8e58d1a730fe5b2317bb/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b7a3b86e411e4bce21186e1c180d792f3d99223dcfa3b4f597ecc92fa1a422", size = 13518605, upload-time = "2025-01-10T08:07:46.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d8/8d603bdd26601f4b07e2363032b8565ab82eb857f93d86d0f7956fcf4523/scikit_learn-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7a73d457070e3318e32bdb3aa79a8d990474f19035464dfd8bede2883ab5dc3b", size = 11155078, upload-time = "2025-01-10T08:07:51.376Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "threadpoolctl", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/43/83/564e141eef908a5863a54da8ca342a137f45a0bfb71d1d79704c9894c9d1/scikit_learn-1.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7509693451651cd7361d30ce4e86a1347493554f172b1c72a39300fa2aea79e", size = 9331967, upload-time = "2025-09-09T08:20:32.421Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d6/ba863a4171ac9d7314c4d3fc251f015704a2caeee41ced89f321c049ed83/scikit_learn-1.7.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0486c8f827c2e7b64837c731c8feff72c0bd2b998067a8a9cbc10643c31f0fe1", size = 8648645, upload-time = "2025-09-09T08:20:34.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89877e19a80c7b11a2891a27c21c4894fb18e2c2e077815bcade10d34287b20d", size = 9715424, upload-time = "2025-09-09T08:20:36.776Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/1f3b22e3207e1d2c883a7e09abb956362e7d1bd2f14458c7de258a26ac15/scikit_learn-1.7.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8da8bf89d4d79aaec192d2bda62f9b56ae4e5b4ef93b6a56b5de4977e375c1f1", size = 9509234, upload-time = "2025-09-09T08:20:38.957Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/71/34ddbd21f1da67c7a768146968b4d0220ee6831e4bcbad3e03dd3eae88b6/scikit_learn-1.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9b7ed8d58725030568523e937c43e56bc01cadb478fc43c042a9aca1dacb3ba1", size = 8894244, upload-time = "2025-09-09T08:20:41.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/aa/3996e2196075689afb9fce0410ebdb4a09099d7964d061d7213700204409/scikit_learn-1.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d91a97fa2b706943822398ab943cde71858a50245e31bc71dba62aab1d60a96", size = 9259818, upload-time = "2025-09-09T08:20:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5d/779320063e88af9c4a7c2cf463ff11c21ac9c8bd730c4a294b0000b666c9/scikit_learn-1.7.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:acbc0f5fd2edd3432a22c69bed78e837c70cf896cd7993d71d51ba6708507476", size = 8636997, upload-time = "2025-09-09T08:20:45.468Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5bf3d930aee75a65478df91ac1225ff89cd28e9ac7bd1196853a9229b6adb0b", size = 9478381, upload-time = "2025-09-09T08:20:47.982Z" },
+    { url = "https://files.pythonhosted.org/packages/82/70/8bf44b933837ba8494ca0fc9a9ab60f1c13b062ad0197f60a56e2fc4c43e/scikit_learn-1.7.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4d6e9deed1a47aca9fe2f267ab8e8fe82ee20b4526b2c0cd9e135cea10feb44", size = 9300296, upload-time = "2025-09-09T08:20:50.366Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/99/ed35197a158f1fdc2fe7c3680e9c70d0128f662e1fee4ed495f4b5e13db0/scikit_learn-1.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:6088aa475f0785e01bcf8529f55280a3d7d298679f50c0bb70a2364a82d0b290", size = 8731256, upload-time = "2025-09-09T08:20:52.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
+    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3730,6 +3929,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -3957,6 +4165,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/e4/120ff3180b0872b1fe6637f6f995bcb009fb5c87d597c1fc21456f50c848/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f", size = 174150, upload-time = "2025-03-05T20:03:35.757Z" },
     { url = "https://files.pythonhosted.org/packages/cb/c3/30e2f9c539b8da8b1d76f64012f3b19253271a63413b2d3adb94b143407f/websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123", size = 176877, upload-time = "2025-03-05T20:03:37.199Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "2.1.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.10' and platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/5e/860a1ef13ce38db8c257c83e138be64bcffde8f401e84bf1e2e91838afa3/xgboost-2.1.4.tar.gz", hash = "sha256:ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7", size = 1091127, upload-time = "2025-02-06T18:18:20.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/fe/7a1d2342c2e93f22b41515e02b73504c7809247b16ae395bd2ee7ef11e19/xgboost-2.1.4-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl", hash = "sha256:78d88da184562deff25c820d943420342014dd55e0f4c017cc4563c2148df5ee", size = 2140692, upload-time = "2025-02-06T18:16:59.23Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b6/653a70910739f127adffbefb688ebc22b51139292757de7c22b1e04ce792/xgboost-2.1.4-py3-none-macosx_12_0_arm64.whl", hash = "sha256:523db01d4e74b05c61a985028bde88a4dd380eadc97209310621996d7d5d14a7", size = 1939418, upload-time = "2025-02-06T18:17:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/905fee34c10fb0d0c3baa15106413b76f360d8e958765ec57c9eddf762fa/xgboost-2.1.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:57c7e98111aceef4b689d7d2ce738564a1f7fe44237136837a47847b8b33bade", size = 4442052, upload-time = "2025-02-06T18:17:04.029Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6a/41956f91ab984f2fa44529b2551d825a20d33807eba051a60d06ede2a87c/xgboost-2.1.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1343a512e634822eab30d300bfc00bf777dc869d881cc74854b42173cfcdb14", size = 4533170, upload-time = "2025-02-06T18:17:05.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/53/37032dca20dae7a88ad1907f817a81f232ca6e935f0c28c98db3c0a0bd22/xgboost-2.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d366097d0db047315736f46af852feaa907f6d7371716af741cdce488ae36d20", size = 4206715, upload-time = "2025-02-06T18:17:08.448Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/e3a93bfa7e8693c825df5ec02a40f7ff5f0950e02198b1e85da9315a8d47/xgboost-2.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:8df6da72963969ab2bf49a520c3e147b1e15cbeddd3aa0e3e039b3532c739339", size = 223642416, upload-time = "2025-02-06T18:17:25.08Z" },
+    { url = "https://files.pythonhosted.org/packages/43/80/0b5a2dfcf5b4da27b0b68d2833f05d77e1a374d43db951fca200a1f12a52/xgboost-2.1.4-py3-none-win_amd64.whl", hash = "sha256:8bbfe4fedc151b83a52edbf0de945fd94358b09a81998f2945ad330fd5f20cd6", size = 124910381, upload-time = "2025-02-06T18:17:43.202Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a complete `src/quant/` module: end-to-end quantitative trading pipeline for 33GB+ Kalshi trade parquet data
- DuckDB-based data loading (zero-copy, memory-efficient), 80+ engineered features (price/volume/imbalance/volatility/time), signal screening with IC/quintile analysis
- Model training (Ridge, LightGBM, XGBoost) with chronological splits, walk-forward backtesting with realistic transaction costs, and edge verification (bootstrap CI, deflated Sharpe, regime robustness)
- New dependencies: numpy, scikit-learn, lightgbm, xgboost

## Test plan
- [ ] `uv run ruff check src/quant/` passes (verified)
- [ ] All modules import successfully (verified)
- [ ] Run `uv run python -m src.quant.run --step signals` on dataset
- [ ] Run full pipeline `uv run python -m src.quant.run` end-to-end
- [ ] Verify output files generated in `output/quant/`

