### PR TITLE
docs: add prediction market research papers to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,7 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Le, N. A. (2026). _Decomposing Crowd Wisdom: Domain-Specific Calibration Dynamics in Prediction Markets_. arXiv. https://arxiv.org/abs/2602.19520
 - Akey P., Gregoire, V., Harvie, N., Martineau, C. (2026). _Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6443103
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
+- Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
+- Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

added two new prediction market research papers to the bibliography in the readme:

- brown, a. (2026). cassandra or the boy who cried wolf? are prediction markets effective early warning systems?
- reichenbach, f., walther, m. (2025). exploring decentralized prediction markets: accuracy, skill, and bias on polymarket

these papers complement the existing research citations and provide additional perspectives on prediction market effectiveness and dynamics.

## Notes to reviewers

modified files:
- readme.md: added two new bibliography entries

## How has it been tested?

no tests required - documentation-only changes. verified that:
- links are valid
- formatting is consistent with existing entries
- content is readable in markdown
