### PR TITLE
fix: consolidated http client with rate limiting, backoff

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,4 +1,4 @@
-from src.common.client import retry_request
+from src.common.client import HttpClient
 from src.common.storage import ParquetStorage
 
-__all__ = ["ParquetStorage", "retry_request"]
+__all__ = ["HttpClient", "ParquetStorage"]

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -1,4 +1,7 @@
 import logging
+import threading
+import time
+from typing import Any, Optional, Union
 
 import httpx
 from tenacity import (
@@ -6,14 +9,13 @@ from tenacity import (
     retry,
     retry_if_exception,
     stop_after_attempt,
-    wait_exponential,
+    wait_exponential_jitter,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _is_retryable_error(exc: BaseException) -> bool:
-    """Check if an exception should trigger a retry."""
+def _is_retryable(exc: BaseException) -> bool:
     if isinstance(exc, (httpx.ConnectError, httpx.TimeoutException)):
         return True
     if isinstance(exc, httpx.HTTPStatusError):
@@ -21,21 +23,78 @@ def _is_retryable_error(exc: BaseException) -> bool:
     return False
 
 
-def retry_request():
-    """Decorator for HTTP requests with exponential backoff.
+class HttpClient:
+    """HTTP client with rate limiting, retries, and connection pooling.
 
-    Retries on:
-    - Connection errors
-    - Timeouts
-    - HTTP 429 (rate limit)
-    - HTTP 5xx (server errors)
-
-    Uses exponential backoff starting at 1s, max 60s, up to 5 attempts.
+    Args:
+        rate_limit: Max requests per second (0 = unlimited).
+        max_retries: Number of retry attempts for transient errors.
+        timeout: Request timeout in seconds.
+        max_connections: Connection pool size.
+        base_url: Optional base URL for all requests.
     """
-    return retry(
-        stop=stop_after_attempt(5),
-        wait=wait_exponential(multiplier=1, min=1, max=60),
-        retry=retry_if_exception(_is_retryable_error),
-        before_sleep=before_sleep_log(logger, logging.WARNING),
-        reraise=True,
-    )
+
+    def __init__(
+        self,
+        *,
+        rate_limit: float = 10,
+        max_retries: int = 5,
+        timeout: float = 30.0,
+        max_connections: int = 20,
+        base_url: str = "",
+    ):
+        self._rate_limit = rate_limit
+        self._max_retries = max_retries
+        self._lock = threading.Lock()
+        self._last_request: float = 0
+
+        self._client = httpx.Client(
+            base_url=base_url,
+            timeout=timeout,
+            limits=httpx.Limits(
+                max_connections=max_connections,
+                max_keepalive_connections=max_connections,
+            ),
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        self._client.close()
+
+    def _throttle(self):
+        if self._rate_limit <= 0:
+            return
+        interval = 1.0 / self._rate_limit
+        with self._lock:
+            now = time.monotonic()
+            wait = self._last_request + interval - now
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request = time.monotonic()
+
+    def get(self, url: str, *, params: Optional[dict] = None) -> Union[dict, list]:
+        return self._request("GET", url, params=params)
+
+    def post(self, url: str, *, json: Optional[Any] = None) -> Union[dict, list]:
+        return self._request("POST", url, json=json)
+
+    def _request(self, method: str, url: str, **kwargs) -> Union[dict, list]:
+        @retry(
+            stop=stop_after_attempt(self._max_retries),
+            wait=wait_exponential_jitter(initial=1, max=60, jitter=2),
+            retry=retry_if_exception(_is_retryable),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+        def _do():
+            self._throttle()
+            response = self._client.request(method, url, **kwargs)
+            response.raise_for_status()
+            return response.json()
+
+        return _do()

--- a/src/indexers/kalshi/client.py
+++ b/src/indexers/kalshi/client.py
@@ -1,9 +1,7 @@
 from collections.abc import Generator
 from typing import Optional
 
-import httpx
-
-from src.common.client import retry_request
+from src.common.client import HttpClient
 from src.indexers.kalshi.models import Market, Trade
 
 KALSHI_API_HOST = "https://api.elections.kalshi.com/trade-api/v2"
@@ -12,26 +10,19 @@ KALSHI_API_HOST = "https://api.elections.kalshi.com/trade-api/v2"
 class KalshiClient:
     def __init__(self, host: str = KALSHI_API_HOST):
         self.host = host
-        self.client = httpx.Client(base_url=host, timeout=30.0)
+        self.http = HttpClient(base_url=host, rate_limit=10)
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
-        self.client.close()
+        self.http.close()
 
     def close(self):
-        self.client.close()
-
-    @retry_request()
-    def _get(self, path: str, params: Optional[dict] = None) -> dict:
-        """Make a GET request with retry/backoff."""
-        response = self.client.get(path, params=params)
-        response.raise_for_status()
-        return response.json()
+        self.http.close()
 
     def get_market(self, ticker: str) -> Market:
-        data = self._get(f"/markets/{ticker}")
+        data = self.http.get(f"/markets/{ticker}")
         return Market.from_dict(data["market"])
 
     def get_market_trades(
@@ -54,7 +45,7 @@ class KalshiClient:
             if max_ts is not None:
                 params["max_ts"] = max_ts
 
-            data = self._get("/markets/trades", params=params)
+            data = self.http.get("/markets/trades", params=params)
 
             trades = [Trade.from_dict(t) for t in data.get("trades", [])]
             if trades:
@@ -70,7 +61,7 @@ class KalshiClient:
 
     def list_markets(self, limit: int = 20, **kwargs) -> list[Market]:
         params = {"limit": limit, **kwargs}
-        data = self._get("/markets", params=params)
+        data = self.http.get("/markets", params=params)
         return [Market.from_dict(m) for m in data.get("markets", [])]
 
     def list_all_markets(self, limit: int = 200) -> list[Market]:
@@ -82,7 +73,7 @@ class KalshiClient:
             if cursor:
                 params["cursor"] = cursor
 
-            data = self._get("/markets", params=params)
+            data = self.http.get("/markets", params=params)
 
             markets = [Market.from_dict(m) for m in data.get("markets", [])]
             if markets:
@@ -111,7 +102,7 @@ class KalshiClient:
             if max_close_ts is not None:
                 params["max_close_ts"] = max_close_ts
 
-            data = self._get("/markets", params=params)
+            data = self.http.get("/markets", params=params)
 
             markets = [Market.from_dict(m) for m in data.get("markets", [])]
             cursor = data.get("cursor")
@@ -122,5 +113,5 @@ class KalshiClient:
                 break
 
     def get_recent_trades(self, limit: int = 100) -> list[Trade]:
-        data = self._get("/markets/trades", params={"limit": limit})
+        data = self.http.get("/markets/trades", params={"limit": limit})
         return [Trade.from_dict(t) for t in data.get("trades", [])]

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -1,52 +1,34 @@
 from collections.abc import Generator
-from typing import Optional, Union
+from typing import Union
 
-import httpx
-
-from src.common.client import retry_request
+from src.common.client import HttpClient
 from src.indexers.polymarket.models import Market
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
 
 
 class PolymarketClient:
-    def __init__(
-        self,
-        gamma_url: str = GAMMA_API_URL,
-    ):
+    def __init__(self, gamma_url: str = GAMMA_API_URL):
         self.gamma_url = gamma_url
-        self.client = httpx.Client(timeout=30.0)
+        self.http = HttpClient(rate_limit=10)
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
-        self.client.close()
+        self.http.close()
 
     def close(self):
-        self.client.close()
-
-    @retry_request()
-    def _get(self, url: str, params: Optional[dict] = None) -> Union[dict, list]:
-        """Make a GET request with retry/backoff."""
-        response = self.client.get(url, params=params)
-        response.raise_for_status()
-        return response.json()
+        self.http.close()
 
     def get_markets(self, limit: int = 500, offset: int = 0, **kwargs) -> list[Market]:
-        """Fetch markets from Gamma API."""
         params = {"limit": limit, "offset": offset, **kwargs}
-        data = self._get(f"{self.gamma_url}/markets", params=params)
+        data: Union[dict, list] = self.http.get(f"{self.gamma_url}/markets", params=params)
         if isinstance(data, list):
             return [Market.from_dict(m) for m in data]
         return [Market.from_dict(m) for m in data.get("markets", data)]
 
     def iter_markets(self, limit: int = 500, offset: int = 0) -> Generator[tuple[list[Market], int], None, None]:
-        """Iterate through all markets using offset pagination.
-
-        Yields:
-            Tuple of (markets, next_offset) where next_offset is -1 when done.
-        """
         current_offset = offset
 
         while True:


### PR DESCRIPTION
## What changed? Why?

replaces the `retry_request` decorator + raw `httpx.Client` setup with a shared `HttpClient` class that handles rate limiting, retries, and connection pooling in one place. fixes [#36](https://github.com/Jon-Becker/prediction-market-analysis/issues/36). kalshi trade indexing was hitting frequent 429s during large historical backfills.

- **rate limiting**: thread-safe throttle (default 10 req/s) prevents bursting into 429s
- **exponential backoff with jitter**: `wait_exponential_jitter` avoids retry storms where multiple requests back off in lockstep
- **connection pooling**: configurable `max_connections` via `httpx.Limits` bounds concurrent connections
- **retries**: same transient error detection (429, 5xx, connection/timeout errors), now configurable per-client

## Notes to reviewers

- `src/common/client.py`: new `HttpClient` class replacing the old `retry_request()` decorator
- `src/indexers/kalshi/client.py`: swapped raw `httpx.Client` + `@retry_request()` for `HttpClient`
- `src/indexers/polymarket/client.py` : same swap
- `src/common/__init__.py`: updated exports

## How has it been tested?

- all 111 existing tests pass (`uv run pytest tests/ -v`)
- ruff lint + format checks clean
