### PR TITLE
docs: add microstructure research papers to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,8 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662
 - Adegbenro, A. (2026). _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. arXiv. https://arxiv.org/abs/2606.17503
+- Dubach, P. D. (2026). _The Anatomy of a Decentralized Prediction Market: Microstructure Evidence from the Polymarket Order Book_. arXiv. https://arxiv.org/abs/2604.24366
+- Rahman, N., Al-Chami, J., Clark, J. (2025). _SoK: Market Microstructure for Decentralized Prediction Markets (DePMs)_. arXiv. https://arxiv.org/abs/2510.15612
+- Palumbo, N. (2026). _A Microstructure Perspective on Prediction Markets_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6325658
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

Adds three new prediction-market microstructure research citations to the Research & Citations section of the README. These papers cite or are relevant to this dataset and were verified from their arXiv and SSRN records:

- Dubach, P. D. (2026). _The Anatomy of a Decentralized Prediction Market: Microstructure Evidence from the Polymarket Order Book_. arXiv.
- Rahman, N., Al-Chami, J., Clark, J. (2025). _SoK: Market Microstructure for Decentralized Prediction Markets (DePMs)_. arXiv.
- Palumbo, N. (2026). _A Microstructure Perspective on Prediction Markets_. SSRN.

## Notes to reviewers

- `README.md` — three new bullets appended to the Research & Citations list, preserving the existing bullet style. No existing entries were modified.

## How has it been tested?

- Verified the README contains all three new URLs.
- Confirmed the diff only changes `README.md` (3 insertions).