### PR TITLE
fix: Polymarket -> fix the double counting issue in the vol analysis

### DIFF
--- a/src/analysis/polymarket/polymarket_volume_over_time.py
+++ b/src/analysis/polymarket/polymarket_volume_over_time.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import duckdb
@@ -17,7 +16,7 @@ BLOCK_BUCKET_SIZE = 10800
 
 
 class PolymarketVolumeOverTimeAnalysis(Analysis):
-    """Analyze quarterly notional trading volume on Polymarket."""
+    """Analyze monthly notional trading volume on Polymarket."""
 
     def __init__(
         self,
@@ -28,24 +27,16 @@ class PolymarketVolumeOverTimeAnalysis(Analysis):
     ):
         super().__init__(
             name="polymarket_volume_over_time",
-            description="Quarterly notional volume analysis for Polymarket",
+            description="Monthly notional volume analysis for Polymarket",
         )
         base_dir = Path(__file__).parent.parent.parent.parent
         self.trades_dir = Path(trades_dir or base_dir / "data" / "polymarket" / "trades")
-        self.legacy_trades_dir = Path(legacy_trades_dir or base_dir / "data" / "polymarket" / "legacy_trades")
         self.blocks_dir = Path(blocks_dir or base_dir / "data" / "polymarket" / "blocks")
-        self.collateral_lookup_path = Path(
-            collateral_lookup_path or base_dir / "data" / "polymarket" / "fpmm_collateral_lookup.json"
-        )
+        
 
     def run(self) -> AnalysisOutput:
         """Execute the analysis and return outputs."""
         con = duckdb.connect()
-
-        # Load USDC market addresses from collateral lookup (only include USDC markets)
-        with open(self.collateral_lookup_path) as f:
-            collateral_lookup = json.load(f)
-        usdc_markets = [addr for addr, info in collateral_lookup.items() if info["collateral_symbol"] == "USDC"]
 
         # Create blocks lookup table with bucket index for efficient joining
         con.execute(
@@ -53,59 +44,59 @@ class PolymarketVolumeOverTimeAnalysis(Analysis):
             CREATE TABLE blocks AS
             SELECT
                 block_number // {BLOCK_BUCKET_SIZE} AS bucket,
-                FIRST(timestamp) AS timestamp
+                MIN(timestamp) AS timestamp
             FROM '{self.blocks_dir}/*.parquet'
             GROUP BY block_number // {BLOCK_BUCKET_SIZE}
             """
         )
 
-        # Register USDC markets as a table for filtering
-        con.execute("CREATE TABLE usdc_markets (fpmm_address VARCHAR)")
-        con.executemany("INSERT INTO usdc_markets VALUES (?)", [(addr,) for addr in usdc_markets])
+        # CTF Exchange trades: volume = USDC cash flow (the side where asset_id = '0')
+        # When maker_asset_id='0': maker pays maker_amount USDC, receives taker_amount tokens
+        # When taker_asset_id='0': taker pays taker_amount USDC, receives maker_amount tokens
+        # Double counting polymarket volume is a common issue as described by paradigm  
+        # here https://www.paradigm.xyz/2025/12/polymarket-volume-is-being-double-counted
+        # per the article, the best way to avoid double counting is to focus on either
+        # maker or taker side volume (but not sum both)
+        # """Taker-side volume can be obtained by filtering and summing OrderFilled 
+        # events where the taker field is equal to one of the two exchange contracts""".
+        # Another point of attention: Polymarket recently migrated to a v2 version of their exchanges
+        # we have to consider both the v1 contracts and the v2 contracts
 
-        # Legacy FPMM trades: amount is in USDC (6 decimals) for USDC-collateralized markets
-        # Only include markets with USDC collateral
-        legacy_volume_query = f"""
-            SELECT
-                DATE_TRUNC('quarter', b.timestamp::TIMESTAMP) AS quarter,
-                SUM(t.amount::BIGINT) / 1e6 AS volume_usd
-            FROM '{self.legacy_trades_dir}/*.parquet' t
-            JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
-            WHERE t.fpmm_address IN (SELECT fpmm_address FROM usdc_markets)
-            GROUP BY DATE_TRUNC('quarter', b.timestamp::TIMESTAMP)
-        """
+        CTF_exchange_v2 = "0xE111180000d2663C0091e4f400237545B87B996B"
+        Neg_Risk_CTF_Exchange_v2 = "0xe2222d279d744050d28e00520010520000310F59"
 
-        # CTF Exchange trades: notional = outcome tokens traded
-        # When maker_asset_id='0': maker pays USDC, receives taker_amount tokens
-        # When taker_asset_id='0': taker pays USDC, receives maker_amount tokens
+        CTF_Exchange_v1 = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+        Neg_Risk_Exchange_v1 = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+
+
+        # Note: the current indexer (src/indexers/polymarket/blockchain.py) only
+        # backfills v1 contracts. v2 entries below are forward-compatible no-ops
+        # until the indexer is extended.
+        exchange_addresses = [
+            CTF_Exchange_v1,
+            Neg_Risk_Exchange_v1,
+            CTF_exchange_v2,
+            Neg_Risk_CTF_Exchange_v2,
+        ]
+        exchanges_in = ", ".join(f"lower('{a}')" for a in exchange_addresses)
+
         ctf_volume_query = f"""
             SELECT
-                DATE_TRUNC('quarter', b.timestamp::TIMESTAMP) AS quarter,
+                DATE_TRUNC('month', b.timestamp::TIMESTAMP) AS month,
                 SUM(
                     CASE
-                        WHEN t.maker_asset_id = '0' THEN t.taker_amount
-                        ELSE t.maker_amount
+                        WHEN t.maker_asset_id = '0' THEN t.maker_amount
+                        ELSE t.taker_amount
                     END
                 ) / 1e6 AS volume_usd
             FROM '{self.trades_dir}/*.parquet' t
             JOIN blocks b ON t.block_number // {BLOCK_BUCKET_SIZE} = b.bucket
-            WHERE t.maker_asset_id = '0' OR t.taker_asset_id = '0'
-            GROUP BY DATE_TRUNC('quarter', b.timestamp::TIMESTAMP)
+            WHERE (t.maker_asset_id = '0' OR t.taker_asset_id = '0')
+              AND lower(t.taker) IN ({exchanges_in})
+            GROUP BY DATE_TRUNC('month', b.timestamp::TIMESTAMP)
+            ORDER BY month
         """
-
-        # Combine both sources and aggregate by quarter
-        df = con.execute(
-            f"""
-            SELECT quarter, SUM(volume_usd) AS volume_usd
-            FROM (
-                {legacy_volume_query}
-                UNION ALL
-                {ctf_volume_query}
-            )
-            GROUP BY quarter
-            ORDER BY quarter
-            """
-        ).df()
+        df = con.execute(ctf_volume_query).df()
 
         fig = self._create_figure(df)
         chart = self._create_chart(df)
@@ -113,26 +104,52 @@ class PolymarketVolumeOverTimeAnalysis(Analysis):
         return AnalysisOutput(figure=fig, data=df, chart=chart)
 
     def _create_figure(self, df: pd.DataFrame) -> plt.Figure:
-        """Create the matplotlib figure."""
-        fig, ax = plt.subplots(figsize=(12, 6))
-        bars = ax.bar(df["quarter"], df["volume_usd"] / 1e6, width=80, color="#4C72B0")
+        """Create the matplotlib figure: one bar per month, one tick per month."""
+        n = len(df)
+        fig, ax = plt.subplots(figsize=(max(14, n * 0.22), 7))
+
+        x = list(range(n))
+        volume_m = (df["volume_usd"] / 1e6).to_numpy()  # in $M
+
+        # Highlight Oct/Nov 2024 (the months the Paradigm article references)
+        highlight_months = {pd.Timestamp("2024-10-01"), pd.Timestamp("2024-11-01")}
+        colors = [
+            "#DD8452" if pd.Timestamp(m) in highlight_months else "#4C72B0"
+            for m in df["month"]
+        ]
+        bars = ax.bar(x, volume_m, width=0.85, color=colors, edgecolor="white", linewidth=0.3)
+
+        # Mark the most recent (potentially in-progress) month
         bars[-1].set_hatch("//")
-        bars[-1].set_edgecolor((1, 1, 1, 0.3))
-        labels = [f"${v / 1e3:.2f}B" if v > 999 else f"${v:.2f}M" for v in df["volume_usd"] / 1e6]
-        ax.bar_label(
-            bars,
-            labels=labels,
-            fontsize=7,
+        bars[-1].set_edgecolor((1, 1, 1, 0.6))
+
+        def fmt(v_m: float) -> str:
+            if v_m >= 1000:
+                return f"${v_m / 1000:.2f}B"
+            if v_m >= 1:
+                return f"${v_m:.1f}M"
+            if v_m >= 0.001:
+                return f"${v_m * 1000:.0f}k"
+            return f"${v_m * 1e6:.0f}"
+
+        labels = [fmt(v) for v in volume_m]
+        ax.bar_label(bars, labels=labels, fontsize=7, rotation=90, padding=2, color="black")
+
+        ax.set_xticks(x)
+        ax.set_xticklabels(
+            [pd.Timestamp(m).strftime("%b %Y") for m in df["month"]],
             rotation=90,
-            label_type="center",
-            color="white",
-            fontweight="bold",
+            fontsize=8,
         )
-        ax.set_xlabel("Date")
-        ax.set_yscale("log")
-        ax.set_ylim(bottom=1)
-        ax.set_ylabel("Quarterly Volume (millions USD)")
-        ax.set_title("Polymarket Quarterly Notional Volume")
+
+        ax.set_ylim(bottom=0, top=volume_m.max() * 1.25)  # headroom so labels don't clip
+        ax.set_xlabel("Month")
+        ax.set_ylabel("Monthly Volume (USD billions)")
+        ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda v, _: f"${v / 1000:.1f}B"))
+        ax.set_title("Polymarket Monthly USDC Volume")
+        ax.grid(axis="y", alpha=0.3)
+        ax.set_axisbelow(True)
+        ax.margins(x=0.005)
 
         plt.tight_layout()
         return fig
@@ -141,7 +158,8 @@ class PolymarketVolumeOverTimeAnalysis(Analysis):
         """Create the chart configuration for web display."""
         chart_data = [
             {
-                "quarter": f"Q{(pd.Timestamp(row['quarter']).month - 1) // 3 + 1} '{str(pd.Timestamp(row['quarter']).year)[2:]}",
+                "month": f"{pd.Timestamp(row['month']).strftime('%b %Y')}",
+
                 "volume": int(row["volume_usd"]),
             }
             for _, row in df.iterrows()
@@ -150,10 +168,10 @@ class PolymarketVolumeOverTimeAnalysis(Analysis):
         return ChartConfig(
             type=ChartType.BAR,
             data=chart_data,
-            xKey="quarter",
+            xKey="month",
             yKeys=["volume"],
-            title="Polymarket Quarterly Notional Volume",
-            xLabel="Quarter",
+            title="Polymarket Monthly USDC Volume",
+            xLabel="Month",
             yLabel="Volume (USD)",
             yUnit=UnitType.DOLLARS,
             yScale=ScaleType.LOG,


### PR DESCRIPTION
**Overview**
  Fixes two bugs in `polymarket_volume_over_time.py` that were inflating the vol headline number by ~5×: (1) every CTF Exchange trade emits two OrderFilled events (one maker-focused per filled maker, one taker-focused where taker = exchange router), and the script summed both, double counting every trade; (2) the SUM was picking the outcome-token side of each event rather than the USDC side, so the result was a sum of tokens wrongfully labeled as dollars. 
The query now filters to taker IN (exchange contracts) to keep one side per trade and sums the leg where asset_id = '0' to get actual USDC cash flow. 

**Motivation**
The Paradigm post (https://www.paradigm.xyz/2025/12/polymarket-volume-is-being-double-counted) describes the same pitfall this analysis was hitting. For Oct/Nov 2024 the article mentions reports ~$1.25B vol (same as visible on DeFiLlama). With the fix applied, this analysis reports $1.37B / $1.40B for those months — a number that's directly comparable to public benchmarks rather than completely off as previously. 

**Notes**
  - Maker vs taker-side asymmetry. When summing USDC (rather than outcome tokens), the maker-side and taker-side definitions disagree by ~10–20% per month — for Oct 2024, maker-side gives $1.16B vs taker-side $1.37B, with DeFiLlama landing in between at $1.25B. We chose taker-side because it's a positive whitelist of two contract addresses (robust to new participants) and produces one row per trade. Reproducing DeFiLlama exactly would require switching the indexer to read OrdersMatched events instead of OrderFilled.
  - v2 contracts. v2 router addresses are included in the IN filter for forward-compatibility, but the indexer at src/indexers/polymarket/blockchain.py only backfills v1 today, so v2 events return zero
  rows. Extending the indexer is a separate change.
  - Legacy FPMM branch removed. The old code summed legacy FPMM trades alongside CTF Exchange trades. This was deleted to focus on more recent data and the new exchange contracts, that are now sanity checked against industry standards (paradigm)
  - Block→timestamp jitter. The 10,800-block bucket (~6h) introduces small month-boundary misclassification (~$5–10M for a $1.4B month). Acceptable for monthly aggregates; would need finer buckets for daily resolution.