### PR TITLE
docs: correct citation bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ If you've found an issue or have a question, please open an issue [here](https:/
 
 - Becker, J. (2026). _The Microstructure of Wealth Transfer in Prediction Markets_. Jbecker. https://jbecker.dev/research/prediction-market-microstructure
 - Le, N. A. (2026). _Decomposing Crowd Wisdom: Domain-Specific Calibration Dynamics in Prediction Markets_. arXiv. https://arxiv.org/abs/2602.19520
-- Akey P., Gregoire, V., Harvie, N., Martineau, C. (2026). _Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6443103
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
 - Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522


### PR DESCRIPTION
## What changed? Why?

Removed the Akey, Grégoire, Harvie, and Martineau (2026) paper _"Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket"_ from the Research & Citations section of the README. This paper was listed among works citing this dataset/research, but on review it does not cite Jon Becker's work and therefore does not belong in this bibliography.

The Della Vedova (2026) paper _"Who Profits from Prediction Markets? Execution, not Information"_ is intentionally retained, as it does cite Jon Becker. All other bibliography entries are left unchanged.

## Notes to reviewers

- `README.md` — single-line deletion in the "Research & Citations" list (removed the Akey et al. entry only).

## How has it been tested?

- `git diff` confirms the change is limited to the one intended line removal in `README.md`; no unrelated entries were altered.
- `uv run ruff check .` — All checks passed.
- `uv run ruff format --check .` — all files already formatted.

This is a documentation-only change with no runtime impact.
