### PR TITLE
feat(polymarket): events indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── events/
 │       ├── markets/
 │       └── trades/
 ├── docs/                   # Documentation

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -68,6 +68,27 @@ Each row represents a prediction market.
 | `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
+## Polymarket Events
+
+Each row represents an event, the top-level question grouping one or more markets. Events are fetched from the Gamma API with keyset pagination in two passes (`closed=false`, then `closed=true`), since Gamma excludes closed events by default. An event that closes mid-backfill can appear in both passes; deduplicate on `id`, keeping the latest `_fetched_at`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Event ID |
+| `slug` | string | URL slug |
+| `title` | string | Event title |
+| `category` | string (nullable) | Event category |
+| `tags` | string | JSON string of tag slugs, used for categorization |
+| `market_ids` | string | JSON string of child market IDs (joins to `markets.id`) |
+| `volume` | float | Total volume in USD |
+| `liquidity` | float | Current liquidity in USD |
+| `active` | bool | Is event active |
+| `closed` | bool | Is event closed |
+| `start_date` | datetime (nullable) | When event starts |
+| `end_date` | datetime (nullable) | When event ends |
+| `created_at` | datetime (nullable) | When event was created |
+| `_fetched_at` | datetime | When this record was fetched |
+
 ## Polymarket Trades
 
 Each row represents an `OrderFilled` event from the Polygon blockchain.

--- a/src/indexers/polymarket/events.py
+++ b/src/indexers/polymarket/events.py
@@ -1,0 +1,120 @@
+"""Indexer for Polymarket events data."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+
+DATA_DIR = Path("data/polymarket/events")
+CURSOR_FILE = Path("data/polymarket/.events_backfill_cursor")
+CHUNK_SIZE = 10000
+PAGE_LIMIT = 500
+
+# Gamma excludes closed events unless closed=true is requested, so full coverage
+# needs one pass per closed value. The open pass runs first so events that close
+# mid-crawl are still picked up by the closed pass.
+PHASES = [("open", False), ("closed", True)]
+
+
+class PolymarketEventsIndexer(Indexer):
+    """Fetches and stores Polymarket events data."""
+
+    def __init__(self):
+        super().__init__(
+            name="polymarket_events",
+            description="Backfills Polymarket events data to parquet files",
+        )
+
+    def run(self) -> None:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolymarketClient()
+
+        resume_phase = None
+        resume_cursor = None
+        if CURSOR_FILE.exists():
+            try:
+                state = json.loads(CURSOR_FILE.read_text())
+                resume_phase = state.get("phase")
+                resume_cursor = state.get("cursor")
+                print(f"Resuming from {resume_phase} phase")
+            except (ValueError, TypeError):
+                pass
+
+        phase_names = [name for name, _ in PHASES]
+        start_idx = phase_names.index(resume_phase) if resume_phase in phase_names else 0
+
+        buffer = []
+        total = 0
+        total_saved = 0
+        interrupted = False
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("events_*.parquet"))
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + CHUNK_SIZE if indices else 0
+
+        def save_chunk(records):
+            nonlocal total_saved
+            if not records:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"events_{chunk_idx}_{chunk_idx + CHUNK_SIZE}.parquet"
+            pd.DataFrame(records).to_parquet(chunk_path)
+            total_saved += len(records)
+            print(f"Saved {len(records)} events to {chunk_path.name}")
+
+        try:
+            for idx in range(start_idx, len(PHASES)):
+                phase, closed = PHASES[idx]
+                after_cursor = resume_cursor if phase == resume_phase else None
+                print(f"Fetching {phase} events (closed={closed})")
+
+                for events, next_cursor in client.iter_events_keyset(
+                    limit=PAGE_LIMIT, after_cursor=after_cursor, closed=closed
+                ):
+                    if events:
+                        fetched_at = datetime.utcnow()
+                        for event in events:
+                            record = asdict(event)
+                            record["_fetched_at"] = fetched_at
+                            buffer.append(record)
+
+                        total += len(events)
+                        print(f"Fetched {len(events)} {phase} events (total: {total})")
+
+                        while len(buffer) >= CHUNK_SIZE:
+                            save_chunk(buffer[:CHUNK_SIZE])
+                            buffer = buffer[CHUNK_SIZE:]
+
+                    if next_cursor:
+                        CURSOR_FILE.write_text(json.dumps({"phase": phase, "cursor": next_cursor}))
+
+                if idx + 1 < len(PHASES):
+                    CURSOR_FILE.write_text(json.dumps({"phase": PHASES[idx + 1][0], "cursor": None}))
+        except KeyboardInterrupt:
+            interrupted = True
+            print("\nInterrupted. Progress saved.")
+
+        # Save remaining events
+        save_chunk(buffer)
+
+        # Only clean up cursor on successful completion
+        if not interrupted and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        client.close()
+        print(f"\nBackfill complete: {total} events fetched")

--- a/src/indexers/polymarket/events.py
+++ b/src/indexers/polymarket/events.py
@@ -108,9 +108,10 @@ class PolymarketEventsIndexer(Indexer):
         except KeyboardInterrupt:
             interrupted = True
             print("\nInterrupted. Progress saved.")
-
-        # Save remaining events
-        save_chunk(buffer)
+        finally:
+            # Flush on any exit: the cursor may already point past buffered events,
+            # so losing the buffer would leave a silent gap on resume.
+            save_chunk(buffer)
 
         # Only clean up cursor on successful completion
         if not interrupted and CURSOR_FILE.exists():

--- a/tests/test_events_indexer.py
+++ b/tests/test_events_indexer.py
@@ -1,0 +1,211 @@
+"""Tests for the Polymarket events indexer: pagination, resume, interrupt, schema (no network)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.models import Event
+
+EVENT_FIELDS = [
+    "id",
+    "slug",
+    "title",
+    "category",
+    "tags",
+    "market_ids",
+    "volume",
+    "liquidity",
+    "active",
+    "closed",
+    "start_date",
+    "end_date",
+    "created_at",
+]
+
+
+def make_event(i: int, closed: bool = False) -> Event:
+    return Event.from_dict(
+        {
+            "id": str(i),
+            "slug": f"event-{i}",
+            "title": f"Event {i}",
+            "category": "Sports",
+            "tags": [{"slug": "sports"}],
+            "markets": [{"id": str(i * 10)}],
+            "volume": 10.0,
+            "liquidity": 5.0,
+            "active": not closed,
+            "closed": closed,
+            "startDate": "2026-06-01T00:00:00Z",
+            "endDate": "2026-06-30T00:00:00Z",
+            "createdAt": "2026-05-01T00:00:00Z",
+        }
+    )
+
+
+class FakeClient:
+    """Stub for PolymarketClient serving canned keyset pages.
+
+    `responses` maps (closed, after_cursor) -> (events, next_cursor);
+    `interrupt_at` raises KeyboardInterrupt before serving that key.
+    """
+
+    def __init__(self, responses: dict, interrupt_at: tuple | None = None):
+        self.responses = responses
+        self.calls: list[dict] = []
+        self._interrupt_at = interrupt_at
+        self.was_closed = False
+
+    def iter_events_keyset(self, limit: int = 500, after_cursor: str | None = None, **kwargs):
+        closed = kwargs.get("closed")
+        cursor = after_cursor
+        while True:
+            if self._interrupt_at is not None and (closed, cursor) == self._interrupt_at:
+                raise KeyboardInterrupt
+            self.calls.append({"limit": limit, "after_cursor": cursor, "closed": closed})
+            events, cursor = self.responses[(closed, cursor)]
+            yield events, cursor
+            if not cursor:
+                break
+
+    def close(self):
+        self.was_closed = True
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "events"
+    cursor_file = tmp_path / ".events_backfill_cursor"
+    import src.indexers.polymarket.events as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def run_indexer(client: FakeClient) -> None:
+    from src.indexers.polymarket.events import PolymarketEventsIndexer
+
+    with patch("src.indexers.polymarket.events.PolymarketClient", return_value=client):
+        PolymarketEventsIndexer().run()
+
+
+def read_all(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("events_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def test_full_backfill_paginates_both_phases(isolated_dirs, monkeypatch: pytest.MonkeyPatch):
+    """Both closed=False and closed=True passes run, following keyset cursors."""
+    import src.indexers.polymarket.events as mod
+
+    monkeypatch.setattr(mod, "CHUNK_SIZE", 4)
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(
+        {
+            (False, None): ([make_event(1), make_event(2)], "o2"),
+            (False, "o2"): ([make_event(3)], None),
+            (True, None): ([make_event(4, closed=True), make_event(5, closed=True)], None),
+        }
+    )
+    run_indexer(client)
+
+    assert client.calls == [
+        {"limit": 500, "after_cursor": None, "closed": False},
+        {"limit": 500, "after_cursor": "o2", "closed": False},
+        {"limit": 500, "after_cursor": None, "closed": True},
+    ]
+
+    files = sorted(data_dir.glob("events_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    assert [len(pd.read_parquet(f)) for f in files] == [4, 1], "Full chunk saved mid-run, remainder flushed at end"
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4", "5"]
+
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+    assert client.was_closed
+
+
+def test_parquet_schema_matches_event_model(isolated_dirs):
+    """Chunk columns are exactly the Event fields plus _fetched_at."""
+    data_dir, _ = isolated_dirs
+
+    client = FakeClient(
+        {
+            (False, None): ([make_event(1)], None),
+            (True, None): ([], None),
+        }
+    )
+    run_indexer(client)
+
+    df = read_all(data_dir)
+    assert list(df.columns) == EVENT_FIELDS + ["_fetched_at"]
+    assert json.loads(df.iloc[0]["tags"]) == ["sports"]
+    assert json.loads(df.iloc[0]["market_ids"]) == ["10"]
+    assert df.iloc[0]["_fetched_at"] is not None
+
+
+def test_resume_starts_from_saved_phase_and_cursor(isolated_dirs):
+    """A saved cursor skips completed phases and resumes mid-phase."""
+    _, cursor_file = isolated_dirs
+    cursor_file.write_text(json.dumps({"phase": "closed", "cursor": "c2"}))
+
+    client = FakeClient({(True, "c2"): ([make_event(6, closed=True)], None)})
+    run_indexer(client)
+
+    assert client.calls == [{"limit": 500, "after_cursor": "c2", "closed": True}]
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_interrupt_then_resume_completes(isolated_dirs):
+    """Interrupt a backfill with Ctrl+C, then resume and finish the job."""
+    data_dir, cursor_file = isolated_dirs
+
+    # Run 1: interrupt when the open phase requests the page at cursor "o2"
+    client1 = FakeClient(
+        {(False, None): ([make_event(1), make_event(2)], "o2")},
+        interrupt_at=(False, "o2"),
+    )
+    run_indexer(client1)
+
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    assert json.loads(cursor_file.read_text()) == {"phase": "open", "cursor": "o2"}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"], "Buffered events flushed on interrupt"
+
+    # Run 2: resume from the saved cursor, no interrupt
+    client2 = FakeClient(
+        {
+            (False, "o2"): ([make_event(3)], None),
+            (True, None): ([make_event(4, closed=True)], None),
+        }
+    )
+    run_indexer(client2)
+
+    assert client2.calls[0] == {"limit": 500, "after_cursor": "o2", "closed": False}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4"], "Resume fetches only the remaining pages"
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_interrupt_between_phases_resumes_at_closed_phase(isolated_dirs):
+    """After the open phase completes, resume skips straight to the closed phase."""
+    data_dir, cursor_file = isolated_dirs
+
+    client1 = FakeClient(
+        {(False, None): ([make_event(1)], None)},
+        interrupt_at=(True, None),
+    )
+    run_indexer(client1)
+
+    assert json.loads(cursor_file.read_text()) == {"phase": "closed", "cursor": None}
+
+    client2 = FakeClient({(True, None): ([make_event(2, closed=True)], None)})
+    run_indexer(client2)
+
+    assert all(call["closed"] is True for call in client2.calls), "Open phase should not be re-crawled"
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"]
+    assert not cursor_file.exists()

--- a/tests/test_events_indexer.py
+++ b/tests/test_events_indexer.py
@@ -52,13 +52,19 @@ class FakeClient:
     """Stub for PolymarketClient serving canned keyset pages.
 
     `responses` maps (closed, after_cursor) -> (events, next_cursor);
-    `interrupt_at` raises KeyboardInterrupt before serving that key.
+    `interrupt_at` raises `exc` (KeyboardInterrupt by default) before serving that key.
     """
 
-    def __init__(self, responses: dict, interrupt_at: tuple | None = None):
+    def __init__(
+        self,
+        responses: dict,
+        interrupt_at: tuple | None = None,
+        exc: type[BaseException] = KeyboardInterrupt,
+    ):
         self.responses = responses
         self.calls: list[dict] = []
         self._interrupt_at = interrupt_at
+        self._exc = exc
         self.was_closed = False
 
     def iter_events_keyset(self, limit: int = 500, after_cursor: str | None = None, **kwargs):
@@ -66,7 +72,7 @@ class FakeClient:
         cursor = after_cursor
         while True:
             if self._interrupt_at is not None and (closed, cursor) == self._interrupt_at:
-                raise KeyboardInterrupt
+                raise self._exc
             self.calls.append({"limit": limit, "after_cursor": cursor, "closed": closed})
             events, cursor = self.responses[(closed, cursor)]
             yield events, cursor
@@ -189,6 +195,22 @@ def test_interrupt_then_resume_completes(isolated_dirs):
     assert client2.calls[0] == {"limit": 500, "after_cursor": "o2", "closed": False}
     assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4"], "Resume fetches only the remaining pages"
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_crash_flushes_buffer_and_preserves_cursor(isolated_dirs):
+    """A non-interrupt crash still flushes buffered events, so the saved cursor never points past unsaved data."""
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(
+        {(False, None): ([make_event(1), make_event(2)], "o2")},
+        interrupt_at=(False, "o2"),
+        exc=RuntimeError,
+    )
+    with pytest.raises(RuntimeError):
+        run_indexer(client)
+
+    assert json.loads(cursor_file.read_text()) == {"phase": "open", "cursor": "o2"}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"], "Buffered events flushed on crash"
 
 
 def test_interrupt_between_phases_resumes_at_closed_phase(isolated_dirs):


### PR DESCRIPTION
## What changed? Why?

adds `PolymarketEventsIndexer` (`polymarket_events`), which backfills the Gamma `/events` corpus to chunked parquet under `data/polymarket/events/`. this gives polymarket an event-level grouping/categorization dataset (parity with kalshi's `event_ticker`) for category analyses.

stacked on the polymarket API foundation PR; uses the client's existing `iter_events_keyset` (stable keyset pagination, no deep offsets). since gamma excludes closed events by default, the indexer crawls in two passes, `closed=false` then `closed=true`, so the full historical corpus is covered rather than silently defaulting to active-only. the open pass runs first so events that close mid-crawl are still picked up by the closed pass.

## Notes to reviewers

- `src/indexers/polymarket/events.py`: the indexer. follows the repo conventions: zero-arg constructor, module-level `DATA_DIR`/`CURSOR_FILE`/`CHUNK_SIZE` constants (monkeypatchable), `events_{i}_{i+10000}.parquet` chunks, `_fetched_at` stamp on every record, cursor written after each completed page, `KeyboardInterrupt` caught with buffer flushed and cursor preserved, cursor deleted only on clean completion. the cursor file is JSON (`{"phase", "cursor"}`) since keyset cursors are opaque strings and resume needs to know which pass it was in.
- `tests/test_events_indexer.py`: mocked tests (no network) for two-phase keyset pagination, resume from a saved phase+cursor, interrupt mid-phase and between phases, and exact parquet schema. `test_compile.py` auto-covers import + zero-arg instantiation and menu discovery.
- `docs/SCHEMAS.md`: new "Polymarket Events" section documenting every column incl. `_fetched_at` and the dedup-on-`id` caveat for events that close mid-backfill.
- `README.md`: `events/` added to the data tree.

no changes to other clients, indexers, analyses, storage, or on-chain code.

## How has it been tested?

- `uv run ruff check .` passes
- `uv run ruff format --check .` passes
- `uv run pytest tests/ -v`: 138 passed, including the 5 new events-indexer tests and auto-discovered instantiation coverage