### PR TITLE
docs: add two new citing papers to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,7 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
 - Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
+- Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
+- Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

added two new papers to the research & citations section of the README. both cite the microstructure of wealth transfer research and/or use the prediction-market-analysis dataset:

- **Bartlett, R., O'Hara, M. (2026)** "Adverse Selection in Prediction Markets: Evidence from Kalshi" (SSRN 6615739). Stanford/Cornell paper measuring adverse selection using Kyle's lambda and Glosten-Harris decomposition on 41.6M Kalshi trades. cites Becker's work directly.
- **Luong, K. L., Heesen, G. (2026)** "The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy" (SSRN 6758662). HKUST paper studying how participant composition affects pricing accuracy on Polymarket, finding that a thin layer of skilled switchers drives market accuracy. cites Becker's work directly.

## Notes to reviewers

- only `README.md` changed (2 lines added to the bibliography section)
- entries follow the existing citation format used in the file

## How has it been tested?

- verified both papers exist and cite the microstructure research by checking their full reference lists on SSRN
- confirmed neither paper was already listed in the README
- verified the SSRN URLs resolve correctly
