### PR TITLE
feat(polymarket): add events, keyset pagination, and CLOB market-data support to client

### DIFF
--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -58,12 +58,14 @@ Each row represents a prediction market.
 | `slug` | string | URL slug |
 | `outcomes` | string | JSON string of outcome names |
 | `outcome_prices` | string | JSON string of outcome prices |
+| `clob_token_ids` | string | JSON string of CLOB token IDs, one per outcome |
 | `volume` | float | Total volume in USD |
 | `liquidity` | float | Current liquidity in USD |
 | `active` | bool | Is market active |
 | `closed` | bool | Is market closed |
 | `end_date` | datetime (nullable) | When market ends |
 | `created_at` | datetime (nullable) | When market was created |
+| `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
 ## Polymarket Trades

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -171,6 +171,6 @@ class PolymarketClient:
         return float(data.get("spread", 0) or 0)
 
     def get_price(self, token_id: str, side: str) -> float:
-        """Fetch the best price for a token; `side` is BUY (best ask) or SELL (best bid)."""
+        """Fetch the best price for a token; `side` is BUY (best bid) or SELL (best ask)."""
         data = self.http.get(f"{self.clob_url}/price", params={"token_id": token_id, "side": side})
         return float(data.get("price", 0) or 0)

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -1,15 +1,17 @@
 from collections.abc import Generator
-from typing import Union
+from typing import Optional, Union
 
 from src.common.client import HttpClient
-from src.indexers.polymarket.models import Market
+from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
+CLOB_API_URL = "https://clob.polymarket.com"
 
 
 class PolymarketClient:
-    def __init__(self, gamma_url: str = GAMMA_API_URL):
+    def __init__(self, gamma_url: str = GAMMA_API_URL, clob_url: str = CLOB_API_URL):
         self.gamma_url = gamma_url
+        self.clob_url = clob_url
         self.http = HttpClient(rate_limit=10)
 
     def __enter__(self):
@@ -20,6 +22,8 @@ class PolymarketClient:
 
     def close(self):
         self.http.close()
+
+    # -- Gamma API (offset pagination) ----------------------------------------
 
     def get_markets(self, limit: int = 500, offset: int = 0, **kwargs) -> list[Market]:
         params = {"limit": limit, "offset": offset, **kwargs}
@@ -45,3 +49,128 @@ class PolymarketClient:
                 break
 
             current_offset = next_offset
+
+    def get_events(self, limit: int = 500, offset: int = 0, **kwargs) -> list[Event]:
+        params = {"limit": limit, "offset": offset, **kwargs}
+        data: Union[dict, list] = self.http.get(f"{self.gamma_url}/events", params=params)
+        if isinstance(data, list):
+            return [Event.from_dict(e) for e in data]
+        return [Event.from_dict(e) for e in data.get("events", data)]
+
+    def iter_events(self, limit: int = 500, offset: int = 0) -> Generator[tuple[list[Event], int], None, None]:
+        current_offset = offset
+
+        while True:
+            events = self.get_events(limit=limit, offset=current_offset)
+
+            if not events:
+                yield [], -1
+                break
+
+            next_offset = current_offset + len(events)
+            yield events, next_offset
+
+            if len(events) < limit:
+                break
+
+            current_offset = next_offset
+
+    # -- Gamma API (keyset pagination) -----------------------------------------
+
+    def get_markets_keyset(
+        self, limit: int = 100, after_cursor: Optional[str] = None, **kwargs
+    ) -> tuple[list[Market], Optional[str]]:
+        """Fetch one page of `/markets/keyset`; returns (markets, next_cursor).
+
+        `next_cursor` is None on the final page. `limit` is capped at 100 by the API.
+        """
+        params = {"limit": limit, **kwargs}
+        if after_cursor:
+            params["after_cursor"] = after_cursor
+        data = self.http.get(f"{self.gamma_url}/markets/keyset", params=params)
+        markets = [Market.from_dict(m) for m in data.get("markets", [])]
+        return markets, data.get("next_cursor")
+
+    def iter_markets_keyset(
+        self, limit: int = 100, after_cursor: Optional[str] = None, **kwargs
+    ) -> Generator[tuple[list[Market], Optional[str]], None, None]:
+        cursor = after_cursor
+
+        while True:
+            markets, cursor = self.get_markets_keyset(limit=limit, after_cursor=cursor, **kwargs)
+            yield markets, cursor
+
+            if not cursor:
+                break
+
+    def get_events_keyset(
+        self, limit: int = 500, after_cursor: Optional[str] = None, **kwargs
+    ) -> tuple[list[Event], Optional[str]]:
+        """Fetch one page of `/events/keyset`; returns (events, next_cursor).
+
+        `next_cursor` is None on the final page. `limit` is capped at 500 by the API.
+        """
+        params = {"limit": limit, **kwargs}
+        if after_cursor:
+            params["after_cursor"] = after_cursor
+        data = self.http.get(f"{self.gamma_url}/events/keyset", params=params)
+        events = [Event.from_dict(e) for e in data.get("events", [])]
+        return events, data.get("next_cursor")
+
+    def iter_events_keyset(
+        self, limit: int = 500, after_cursor: Optional[str] = None, **kwargs
+    ) -> Generator[tuple[list[Event], Optional[str]], None, None]:
+        cursor = after_cursor
+
+        while True:
+            events, cursor = self.get_events_keyset(limit=limit, after_cursor=cursor, **kwargs)
+            yield events, cursor
+
+            if not cursor:
+                break
+
+    # -- CLOB API --------------------------------------------------------------
+
+    def get_price_history(
+        self,
+        token_id: str,
+        interval: Optional[str] = "max",
+        fidelity: Optional[int] = None,
+        start_ts: Optional[int] = None,
+        end_ts: Optional[int] = None,
+    ) -> list[PricePoint]:
+        """Fetch the price time series for a CLOB token from `/prices-history`.
+
+        `interval` is one of max, all, 1m, 1w, 1d, 6h, 1h; `fidelity` is the
+        resolution in minutes; `start_ts`/`end_ts` are unix seconds. Pass
+        `interval=None` when querying by explicit timestamp bounds.
+        """
+        params: dict = {"market": token_id}
+        if interval:
+            params["interval"] = interval
+        if fidelity is not None:
+            params["fidelity"] = fidelity
+        if start_ts is not None:
+            params["startTs"] = start_ts
+        if end_ts is not None:
+            params["endTs"] = end_ts
+        data = self.http.get(f"{self.clob_url}/prices-history", params=params)
+        history = data.get("history") or [] if isinstance(data, dict) else []
+        return [PricePoint.from_dict(token_id, point) for point in history]
+
+    def get_order_book(self, token_id: str) -> OrderBookSnapshot:
+        data = self.http.get(f"{self.clob_url}/book", params={"token_id": token_id})
+        return OrderBookSnapshot.from_dict(data)
+
+    def get_midpoint(self, token_id: str) -> float:
+        data = self.http.get(f"{self.clob_url}/midpoint", params={"token_id": token_id})
+        return float(data.get("mid", 0) or 0)
+
+    def get_spread(self, token_id: str) -> float:
+        data = self.http.get(f"{self.clob_url}/spread", params={"token_id": token_id})
+        return float(data.get("spread", 0) or 0)
+
+    def get_price(self, token_id: str, side: str) -> float:
+        """Fetch the best price for a token; `side` is BUY (best ask) or SELL (best bid)."""
+        data = self.http.get(f"{self.clob_url}/price", params={"token_id": token_id, "side": side})
+        return float(data.get("price", 0) or 0)

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -1,6 +1,18 @@
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
+
+
+def parse_time(val: Optional[str]) -> Optional[datetime]:
+    if not val:
+        return None
+    try:
+        # Handle ISO format with Z suffix
+        val = val.replace("Z", "+00:00")
+        return datetime.fromisoformat(val)
+    except (ValueError, TypeError):
+        return None
 
 
 @dataclass
@@ -22,16 +34,6 @@ class Market:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Market":
-        def parse_time(val: Optional[str]) -> Optional[datetime]:
-            if not val:
-                return None
-            try:
-                # Handle ISO format with Z suffix
-                val = val.replace("Z", "+00:00")
-                return datetime.fromisoformat(val)
-            except (ValueError, TypeError):
-                return None
-
         return cls(
             id=data.get("id", ""),
             condition_id=data.get("conditionId", ""),
@@ -47,4 +49,96 @@ class Market:
             end_date=parse_time(data.get("endDate")),
             created_at=parse_time(data.get("createdAt")),
             market_maker_address=data.get("marketMakerAddress"),
+        )
+
+
+@dataclass
+class Event:
+    id: str
+    slug: str
+    title: str
+    category: Optional[str]
+    tags: str  # JSON string of tag slugs
+    market_ids: str  # JSON string of child market IDs
+    volume: float
+    liquidity: float
+    active: bool
+    closed: bool
+    start_date: Optional[datetime]
+    end_date: Optional[datetime]
+    created_at: Optional[datetime]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Event":
+        return cls(
+            id=data.get("id", ""),
+            slug=data.get("slug", ""),
+            title=data.get("title", ""),
+            category=data.get("category"),
+            tags=json.dumps([t.get("slug", "") for t in data.get("tags") or []]),
+            market_ids=json.dumps([m.get("id", "") for m in data.get("markets") or []]),
+            volume=float(data.get("volume", 0) or 0),
+            liquidity=float(data.get("liquidity", 0) or 0),
+            active=data.get("active", False),
+            closed=data.get("closed", False),
+            start_date=parse_time(data.get("startDate")),
+            end_date=parse_time(data.get("endDate")),
+            created_at=parse_time(data.get("createdAt")),
+        )
+
+
+@dataclass
+class PricePoint:
+    token_id: str
+    timestamp: int  # unix seconds
+    price: float
+
+    @classmethod
+    def from_dict(cls, token_id: str, data: dict) -> "PricePoint":
+        return cls(
+            token_id=token_id,
+            timestamp=int(data.get("t", 0) or 0),
+            price=float(data.get("p", 0) or 0),
+        )
+
+
+@dataclass
+class OrderBookLevel:
+    price: float
+    size: float
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OrderBookLevel":
+        return cls(
+            price=float(data.get("price", 0) or 0),
+            size=float(data.get("size", 0) or 0),
+        )
+
+
+@dataclass
+class OrderBookSnapshot:
+    condition_id: str  # `market` in the API response
+    token_id: str  # `asset_id` in the API response
+    timestamp: int  # unix milliseconds
+    hash: str
+    bids: list[OrderBookLevel] = field(default_factory=list)
+    asks: list[OrderBookLevel] = field(default_factory=list)
+    min_order_size: float = 0.0
+    tick_size: float = 0.0
+    neg_risk: bool = False
+    last_trade_price: float = 0.0
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OrderBookSnapshot":
+        return cls(
+            condition_id=data.get("market", ""),
+            token_id=data.get("asset_id", ""),
+            timestamp=int(data.get("timestamp", 0) or 0),
+            hash=data.get("hash", ""),
+            bids=[OrderBookLevel.from_dict(level) for level in data.get("bids") or []],
+            asks=[OrderBookLevel.from_dict(level) for level in data.get("asks") or []],
+            min_order_size=float(data.get("min_order_size", 0) or 0),
+            tick_size=float(data.get("tick_size", 0) or 0),
+            neg_risk=data.get("neg_risk", False),
+            last_trade_price=float(data.get("last_trade_price", 0) or 0),
         )

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -1,0 +1,311 @@
+"""Unit tests for PolymarketClient and its Gamma/CLOB models (no network)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from src.indexers.polymarket.client import PolymarketClient
+from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+
+GAMMA_MARKET = {
+    "id": "500000",
+    "conditionId": "0x" + "ab" * 32,
+    "question": "Will it rain tomorrow?",
+    "slug": "will-it-rain-tomorrow",
+    "outcomes": '["Yes", "No"]',
+    "outcomePrices": '["0.65", "0.35"]',
+    "clobTokenIds": '["111", "222"]',
+    "volume": "1234.5",
+    "liquidity": "678.9",
+    "active": True,
+    "closed": False,
+    "endDate": "2026-08-01T00:00:00Z",
+    "createdAt": "2026-07-01T12:30:00Z",
+    "marketMakerAddress": "0x" + "cd" * 20,
+}
+
+GAMMA_EVENT = {
+    "id": "2891",
+    "slug": "nba-finals-2026",
+    "title": "NBA Finals 2026",
+    "category": "Sports",
+    "tags": [{"id": "1", "label": "Sports", "slug": "sports"}, {"id": "2", "label": "NBA", "slug": "nba"}],
+    "markets": [{"id": "500000"}, {"id": "500001"}],
+    "volume": 1335.05,
+    "liquidity": 42.0,
+    "active": True,
+    "closed": True,
+    "startDate": "2026-06-04T00:00:00Z",
+    "endDate": "2026-06-22T00:00:00Z",
+    "createdAt": "2026-05-27T14:40:02.074Z",
+}
+
+ORDER_BOOK = {
+    "market": "0x" + "ab" * 32,
+    "asset_id": "111",
+    "timestamp": "1784254990511",
+    "hash": "720dff71476f22d3",
+    "bids": [{"price": "0.45", "size": "100"}, {"price": "0.44", "size": "50.5"}],
+    "asks": [{"price": "0.46", "size": "150"}],
+    "min_order_size": "5",
+    "tick_size": "0.001",
+    "neg_risk": True,
+    "last_trade_price": "0.45",
+}
+
+
+class FakeHttp:
+    """Stub for HttpClient that returns canned responses and records calls."""
+
+    def __init__(self, responses: list):
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, *, params: dict | None = None):
+        self.calls.append((url, params or {}))
+        return self.responses.pop(0)
+
+    def close(self):
+        pass
+
+
+def make_client(responses: list) -> PolymarketClient:
+    client = PolymarketClient()
+    client.http.close()
+    client.http = FakeHttp(responses)
+    return client
+
+
+# -- Model parsing -------------------------------------------------------------
+
+
+def test_market_from_dict():
+    market = Market.from_dict(GAMMA_MARKET)
+
+    assert market.id == "500000"
+    assert market.condition_id == "0x" + "ab" * 32
+    assert market.clob_token_ids == '["111", "222"]'
+    assert market.volume == 1234.5
+    assert market.liquidity == 678.9
+    assert market.active is True
+    assert market.closed is False
+    assert market.end_date == datetime(2026, 8, 1, tzinfo=timezone.utc)
+    assert market.created_at == datetime(2026, 7, 1, 12, 30, tzinfo=timezone.utc)
+    assert market.market_maker_address == "0x" + "cd" * 20
+
+
+def test_market_from_dict_defaults():
+    market = Market.from_dict({})
+
+    assert market.id == ""
+    assert market.outcomes == "[]"
+    assert market.volume == 0.0
+    assert market.active is False
+    assert market.end_date is None
+    assert market.market_maker_address is None
+
+
+def test_event_from_dict():
+    event = Event.from_dict(GAMMA_EVENT)
+
+    assert event.id == "2891"
+    assert event.slug == "nba-finals-2026"
+    assert event.title == "NBA Finals 2026"
+    assert event.category == "Sports"
+    assert json.loads(event.tags) == ["sports", "nba"]
+    assert json.loads(event.market_ids) == ["500000", "500001"]
+    assert event.volume == 1335.05
+    assert event.liquidity == 42.0
+    assert event.active is True
+    assert event.closed is True
+    assert event.start_date == datetime(2026, 6, 4, tzinfo=timezone.utc)
+    assert event.end_date == datetime(2026, 6, 22, tzinfo=timezone.utc)
+    assert event.created_at is not None
+
+
+def test_event_from_dict_defaults():
+    event = Event.from_dict({})
+
+    assert event.id == ""
+    assert event.category is None
+    assert json.loads(event.tags) == []
+    assert json.loads(event.market_ids) == []
+    assert event.volume == 0.0
+    assert event.start_date is None
+
+
+def test_price_point_from_dict():
+    point = PricePoint.from_dict("111", {"t": 1784251816, "p": 0.0125})
+
+    assert point.token_id == "111"
+    assert point.timestamp == 1784251816
+    assert point.price == 0.0125
+
+
+def test_order_book_snapshot_from_dict():
+    book = OrderBookSnapshot.from_dict(ORDER_BOOK)
+
+    assert book.condition_id == "0x" + "ab" * 32
+    assert book.token_id == "111"
+    assert book.timestamp == 1784254990511
+    assert book.hash == "720dff71476f22d3"
+    assert [(level.price, level.size) for level in book.bids] == [(0.45, 100.0), (0.44, 50.5)]
+    assert [(level.price, level.size) for level in book.asks] == [(0.46, 150.0)]
+    assert book.min_order_size == 5.0
+    assert book.tick_size == 0.001
+    assert book.neg_risk is True
+    assert book.last_trade_price == 0.45
+
+
+def test_order_book_snapshot_from_dict_empty():
+    book = OrderBookSnapshot.from_dict({})
+
+    assert book.condition_id == ""
+    assert book.bids == []
+    assert book.asks == []
+    assert book.neg_risk is False
+
+
+# -- Gamma offset pagination ----------------------------------------------------
+
+
+def test_iter_markets_stops_on_short_page():
+    client = make_client([[GAMMA_MARKET] * 2, [GAMMA_MARKET]])
+
+    pages = list(client.iter_markets(limit=2))
+
+    assert [(len(markets), offset) for markets, offset in pages] == [(2, 2), (1, 3)]
+    assert all(isinstance(m, Market) for m in pages[0][0])
+    assert client.http.calls[0] == ("https://gamma-api.polymarket.com/markets", {"limit": 2, "offset": 0})
+    assert client.http.calls[1][1] == {"limit": 2, "offset": 2}
+
+
+def test_iter_markets_empty_first_page_yields_sentinel():
+    client = make_client([[]])
+
+    assert list(client.iter_markets(limit=2)) == [([], -1)]
+
+
+def test_iter_events_matches_iter_markets_semantics():
+    client = make_client([[GAMMA_EVENT] * 2, []])
+
+    pages = list(client.iter_events(limit=2))
+
+    assert [(len(events), offset) for events, offset in pages] == [(2, 2), (0, -1)]
+    assert all(isinstance(e, Event) for e in pages[0][0])
+    assert client.http.calls[0] == ("https://gamma-api.polymarket.com/events", {"limit": 2, "offset": 0})
+
+
+def test_get_events_passes_filters():
+    client = make_client([[GAMMA_EVENT]])
+
+    events = client.get_events(limit=10, offset=5, closed=True)
+
+    assert len(events) == 1
+    assert client.http.calls == [
+        ("https://gamma-api.polymarket.com/events", {"limit": 10, "offset": 5, "closed": True})
+    ]
+
+
+# -- Gamma keyset pagination ----------------------------------------------------
+
+
+def test_get_markets_keyset_first_page_omits_cursor():
+    client = make_client([{"markets": [GAMMA_MARKET], "next_cursor": "abc123"}])
+
+    markets, cursor = client.get_markets_keyset(limit=100, closed=True)
+
+    assert len(markets) == 1
+    assert isinstance(markets[0], Market)
+    assert cursor == "abc123"
+    url, params = client.http.calls[0]
+    assert url == "https://gamma-api.polymarket.com/markets/keyset"
+    assert params == {"limit": 100, "closed": True}
+    assert "after_cursor" not in params
+
+
+def test_get_markets_keyset_final_page_returns_none_cursor():
+    client = make_client([{"markets": [GAMMA_MARKET]}])
+
+    markets, cursor = client.get_markets_keyset(after_cursor="abc123")
+
+    assert len(markets) == 1
+    assert cursor is None
+    assert client.http.calls[0][1]["after_cursor"] == "abc123"
+
+
+def test_iter_markets_keyset_follows_cursor_until_exhausted():
+    client = make_client(
+        [
+            {"markets": [GAMMA_MARKET] * 2, "next_cursor": "page2"},
+            {"markets": [GAMMA_MARKET]},
+        ]
+    )
+
+    pages = list(client.iter_markets_keyset(limit=2))
+
+    assert [(len(markets), cursor) for markets, cursor in pages] == [(2, "page2"), (1, None)]
+    assert "after_cursor" not in client.http.calls[0][1]
+    assert client.http.calls[1][1]["after_cursor"] == "page2"
+
+
+def test_iter_events_keyset_resumes_from_cursor():
+    client = make_client([{"events": [GAMMA_EVENT]}])
+
+    pages = list(client.iter_events_keyset(after_cursor="resume-here"))
+
+    assert [(len(events), cursor) for events, cursor in pages] == [(1, None)]
+    url, params = client.http.calls[0]
+    assert url == "https://gamma-api.polymarket.com/events/keyset"
+    assert params["after_cursor"] == "resume-here"
+
+
+# -- CLOB endpoints --------------------------------------------------------------
+
+
+def test_get_price_history_parses_points_in_order():
+    client = make_client([{"history": [{"t": 100, "p": 0.5}, {"t": 160, "p": 0.55}]}])
+
+    points = client.get_price_history("111")
+
+    assert [(p.token_id, p.timestamp, p.price) for p in points] == [("111", 100, 0.5), ("111", 160, 0.55)]
+    assert client.http.calls == [("https://clob.polymarket.com/prices-history", {"market": "111", "interval": "max"})]
+
+
+def test_get_price_history_passes_bounds_without_interval():
+    client = make_client([{"history": []}])
+
+    points = client.get_price_history("111", interval=None, fidelity=10, start_ts=100, end_ts=200)
+
+    assert points == []
+    assert client.http.calls[0][1] == {"market": "111", "fidelity": 10, "startTs": 100, "endTs": 200}
+
+
+def test_get_price_history_tolerates_missing_history():
+    client = make_client([{}])
+
+    assert client.get_price_history("111") == []
+
+
+def test_get_order_book():
+    client = make_client([ORDER_BOOK])
+
+    book = client.get_order_book("111")
+
+    assert isinstance(book, OrderBookSnapshot)
+    assert book.token_id == "111"
+    assert client.http.calls == [("https://clob.polymarket.com/book", {"token_id": "111"})]
+
+
+def test_get_midpoint_spread_and_price():
+    client = make_client([{"mid": "0.012"}, {"spread": "0.014"}, {"price": "0.005"}])
+
+    assert client.get_midpoint("111") == 0.012
+    assert client.get_spread("111") == 0.014
+    assert client.get_price("111", "BUY") == 0.005
+    assert client.http.calls == [
+        ("https://clob.polymarket.com/midpoint", {"token_id": "111"}),
+        ("https://clob.polymarket.com/spread", {"token_id": "111"}),
+        ("https://clob.polymarket.com/price", {"token_id": "111", "side": "BUY"}),
+    ]


### PR DESCRIPTION
## What changed? Why?

This PR lays the client/model foundation for the public Polymarket API stack, expanding `PolymarketClient` beyond the single Gamma `/markets` offset listing it supported before. It is scoped to clients and models only — no indexers, WebSockets, on-chain resolution decoding, or storage changes.

**New models** (`src/indexers/polymarket/models.py`):
- `Event` — Gamma event metadata (title, category, tag slugs and child market IDs as JSON strings, volume/liquidity, active/closed, dates), giving Polymarket the event-grouping backbone that Kalshi analyses get from `event_ticker`.
- `PricePoint` — one `{t, p}` observation from CLOB `/prices-history`, keyed by token ID.
- `OrderBookLevel` / `OrderBookSnapshot` — parsed CLOB `/book` response (`OrderBookSummary`): condition ID, token ID, millisecond timestamp, hash, bid/ask levels, min order size, tick size, neg-risk flag, last trade price. String prices/sizes from the API are parsed to floats.
- The existing `parse_time` helper was hoisted from `Market.from_dict` to module level so all models share it; `Market` behavior is unchanged.

**Client additions** (`src/indexers/polymarket/client.py`):
- Gamma events: `get_events` / `iter_events`, mirroring the existing `get_markets` / `iter_markets` pagination semantics exactly (including the `([], -1)` empty-page sentinel).
- Gamma keyset pagination: `get_markets_keyset` / `get_events_keyset` and iterator variants over `GET /markets/keyset` and `GET /events/keyset` (`after_cursor` → `next_cursor`, absent cursor = final page). This is the docs-recommended stable pagination for full-corpus crawls, since these endpoints reject `offset`.
- CLOB market data: `get_price_history` (`/prices-history` with `interval`/`fidelity`/`startTs`/`endTs`), `get_order_book` (`/book`), `get_midpoint` (`/midpoint`), `get_spread` (`/spread`), and `get_price` (`/price` with BUY/SELL side), all on the existing shared rate-limited `HttpClient`.

All request/response shapes follow the official docs (docs.polymarket.com API reference and OpenAPI blocks) and were verified against the live APIs — notably `/midpoint` returns `{"mid": ...}` and CLOB prices/sizes arrive as strings, which the models normalize.

`docs/SCHEMAS.md` also gets a drift fix: the Polymarket Markets table was missing `clob_token_ids` and `market_maker_address`, both already written by the markets indexer. No new dataset directories are introduced, so the README project tree is unchanged.

## Notes to reviewers

- `src/indexers/polymarket/models.py` — new `Event`, `PricePoint`, `OrderBookLevel`, `OrderBookSnapshot` dataclasses; `parse_time` hoisted to module level (pure refactor, `Market.from_dict` output identical).
- `src/indexers/polymarket/client.py` — new `CLOB_API_URL` constant and `clob_url` constructor param (defaulted, backward compatible); events, keyset, and CLOB methods described above. Existing `get_markets` / `iter_markets` are untouched.
- `tests/test_polymarket_client.py` — new; all HTTP is stubbed via a `FakeHttp` injected in place of `client.http`.
- `docs/SCHEMAS.md` — two added rows in the Polymarket Markets table.
- Keyset `limit` defaults differ deliberately (100 for markets, 500 for events) to match each endpoint's documented cap.

## How has it been tested?

- 23 new mocked unit tests in `tests/test_polymarket_client.py` covering: `Market.from_dict` regression + defaults, `Event`/`PricePoint`/`OrderBookSnapshot` parsing (including empty payloads), offset-pagination semantics for markets and events (short page, empty-page sentinel, filter passthrough), keyset pagination (cursor omitted on first page, `None` cursor on final page, cursor threading across pages, resume from a supplied cursor), and every CLOB endpoint (param passthrough, ordered parse, missing-`history` tolerance, string→float normalization).
- Full local CI suite: `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pytest tests/ -v` — 131 passed, 0 failed.
- Response fixtures in the tests mirror shapes confirmed with read-only requests against the live Gamma and CLOB APIs.