### PR TITLE
docs: add adegbenro (2026) citing paper to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,6 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662
+- Adegbenro, A. (2026). _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. arXiv. https://arxiv.org/abs/2606.17503
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

adds one new citing paper to the research & citations section of the README:

- Adegbenro, A. (2026). "What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America." arXiv:2606.17503

this paper uses the prediction-market-analysis dataset as its primary source material (408,863 polymarket market records and kalshi data from the archive's feb 2026 snapshot) to study which uncertainties become tradable contracts on prediction markets. it focuses on africa and latin america topic contracts across polymarket and kalshi.

## Notes to reviewers

single line addition to README.md in the research & citations section. no code changes.

## How has it been tested?

verified the paper genuinely cites/uses this dataset by reading the full text (section 3.1 explicitly names "the prediction-market-analysis archive assembled by Jon Becker" as the source material). confirmed the entry was not already listed in the README. verified the arXiv link resolves correctly.
