### PR TITLE
feat(polymarket): price history indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── price_history/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -68,6 +68,17 @@ Each row represents a prediction market.
 | `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
+## Polymarket Price History
+
+Each row represents one point in the price time series of a single outcome token, fetched from the CLOB `/prices-history` endpoint at hourly fidelity. Both outcome tokens of every market in the markets dataset are covered.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID (joins to an entry of `clob_token_ids` in Polymarket Markets) |
+| `timestamp` | int | Unix timestamp of the price point (seconds) |
+| `price` | float | Token price (decimal between 0 and 1, see the note on Polymarket prices below) |
+| `_fetched_at` | datetime | When this record was fetched |
+
 ## Polymarket Trades
 
 Each row represents an `OrderFilled` event from the Polygon blockchain.

--- a/src/indexers/polymarket/price_history.py
+++ b/src/indexers/polymarket/price_history.py
@@ -18,7 +18,7 @@ DATA_DIR = Path("data/polymarket/price_history")
 MARKETS_DIR = Path("data/polymarket/markets")
 BATCH_SIZE = 10000
 FIDELITY_MINUTES = 60
-WINDOW_SECONDS = 30 * 24 * 60 * 60  # max span per /prices-history request; longer ranges get truncated
+WINDOW_SECONDS = 15 * 24 * 60 * 60  # max span per /prices-history request; the API 400s on longer ranges
 END_PADDING_SECONDS = 7 * 24 * 60 * 60  # markets can keep trading past their scheduled end until resolution
 EARLIEST_TS = 1577836800  # 2020-01-01, before the first Polymarket market
 

--- a/src/indexers/polymarket/price_history.py
+++ b/src/indexers/polymarket/price_history.py
@@ -1,0 +1,196 @@
+"""Indexer for Polymarket CLOB price history data."""
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+
+DATA_DIR = Path("data/polymarket/price_history")
+MARKETS_DIR = Path("data/polymarket/markets")
+BATCH_SIZE = 10000
+FIDELITY_MINUTES = 60
+WINDOW_SECONDS = 30 * 24 * 60 * 60  # max span per /prices-history request; longer ranges get truncated
+END_PADDING_SECONDS = 7 * 24 * 60 * 60  # markets can keep trading past their scheduled end until resolution
+EARLIEST_TS = 1577836800  # 2020-01-01, before the first Polymarket market
+
+
+def _to_epoch_seconds(value: Optional[datetime], default: int) -> int:
+    try:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp())
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return default
+
+
+def _discover_token_windows() -> dict[str, tuple[int, int]]:
+    """Map every CLOB token ID in the markets dataset to its (start_ts, end_ts) fetch window."""
+    rows = duckdb.sql(f"SELECT clob_token_ids, created_at, end_date FROM '{MARKETS_DIR}/markets_*.parquet'").fetchall()
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    windows: dict[str, tuple[int, int]] = {}
+    for clob_token_ids, created_at, end_date in rows:
+        try:
+            token_ids = json.loads(clob_token_ids)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(token_ids, list):
+            continue
+
+        start_ts = _to_epoch_seconds(created_at, EARLIEST_TS)
+        end_ts = min(_to_epoch_seconds(end_date, now_ts) + END_PADDING_SECONDS, now_ts)
+        end_ts = max(end_ts, start_ts + 1)
+
+        for token_id in token_ids:
+            if not isinstance(token_id, str) or not token_id:
+                continue
+            if token_id in windows:
+                prev_start, prev_end = windows[token_id]
+                windows[token_id] = (min(prev_start, start_ts), max(prev_end, end_ts))
+            else:
+                windows[token_id] = (start_ts, end_ts)
+
+    return windows
+
+
+class PolymarketPriceHistoryIndexer(Indexer):
+    """Fetches and stores Polymarket CLOB price history data."""
+
+    def __init__(self, max_workers: int = 10):
+        super().__init__(
+            name="polymarket_price_history",
+            description="Backfills Polymarket price history data to parquet files",
+        )
+        self._max_workers = max_workers
+
+    def run(self) -> None:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        if not list(MARKETS_DIR.glob("markets_*.parquet")):
+            print(f"No markets data found in {MARKETS_DIR}, run the polymarket_markets indexer first")
+            return
+
+        token_windows = _discover_token_windows()
+        print(f"Found {len(token_windows)} unique tokens across all markets")
+
+        # Load existing token IDs for deduplication (this is also the resume mechanism)
+        existing_tokens: set[str] = set()
+        parquet_files = list(DATA_DIR.glob("prices_*.parquet"))
+        if parquet_files:
+            print("Loading existing tokens for deduplication...")
+            try:
+                result = duckdb.sql(f"SELECT DISTINCT token_id FROM '{DATA_DIR}/prices_*.parquet'").fetchall()
+                existing_tokens = {row[0] for row in result}
+                print(f"Found {len(existing_tokens)} existing tokens")
+            except Exception:
+                pass
+
+        tokens_to_process = [(t, w) for t, w in sorted(token_windows.items()) if t not in existing_tokens]
+        print(
+            f"Skipped {len(token_windows) - len(tokens_to_process)} already processed, "
+            f"{len(tokens_to_process)} to fetch"
+        )
+
+        if not tokens_to_process:
+            print("Nothing to process")
+            return
+
+        all_points: list[dict] = []
+        total_points_saved = 0
+        next_chunk_idx = 0
+
+        # Calculate next chunk index
+        if parquet_files:
+            indices = []
+            for f in parquet_files:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            if indices:
+                next_chunk_idx = max(indices) + BATCH_SIZE
+
+        def save_batch(points_batch: list[dict]) -> int:
+            nonlocal next_chunk_idx
+            if not points_batch:
+                return 0
+            chunk_path = DATA_DIR / f"prices_{next_chunk_idx}_{next_chunk_idx + BATCH_SIZE}.parquet"
+            pd.DataFrame(points_batch).to_parquet(chunk_path)
+            next_chunk_idx += BATCH_SIZE
+            return len(points_batch)
+
+        def fetch_token_history(token_id: str, start_ts: int, end_ts: int) -> list[dict]:
+            """Fetch the full price history for a single token in bounded windows."""
+            client = PolymarketClient()
+            try:
+                fetched_at = datetime.utcnow()
+                records: list[dict] = []
+                seen_ts: set[int] = set()
+                cursor = start_ts
+                while cursor < end_ts:
+                    window_end = min(cursor + WINDOW_SECONDS, end_ts)
+                    points = client.get_price_history(
+                        token_id,
+                        interval=None,
+                        fidelity=FIDELITY_MINUTES,
+                        start_ts=cursor,
+                        end_ts=window_end,
+                    )
+                    for point in points:
+                        if point.timestamp not in seen_ts:
+                            seen_ts.add(point.timestamp)
+                            records.append({**asdict(point), "_fetched_at": fetched_at})
+                    cursor = window_end
+                return records
+            finally:
+                client.close()
+
+        # Concurrent fetching
+        pbar = tqdm(total=len(tokens_to_process), desc="Fetching price history")
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {
+                executor.submit(fetch_token_history, token, start, end): token
+                for token, (start, end) in tokens_to_process
+            }
+
+            for future in as_completed(futures):
+                token = futures[future]
+                try:
+                    points_data = future.result()
+                    if points_data:
+                        all_points.extend(points_data)
+
+                    pbar.update(1)
+                    pbar.set_postfix(buffer=len(all_points), saved=total_points_saved, last=token[-20:])
+
+                    # Save in batches
+                    while len(all_points) >= BATCH_SIZE:
+                        saved = save_batch(all_points[:BATCH_SIZE])
+                        total_points_saved += saved
+                        all_points = all_points[BATCH_SIZE:]
+
+                except Exception as e:
+                    pbar.update(1)
+                    tqdm.write(f"Error fetching {token}: {e}")
+
+        pbar.close()
+
+        # Save remaining
+        if all_points:
+            total_points_saved += save_batch(all_points)
+
+        print(
+            f"\nBackfill price history complete: {len(tokens_to_process)} tokens processed, "
+            f"{total_points_saved} points saved"
+        )

--- a/tests/test_price_history_indexer.py
+++ b/tests/test_price_history_indexer.py
@@ -198,7 +198,7 @@ def test_parquet_schema_and_values(isolated_dirs):
 
 def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
     data_dir, markets_dir = isolated_dirs
-    end_date = CREATED_AT + timedelta(days=40)  # spans two request windows
+    end_date = CREATED_AT + timedelta(days=40)  # spans multiple request windows
     write_markets(markets_dir, [{"clob_token_ids": '["111"]', "created_at": CREATED_AT, "end_date": end_date}])
     boundary_ts = BASE_TS + mod.WINDOW_SECONDS
     fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.5), (boundary_ts, 0.6), (boundary_ts + 60, 0.7)]})
@@ -208,8 +208,13 @@ def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
     expected_end = int(end_date.timestamp()) + mod.END_PADDING_SECONDS
     assert fake.calls == [
         ("111", None, mod.FIDELITY_MINUTES, BASE_TS, boundary_ts),
-        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, expected_end),
+        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, BASE_TS + 2 * mod.WINDOW_SECONDS),
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS + 2 * mod.WINDOW_SECONDS, BASE_TS + 3 * mod.WINDOW_SECONDS),
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS + 3 * mod.WINDOW_SECONDS, expected_end),
     ]
+    assert all(call[4] - call[3] <= 15 * 24 * 60 * 60 for call in fake.calls), (
+        "/prices-history rejects startTs/endTs spans longer than 15 days"
+    )
     df = load_prices(data_dir)
     assert len(df) == 3, "boundary point returned by both windows should be stored once"
     assert sorted(df["timestamp"].tolist()) == [BASE_TS + 60, boundary_ts, boundary_ts + 60]

--- a/tests/test_price_history_indexer.py
+++ b/tests/test_price_history_indexer.py
@@ -1,0 +1,215 @@
+"""Tests for the Polymarket price history indexer (no network)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import src.indexers.polymarket.price_history as mod
+from src.indexers.polymarket.models import PricePoint
+from src.indexers.polymarket.price_history import PolymarketPriceHistoryIndexer
+
+CREATED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+END_DATE = datetime(2026, 1, 15, tzinfo=timezone.utc)
+BASE_TS = int(CREATED_AT.timestamp())
+
+
+class FakeClient:
+    """Stub for PolymarketClient that returns canned histories and records calls."""
+
+    def __init__(self, histories: dict[str, list[tuple[int, float]]] | None = None, errors: set[str] | None = None):
+        self.histories = histories or {}
+        self.errors = errors or set()
+        self.calls: list[tuple[str, str | None, int | None, int | None, int | None]] = []
+
+    def get_price_history(self, token_id, interval="max", fidelity=None, start_ts=None, end_ts=None):
+        self.calls.append((token_id, interval, fidelity, start_ts, end_ts))
+        if token_id in self.errors:
+            raise RuntimeError("API unavailable")
+        return [
+            PricePoint(token_id=token_id, timestamp=t, price=p)
+            for t, p in self.histories.get(token_id, [])
+            if start_ts <= t <= end_ts
+        ]
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and MARKETS_DIR at temp directories."""
+    data_dir = tmp_path / "price_history"
+    markets_dir = tmp_path / "markets"
+    markets_dir.mkdir()
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "MARKETS_DIR", markets_dir)
+    return data_dir, markets_dir
+
+
+def write_markets(markets_dir: Path, rows: list[dict]) -> None:
+    records = [
+        {
+            "id": str(i),
+            "clob_token_ids": row.get("clob_token_ids", "[]"),
+            "volume": row.get("volume", 0.0),
+            "created_at": row.get("created_at", CREATED_AT),
+            "end_date": row.get("end_date", END_DATE),
+        }
+        for i, row in enumerate(rows)
+    ]
+    pd.DataFrame(records).to_parquet(markets_dir / f"markets_0_{len(records)}.parquet")
+
+
+def run_indexer(fake: FakeClient, max_workers: int = 2) -> None:
+    with patch.object(mod, "PolymarketClient", return_value=fake):
+        PolymarketPriceHistoryIndexer(max_workers=max_workers).run()
+
+
+def load_prices(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("prices_*.parquet"))
+    assert files, "expected at least one prices parquet chunk"
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def test_fetches_both_outcome_tokens(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"111", "222"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222"]
+
+
+def test_covers_all_markets_regardless_of_volume(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(
+        markets_dir,
+        [
+            {"clob_token_ids": '["111", "222"]', "volume": 0.0},
+            {"clob_token_ids": '["333", "444"]', "volume": 250000.0},
+        ],
+    )
+    histories = {t: [(BASE_TS + 60, 0.5)] for t in ["111", "222", "333", "444"]}
+    fake = FakeClient(histories=histories)
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"111", "222", "333", "444"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222", "333", "444"]
+
+
+def test_malformed_token_arrays_are_skipped(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(
+        markets_dir,
+        [
+            {"clob_token_ids": "not json"},
+            {"clob_token_ids": '"111"'},  # valid JSON but not a list
+            {"clob_token_ids": '[123, null, ""]'},  # non-string and empty entries
+            {"clob_token_ids": None},
+            {"clob_token_ids": '["555"]'},
+        ],
+    )
+    fake = FakeClient(histories={"555": [(BASE_TS + 60, 0.9)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"555"}
+    df = load_prices(data_dir)
+    assert df["token_id"].unique().tolist() == ["555"]
+
+
+def test_resume_skips_already_stored_tokens(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    data_dir.mkdir(parents=True)
+    existing = pd.DataFrame([{"token_id": "111", "timestamp": BASE_TS, "price": 0.5, "_fetched_at": datetime.utcnow()}])
+    existing.to_parquet(data_dir / "prices_0_10000.parquet")
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    fake = FakeClient(histories={"222": [(BASE_TS + 60, 0.7)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"222"}
+    files = sorted(f.name for f in data_dir.glob("prices_*.parquet"))
+    assert files == ["prices_0_10000.parquet", "prices_10000_20000.parquet"]
+    new_chunk = pd.read_parquet(data_dir / "prices_10000_20000.parquet")
+    assert new_chunk["token_id"].unique().tolist() == ["222"]
+
+
+def test_rerun_after_completion_is_noop(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    histories = {"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]}
+
+    run_indexer(FakeClient(histories=histories))
+    rerun = FakeClient(histories=histories)
+    run_indexer(rerun)
+
+    assert rerun.calls == []
+    assert len(list(data_dir.glob("prices_*.parquet"))) == 1
+
+
+def test_api_failure_skips_token_and_retries_next_run(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    histories = {"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]}
+    failing = FakeClient(histories=histories, errors={"111"})
+
+    run_indexer(failing)
+
+    df = load_prices(data_dir)
+    assert df["token_id"].unique().tolist() == ["222"]
+
+    recovered = FakeClient(histories=histories)
+    run_indexer(recovered)
+
+    assert {call[0] for call in recovered.calls} == {"111"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222"]
+
+
+def test_parquet_schema_and_values(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111"]'}])
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.65), (BASE_TS + 120, 0.66)]})
+
+    run_indexer(fake, max_workers=1)
+
+    df = load_prices(data_dir)
+    assert list(df.columns) == ["token_id", "timestamp", "price", "_fetched_at"]
+    assert df["token_id"].dtype == object
+    assert df["timestamp"].dtype == "int64"
+    assert df["price"].dtype == "float64"
+    assert pd.api.types.is_datetime64_any_dtype(df["_fetched_at"])
+    assert df.sort_values("timestamp")[["timestamp", "price"]].values.tolist() == [
+        [BASE_TS + 60, 0.65],
+        [BASE_TS + 120, 0.66],
+    ]
+
+
+def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    end_date = CREATED_AT + timedelta(days=40)  # spans two request windows
+    write_markets(markets_dir, [{"clob_token_ids": '["111"]', "created_at": CREATED_AT, "end_date": end_date}])
+    boundary_ts = BASE_TS + mod.WINDOW_SECONDS
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.5), (boundary_ts, 0.6), (boundary_ts + 60, 0.7)]})
+
+    run_indexer(fake, max_workers=1)
+
+    expected_end = int(end_date.timestamp()) + mod.END_PADDING_SECONDS
+    assert fake.calls == [
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS, boundary_ts),
+        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, expected_end),
+    ]
+    df = load_prices(data_dir)
+    assert len(df) == 3, "boundary point returned by both windows should be stored once"
+    assert sorted(df["timestamp"].tolist()) == [BASE_TS + 60, boundary_ts, boundary_ts + 60]


### PR DESCRIPTION
## What changed? Why?

adds a `polymarket_price_history` indexer that backfills per-token price time series from the official CLOB `/prices-history` endpoint into `data/polymarket/price_history/`. trades only give executed prices; this dataset enables longitudinal price analyses and pre-resolution calibration snapshots.

- discovers CLOB token ids from the stored gamma markets parquet files, safely parsing the JSON-stringified `clob_token_ids` column (malformed or non-list values are skipped, both outcome tokens are fetched)
- covers every historical and current market, no volume threshold
- fetches with explicit `startTs`/`endTs` bounds derived from each market's `created_at`/`end_date` (padded a week past scheduled end for resolution-lag trading), windowed into 15-day requests at hourly fidelity to stay within the API's range limits, deduping window-boundary points
- resumes idempotently: already-stored token ids are skipped on rerun (token-level dedup is the cursor, same pattern as kalshi trades), and a failed token is simply retried on the next run
- writes chunked parquet (`prices_{i}_{i+10000}.parquet`) with a `_fetched_at` column, following existing storage conventions
- documents the new dataset in `docs/SCHEMAS.md` and adds `price_history/` to the README project tree

stacked on `jon-becker/polymarket-api-foundation`, which provides `PolymarketClient.get_price_history`.

## Notes to reviewers

- `src/indexers/polymarket/price_history.py` (new): the indexer, structural clone of the kalshi trades fan-out pattern (threadpool, batch saves, tqdm)
- `tests/test_price_history_indexer.py` (new): 8 tests covering malformed token arrays, both outcome tokens, zero-volume coverage, dedup/resume, no-op rerun, API failure recovery, parquet schema/dtypes, and request windowing with boundary dedup
- `docs/SCHEMAS.md`: new "Polymarket Price History" section
- `README.md`: project-structure tree update

## How has it been tested?

- `uv run ruff check .` and `uv run ruff format --check .` pass
- `uv run pytest tests/ -v`: 141 passed, including the 8 new indexer tests (fake client, no network)
