### PR TITLE
feat(polymarket): decode ConditionResolution events in PolygonClient

### DIFF
--- a/src/indexers/polymarket/blockchain.py
+++ b/src/indexers/polymarket/blockchain.py
@@ -36,6 +36,30 @@ ORDER_FILLED_ABI = {
     "type": "event",
 }
 
+# Gnosis ConditionalTokens contract used by Polymarket
+CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+
+# ConditionResolution event signature
+# ConditionResolution(bytes32 indexed conditionId, address indexed oracle, bytes32 indexed questionId,
+#                     uint256 outcomeSlotCount, uint256[] payoutNumerators)
+CONDITION_RESOLUTION_TOPIC = (
+    "0x" + Web3.keccak(text="ConditionResolution(bytes32,address,bytes32,uint256,uint256[])").hex()
+)
+
+# ABI for ConditionResolution event
+CONDITION_RESOLUTION_ABI = {
+    "anonymous": False,
+    "inputs": [
+        {"indexed": True, "name": "conditionId", "type": "bytes32"},
+        {"indexed": True, "name": "oracle", "type": "address"},
+        {"indexed": True, "name": "questionId", "type": "bytes32"},
+        {"indexed": False, "name": "outcomeSlotCount", "type": "uint256"},
+        {"indexed": False, "name": "payoutNumerators", "type": "uint256[]"},
+    ],
+    "name": "ConditionResolution",
+    "type": "event",
+}
+
 # Public Polygon RPC
 POLYGON_RPC = os.getenv("POLYGON_RPC", "")
 
@@ -99,6 +123,28 @@ class BlockchainTrade:
         return hex(asset_id)
 
 
+@dataclass
+class ConditionResolution:
+    """A ConditionResolution event decoded from the blockchain."""
+
+    block_number: int
+    transaction_hash: str
+    log_index: int
+    condition_id: str  # 0x-prefixed hex, joins to markets.condition_id
+    oracle: str
+    question_id: str  # 0x-prefixed hex
+    outcome_slot_count: int
+    payout_numerators: list[int]
+
+    @property
+    def winning_outcome(self) -> Optional[int]:
+        """Index of the sole winning outcome, or None for split/invalid payouts."""
+        nonzero = [i for i, numerator in enumerate(self.payout_numerators) if numerator != 0]
+        if len(nonzero) == 1:
+            return nonzero[0]
+        return None
+
+
 class PolygonClient:
     """Client for fetching Polymarket trades from Polygon blockchain."""
 
@@ -112,6 +158,10 @@ class PolygonClient:
         self.negrisk_exchange = self.w3.eth.contract(
             address=Web3.to_checksum_address(NEGRISK_CTF_EXCHANGE),
             abi=[ORDER_FILLED_ABI],
+        )
+        self.conditional_tokens = self.w3.eth.contract(
+            address=Web3.to_checksum_address(CONDITIONAL_TOKENS),
+            abi=[CONDITION_RESOLUTION_ABI],
         )
 
     def get_block_number(self) -> int:
@@ -169,6 +219,43 @@ class PolygonClient:
                 print(f"Error decoding log: {e}")
 
         return trades
+
+    def _decode_condition_resolution(self, log: dict) -> ConditionResolution:
+        """Decode a ConditionResolution event log."""
+        decoded = self.conditional_tokens.events.ConditionResolution().process_log(log)
+        args = decoded["args"]
+
+        return ConditionResolution(
+            block_number=log["blockNumber"],
+            transaction_hash=log["transactionHash"].hex(),
+            log_index=log["logIndex"],
+            condition_id="0x" + bytes(args["conditionId"]).hex(),
+            oracle=args["oracle"],
+            question_id="0x" + bytes(args["questionId"]).hex(),
+            outcome_slot_count=args["outcomeSlotCount"],
+            payout_numerators=list(args["payoutNumerators"]),
+        )
+
+    def get_condition_resolutions(self, from_block: int, to_block: int) -> list[ConditionResolution]:
+        """Fetch ConditionResolution events from a block range."""
+        logs = self.w3.eth.get_logs(
+            {
+                "address": Web3.to_checksum_address(CONDITIONAL_TOKENS),
+                "topics": [CONDITION_RESOLUTION_TOPIC],
+                "fromBlock": from_block,
+                "toBlock": to_block,
+            }
+        )
+
+        resolutions = []
+        for log in logs:
+            try:
+                resolution = self._decode_condition_resolution(log)
+                resolutions.append(resolution)
+            except Exception as e:
+                print(f"Error decoding log: {e}")
+
+        return resolutions
 
     def _fetch_chunk(self, start: int, end: int, contract_address: str) -> tuple[list[BlockchainTrade], int, int]:
         """Fetch a single chunk of trades. Used by thread pool."""
@@ -238,6 +325,9 @@ class PolygonClient:
 
 # Polymarket CTF Exchange created at block 33605403
 POLYMARKET_START_BLOCK = int(os.getenv("POLYMARKET_START_BLOCK", "33605403"))
+
+# Gnosis ConditionalTokens deployed at block 4023686
+CONDITIONAL_TOKENS_START_BLOCK = int(os.getenv("CONDITIONAL_TOKENS_START_BLOCK", "4023686"))
 
 
 def get_deployment_block() -> int:

--- a/tests/test_blockchain_decode.py
+++ b/tests/test_blockchain_decode.py
@@ -1,0 +1,126 @@
+"""Unit tests for decoding ConditionResolution events from hand-built logs."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from eth_abi import encode
+from hexbytes import HexBytes
+from web3 import Web3
+
+from src.indexers.polymarket.blockchain import (
+    CONDITION_RESOLUTION_TOPIC,
+    CONDITIONAL_TOKENS,
+    ConditionResolution,
+    PolygonClient,
+)
+
+CONDITION_ID = "0x" + "11" * 32
+QUESTION_ID = "0x" + "22" * 32
+ORACLE = Web3.to_checksum_address("0x" + "ab" * 20)
+TX_HASH = "0x" + "cd" * 32
+
+
+def build_log(
+    payout_numerators: list[int],
+    outcome_slot_count: int | None = None,
+    block_number: int = 12345,
+    log_index: int = 7,
+) -> dict:
+    """Build a raw eth_getLogs-style entry for a ConditionResolution event."""
+    if outcome_slot_count is None:
+        outcome_slot_count = len(payout_numerators)
+    data = encode(["uint256", "uint256[]"], [outcome_slot_count, payout_numerators])
+    return {
+        "address": Web3.to_checksum_address(CONDITIONAL_TOKENS),
+        "topics": [
+            HexBytes(CONDITION_RESOLUTION_TOPIC),
+            HexBytes(CONDITION_ID),
+            HexBytes("0x" + "00" * 12 + ORACLE[2:]),
+            HexBytes(QUESTION_ID),
+        ],
+        "data": HexBytes(data),
+        "blockNumber": block_number,
+        "blockHash": HexBytes("0x" + "ef" * 32),
+        "transactionHash": HexBytes(TX_HASH),
+        "transactionIndex": 0,
+        "logIndex": log_index,
+    }
+
+
+@pytest.fixture()
+def client() -> PolygonClient:
+    return PolygonClient(rpc_url="http://localhost:8545")
+
+
+def test_decode_condition_resolution(client: PolygonClient):
+    log = build_log([1, 0])
+
+    resolution = client._decode_condition_resolution(log)
+
+    assert resolution.block_number == 12345
+    assert resolution.transaction_hash == HexBytes(TX_HASH).hex()
+    assert resolution.log_index == 7
+    assert resolution.condition_id == CONDITION_ID
+    assert resolution.oracle == ORACLE
+    assert resolution.question_id == QUESTION_ID
+    assert resolution.outcome_slot_count == 2
+    assert resolution.payout_numerators == [1, 0]
+
+
+@pytest.mark.parametrize(
+    ("payout_numerators", "expected"),
+    [
+        ([1, 0], 0),
+        ([0, 1], 1),
+        ([1, 1], None),  # split/invalid resolution (e.g. 50/50)
+        ([0, 0, 1], 2),
+        ([2, 3], None),
+        ([0, 0], None),
+        ([], None),
+    ],
+)
+def test_winning_outcome(payout_numerators: list[int], expected: int | None):
+    resolution = ConditionResolution(
+        block_number=1,
+        transaction_hash="0x00",
+        log_index=0,
+        condition_id=CONDITION_ID,
+        oracle=ORACLE,
+        question_id=QUESTION_ID,
+        outcome_slot_count=max(len(payout_numerators), 2),
+        payout_numerators=payout_numerators,
+    )
+    assert resolution.winning_outcome == expected
+
+
+def test_get_condition_resolutions_filters_and_decodes(client: PolygonClient):
+    logs = [build_log([1, 0], block_number=100, log_index=1), build_log([0, 1], block_number=200, log_index=2)]
+    captured = {}
+
+    def fake_get_logs(params):
+        captured.update(params)
+        return logs
+
+    with patch.object(client.w3.eth, "get_logs", side_effect=fake_get_logs):
+        resolutions = client.get_condition_resolutions(from_block=100, to_block=200)
+
+    assert captured["address"] == Web3.to_checksum_address(CONDITIONAL_TOKENS)
+    assert captured["topics"] == [CONDITION_RESOLUTION_TOPIC]
+    assert captured["fromBlock"] == 100
+    assert captured["toBlock"] == 200
+    assert [r.block_number for r in resolutions] == [100, 200]
+    assert [r.winning_outcome for r in resolutions] == [0, 1]
+
+
+def test_get_condition_resolutions_skips_undecodable_logs(client: PolygonClient, capsys: pytest.CaptureFixture):
+    bad_log = build_log([1, 0])
+    bad_log["data"] = HexBytes("0x")  # truncated payload
+
+    with patch.object(client.w3.eth, "get_logs", return_value=[bad_log, build_log([0, 1])]):
+        resolutions = client.get_condition_resolutions(from_block=0, to_block=10)
+
+    assert len(resolutions) == 1
+    assert resolutions[0].winning_outcome == 1
+    assert "Error decoding log" in capsys.readouterr().out


### PR DESCRIPTION
## What changed? Why?

Adds exact on-chain resolution decoding for Polymarket markets to `src/indexers/polymarket/blockchain.py`:

- `CONDITIONAL_TOKENS` constant for the Gnosis ConditionalTokens contract on Polygon (`0x4D97DCd97eC945f40cF65F87097ACe5EA0476045`), plus `CONDITION_RESOLUTION_TOPIC` (keccak of `ConditionResolution(bytes32,address,bytes32,uint256,uint256[])`, matching on-chain topic0 `0xb44d84d3...5894`) and `CONDITION_RESOLUTION_ABI`, following the existing `OrderFilled` / FPMM topic conventions.
- A typed `ConditionResolution` dataclass (`condition_id`, `oracle`, `question_id`, `outcome_slot_count`, `payout_numerators`, log coordinates) with a `winning_outcome` property that returns the index of the sole nonzero payout numerator, or `None` for split/invalid payouts (e.g. `[1, 1]` 50/50 resolutions).
- `PolygonClient.get_condition_resolutions(from_block, to_block)` fetching and decoding logs with the same shape and per-log error handling as `get_trades`.
- `CONDITIONAL_TOKENS_START_BLOCK` (deployment block 4023686, env-overridable like `POLYMARKET_START_BLOCK`).

Analyses currently infer resolution from a `>0.99`/`<0.01` outcome-price heuristic, silently dropping ambiguously-priced closed markets. On-chain `ConditionResolution` events give exact payout numerators; `condition_id` joins directly to `markets.condition_id`. A resolutions indexer and analysis integration will follow in separate PRs — this PR is decode-layer only and does not change any existing trade behavior.

## Notes to reviewers

- `src/indexers/polymarket/blockchain.py` — new constants, `ConditionResolution` dataclass, contract instance, and `get_condition_resolutions` / `_decode_condition_resolution` methods; no changes to existing `BlockchainTrade`, `get_trades`, or `iter_trades` code paths.
- `tests/test_blockchain_decode.py` — new pure unit tests (no network) using hand-built ABI-encoded logs.

## How has it been tested?

- `uv run ruff check .` and `uv run ruff format --check .` pass.
- `uv run pytest tests/ -v` — 121 passed, including 10 new tests covering: exact field decoding from a hand-built log (topics + `eth_abi`-encoded data), `winning_outcome` across `[1,0]`, `[0,1]`, `[1,1]`, `[0,0,1]`, `[2,3]`, `[0,0]`, and `[]` payout vectors, `get_logs` filter parameters (address/topic/block range), and that undecodable logs are skipped with an error print without aborting the batch.
- Verified the computed topic hash equals the canonical on-chain topic0 for `ConditionResolution`.