### PR TITLE
chore: remove deadcode. Polymarket Data API trade fetching

### DIFF
--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -4,20 +4,17 @@ from typing import Optional, Union
 import httpx
 
 from src.common.client import retry_request
-from src.indexers.polymarket.models import Market, Trade
+from src.indexers.polymarket.models import Market
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
-DATA_API_URL = "https://data-api.polymarket.com"
 
 
 class PolymarketClient:
     def __init__(
         self,
         gamma_url: str = GAMMA_API_URL,
-        data_url: str = DATA_API_URL,
     ):
         self.gamma_url = gamma_url
-        self.data_url = data_url
         self.client = httpx.Client(timeout=30.0)
 
     def __enter__(self):
@@ -63,47 +60,6 @@ class PolymarketClient:
             yield markets, next_offset
 
             if len(markets) < limit:
-                break
-
-            current_offset = next_offset
-
-    def get_trades(self, limit: int = 500, offset: int = 0) -> list[Trade]:
-        """Fetch trades from Data API.
-
-        Note: The Polymarket data API does not support filtering by market.
-        All trades are returned globally.
-
-        Args:
-            limit: Max trades to fetch (max 500)
-            offset: Pagination offset
-        """
-        params = {"limit": min(limit, 500), "offset": offset}
-        data = self._get(f"{self.data_url}/trades", params=params)
-        if isinstance(data, list):
-            return [Trade.from_dict(t) for t in data]
-        return [Trade.from_dict(t) for t in data.get("trades", data)]
-
-    def iter_trades(self, limit: int = 500, offset: int = 0) -> Generator[tuple[list[Trade], int], None, None]:
-        """Iterate through all trades using offset pagination.
-
-        Note: The Polymarket data API does not support filtering by market.
-
-        Yields:
-            Tuple of (trades, next_offset) where next_offset is -1 when done.
-        """
-        current_offset = offset
-
-        while True:
-            trades = self.get_trades(limit=limit, offset=current_offset)
-
-            if not trades:
-                yield [], -1
-                break
-
-            next_offset = current_offset + len(trades)
-            yield trades, next_offset
-
-            if len(trades) < limit:
                 break
 
             current_offset = next_offset

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -48,30 +48,3 @@ class Market:
             created_at=parse_time(data.get("createdAt")),
             market_maker_address=data.get("marketMakerAddress"),
         )
-
-
-@dataclass
-class Trade:
-    condition_id: str
-    asset: str  # Asset/token ID
-    side: str  # BUY or SELL
-    size: float  # Number of shares
-    price: float  # Price (0-1)
-    timestamp: int  # Unix timestamp
-    outcome: str
-    outcome_index: int  # 0 or 1
-    transaction_hash: str
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "Trade":
-        return cls(
-            condition_id=data.get("conditionId", data.get("market", "")),
-            asset=data.get("asset", ""),
-            side=data.get("side", ""),
-            size=float(data.get("size", 0) or 0),
-            price=float(data.get("price", 0) or 0),
-            timestamp=int(data.get("timestamp", 0) or 0),
-            outcome=data.get("outcome", ""),
-            outcome_index=int(data.get("outcomeIndex", 0) or 0),
-            transaction_hash=data.get("transactionHash", ""),
-        )


### PR DESCRIPTION
## Summary
- `PolymarketClient.get_trades` / `iter_trades` hit the off-chain Polymarket Data API and were never called anywhere in the repo
- All Polymarket trade data is sourced on-chain via `PolygonClient` (`blockchain.py` consumed by `trades.py`), which is unaffected
- Drop the dead methods, the `DATA_API_URL` constant, and the `Trade` dataclass; `PolymarketClient` still serves Gamma API market fetches

## Test plan
- [x] `python -m src.indexers.polymarket.markets` (Gamma markets fetch still works via `PolymarketClient`)
- [x] `python -m src.indexers.polymarket.trades` (on-chain backfill via `PolygonClient` unaffected)
- [x] Existing test suite passes