### PR TITLE
feat(polymarket): add live CLOB orderbook websocket recorder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: analyze run index package lint format test setup
+.PHONY: analyze run index record package lint format test setup
 
 RUN = uv run main.py
 
@@ -10,6 +10,9 @@ run:
 
 index:
 	$(RUN) index
+
+record:
+	$(RUN) record $(filter-out $@,$(MAKECMDGOALS))
 
 package:
 	$(RUN) package

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project enables research and analysis of prediction markets by providing:
 Currently supported features:
 - Market metadata collection (Kalshi & Polymarket)
 - Trade history collection via API and blockchain
+- Live order-book recording via the Polymarket CLOB WebSocket
 - Parquet-based storage with automatic progress saving
 - Extensible analysis script framework
 
@@ -40,6 +41,17 @@ make index
 ```
 
 This opens an interactive menu to select which indexer to run. Data is saved to `data/kalshi/` and `data/polymarket/` directories. Progress is saved automatically, so you can interrupt and resume collection.
+
+### Live Orderbook Recording
+
+**Polymarket provides no API for historical order-book depth — it cannot be backfilled after the fact and must be recorded live.** The recorder subscribes to the CLOB market WebSocket channel and persists full book snapshots plus incremental price changes (see [docs/SCHEMAS.md](docs/SCHEMAS.md)):
+
+```bash
+make record                            # record the highest-volume open markets
+uv run main.py record <token_id> ...   # record specific CLOB token IDs
+```
+
+Recording runs until interrupted with Ctrl+C; buffered rows are flushed to `data/polymarket/orderbook/` on exit and every 10,000 rows. The recorder heartbeats every 10 seconds and reconnects automatically — after a reconnect the exchange re-sends full snapshots, so gaps only span the time actually spent offline.
 
 ### Running Analyses
 
@@ -77,6 +89,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── orderbook/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -137,3 +137,40 @@ Mapping from Polygon block numbers to timestamps.
 |--------|------|-------------|
 | `block_number` | int | Polygon block number |
 | `timestamp` | string | ISO 8601 timestamp (e.g., `2024-01-15T12:30:00Z`) |
+
+## Polymarket Orderbook (live recording)
+
+Located in `data/polymarket/orderbook/{books,price_changes}/`.
+
+**Polymarket exposes no historical order-book endpoint — depth data cannot be fetched retroactively.** These tables only cover periods when the live recorder (`uv run main.py record`) was running against the CLOB market WebSocket channel. Prices and sizes are stored as raw strings exactly as sent by the exchange so books can be replayed and verified against the `hash` field.
+
+### Orderbook Book Snapshots (`books/`)
+
+Each row is a full L2 `book` snapshot for one token. The server sends a snapshot on every (re)subscribe and after each trade that affects the book, so a reconnect always re-baselines the state — deltas missed while disconnected are superseded by the next snapshot.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID (`asset_id` in the message) |
+| `condition_id` | string | Condition ID (`market` in the message) |
+| `timestamp` | int | Exchange timestamp in unix **milliseconds** |
+| `hash` | string | Book integrity hash from the exchange |
+| `bids` | string | Raw JSON array of `{price, size}` levels, as sent |
+| `asks` | string | Raw JSON array of `{price, size}` levels, as sent |
+| `_recorded_at` | datetime | When the message was received locally |
+
+### Orderbook Price Changes (`price_changes/`)
+
+Each row is one changed level from a `price_change` message (order placements/cancellations). To reconstruct the book at time T: take the latest snapshot at or before T and apply subsequent deltas in `timestamp` order.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID |
+| `condition_id` | string | Condition ID |
+| `timestamp` | int | Exchange timestamp in unix **milliseconds** |
+| `hash` | string | Book hash after this change |
+| `side` | string | `BUY` (bid level) or `SELL` (ask level) |
+| `price` | string | Price level that changed (raw string) |
+| `size` | string | New total size at that level; `"0"` means the level was removed |
+| `best_bid` | string | Best bid after this change |
+| `best_ask` | string | Best ask after this change |
+| `_recorded_at` | datetime | When the message was received locally |

--- a/main.py
+++ b/main.py
@@ -126,6 +126,13 @@ def index():
     print("\nIndexer complete.")
 
 
+def record(token_ids: list[str] | None = None):
+    """Run the live Polymarket orderbook recorder until interrupted."""
+    from src.indexers.polymarket.orderbook import PolymarketOrderbookRecorder
+
+    PolymarketOrderbookRecorder(token_ids=token_ids).run()
+
+
 def package():
     """Package the data directory into a zstd-compressed tar archive."""
     success = package_data()
@@ -135,7 +142,7 @@ def package():
 def main():
     if len(sys.argv) < 2:
         print("\nUsage: uv run main.py <command>")
-        print("Commands: analyze, index, package")
+        print("Commands: analyze, index, record, package")
         sys.exit(0)
 
     command = sys.argv[1]
@@ -149,12 +156,16 @@ def main():
         index()
         sys.exit(0)
 
+    if command == "record":
+        record(sys.argv[2:] or None)
+        sys.exit(0)
+
     if command == "package":
         package()
         sys.exit(0)
 
     print(f"Unknown command: {command}")
-    print("Commands: analyze, index, package")
+    print("Commands: analyze, index, record, package")
     sys.exit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "simple-term-menu>=1.6.0",
     "python-dotenv>=1.2.1",
     "requests>=2.32.5",
+    "websockets>=15.0.1",
 ]
 
 [dependency-groups]

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -116,6 +116,44 @@ class OrderBookLevel:
 
 
 @dataclass
+class OrderBookDelta:
+    condition_id: str
+    token_id: str
+    timestamp: int  # unix milliseconds
+    hash: str
+    side: str  # BUY (bid level) or SELL (ask level)
+    price: str  # raw string, preserved for exact replay
+    size: str  # raw string; "0" means the level was removed
+    best_bid: str
+    best_ask: str
+
+    @classmethod
+    def list_from_message(cls, data: dict) -> list["OrderBookDelta"]:
+        """Parse a market-channel `price_change` message into one delta per changed level.
+
+        Handles both the current shape (`price_changes` with per-change `asset_id`
+        and `hash`) and the legacy shape (`changes` with top-level `asset_id`).
+        """
+        condition_id = data.get("market", "")
+        timestamp = int(data.get("timestamp", 0) or 0)
+        changes = data.get("price_changes") or data.get("changes") or []
+        return [
+            cls(
+                condition_id=condition_id,
+                token_id=str(change.get("asset_id") or data.get("asset_id") or ""),
+                timestamp=timestamp,
+                hash=change.get("hash") or data.get("hash") or "",
+                side=change.get("side", ""),
+                price=str(change.get("price", "")),
+                size=str(change.get("size", "")),
+                best_bid=str(change.get("best_bid", "")),
+                best_ask=str(change.get("best_ask", "")),
+            )
+            for change in changes
+        ]
+
+
+@dataclass
 class OrderBookSnapshot:
     condition_id: str  # `market` in the API response
     token_id: str  # `asset_id` in the API response

--- a/src/indexers/polymarket/orderbook.py
+++ b/src/indexers/polymarket/orderbook.py
@@ -1,0 +1,216 @@
+"""Live recorder for the Polymarket CLOB market WebSocket channel.
+
+Polymarket exposes no historical order-book endpoint: depth data cannot be
+fetched retroactively and only exists for the periods this recorder was
+running. It subscribes to the market channel by CLOB token IDs, persists
+full `book` snapshots and `price_change` deltas with their raw string
+levels and integrity hashes (millisecond exchange timestamps preserved),
+sends the required `PING` heartbeat every 10 seconds, and reconnects with
+backoff on disconnect. Reconnects are safe for replay because the server
+re-sends a full `book` snapshot for every subscribed token on subscribe,
+superseding any deltas missed while offline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import websockets
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+from src.indexers.polymarket.models import OrderBookDelta
+
+WS_MARKET_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+DATA_DIR = Path("data/polymarket/orderbook")
+CHUNK_SIZE = 10000
+PING_INTERVAL_SECONDS = 10.0
+INITIAL_RECONNECT_DELAY_SECONDS = 1.0
+MAX_RECONNECT_DELAY_SECONDS = 60.0
+DISCOVER_MARKET_COUNT = 100
+
+
+def discover_token_ids(client: PolymarketClient, max_markets: int = DISCOVER_MARKET_COUNT) -> list[str]:
+    """Resolve CLOB token IDs for the highest-volume open markets on Gamma."""
+    markets = client.get_markets(limit=max_markets, active=True, closed=False, order="volume", ascending=False)
+    token_ids: list[str] = []
+    for market in markets:
+        try:
+            ids = json.loads(market.clob_token_ids)
+        except (TypeError, ValueError):
+            continue
+        token_ids.extend(str(token_id) for token_id in ids if token_id)
+    return list(dict.fromkeys(token_ids))
+
+
+class OrderBookWriter:
+    """Buffers recorded rows and flushes them to timestamp-ranged parquet chunks."""
+
+    def __init__(self, data_dir: Path = DATA_DIR, chunk_size: int = CHUNK_SIZE):
+        self.data_dir = Path(data_dir)
+        self.chunk_size = chunk_size
+        self._buffers: dict[str, list[dict]] = {"books": [], "price_changes": []}
+
+    def add_book(self, row: dict) -> None:
+        self._append("books", [row])
+
+    def add_price_changes(self, rows: list[dict]) -> None:
+        self._append("price_changes", rows)
+
+    def flush(self) -> None:
+        for table in self._buffers:
+            self._flush_table(table)
+
+    def _append(self, table: str, rows: list[dict]) -> None:
+        self._buffers[table].extend(rows)
+        if len(self._buffers[table]) >= self.chunk_size:
+            self._flush_table(table)
+
+    def _flush_table(self, table: str) -> None:
+        buffer = self._buffers[table]
+        if not buffer:
+            return
+        directory = self.data_dir / table
+        directory.mkdir(parents=True, exist_ok=True)
+        start, end = buffer[0]["timestamp"], buffer[-1]["timestamp"]
+        path = directory / f"{table}_{start}_{end}.parquet"
+        suffix = 1
+        while path.exists():
+            path = directory / f"{table}_{start}_{end}_{suffix}.parquet"
+            suffix += 1
+        pd.DataFrame(buffer).to_parquet(path)
+        self._buffers[table] = []
+        print(f"Flushed {len(buffer)} rows to {path}")
+
+
+class OrderBookRecorder:
+    """Consumes the CLOB market channel and persists book snapshots and deltas."""
+
+    def __init__(
+        self,
+        token_ids: list[str],
+        writer: OrderBookWriter,
+        ws_url: str = WS_MARKET_URL,
+        ping_interval: float = PING_INTERVAL_SECONDS,
+        initial_reconnect_delay: float = INITIAL_RECONNECT_DELAY_SECONDS,
+        connect: Callable | None = None,
+    ):
+        self.token_ids = list(token_ids)
+        self.writer = writer
+        self.ws_url = ws_url
+        self.ping_interval = ping_interval
+        self.initial_reconnect_delay = initial_reconnect_delay
+        self._connect = connect or (lambda: websockets.connect(self.ws_url))
+        self._stop: asyncio.Event | None = None
+
+    def stop(self) -> None:
+        if self._stop is not None:
+            self._stop.set()
+
+    async def record(self) -> None:
+        """Connect, subscribe, and record until stopped; reconnects on disconnect."""
+        self._stop = asyncio.Event()
+        delay = self.initial_reconnect_delay
+        try:
+            while not self._stop.is_set():
+                try:
+                    async with self._connect() as ws:
+                        await self._subscribe(ws)
+                        ping_task = asyncio.create_task(self._ping_loop(ws))
+                        try:
+                            async for raw in ws:
+                                self.handle_message(raw)
+                                delay = self.initial_reconnect_delay
+                                if self._stop.is_set():
+                                    break
+                        finally:
+                            ping_task.cancel()
+                            with contextlib.suppress(Exception, asyncio.CancelledError):
+                                await ping_task
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    print(f"WebSocket error: {exc}")
+                if self._stop.is_set():
+                    break
+                print(f"Disconnected; reconnecting in {delay:.0f}s")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, MAX_RECONNECT_DELAY_SECONDS)
+        finally:
+            self.writer.flush()
+
+    def handle_message(self, raw: str) -> None:
+        """Parse one WebSocket frame and persist any book/price_change events."""
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            return  # PONG heartbeat replies and other non-JSON frames
+        messages = payload if isinstance(payload, list) else [payload]
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            event_type = message.get("event_type")
+            if event_type == "book":
+                self.writer.add_book(self._book_row(message))
+            elif event_type == "price_change":
+                deltas = OrderBookDelta.list_from_message(message)
+                if deltas:
+                    recorded_at = datetime.now(timezone.utc)
+                    self.writer.add_price_changes([{**asdict(delta), "_recorded_at": recorded_at} for delta in deltas])
+
+    @staticmethod
+    def _book_row(message: dict) -> dict:
+        return {
+            "token_id": message.get("asset_id", ""),
+            "condition_id": message.get("market", ""),
+            "timestamp": int(message.get("timestamp", 0) or 0),
+            "hash": message.get("hash", ""),
+            "bids": json.dumps(message.get("bids") or []),
+            "asks": json.dumps(message.get("asks") or []),
+            "_recorded_at": datetime.now(timezone.utc),
+        }
+
+    async def _subscribe(self, ws) -> None:
+        await ws.send(json.dumps({"assets_ids": self.token_ids, "type": "market"}))
+
+    async def _ping_loop(self, ws) -> None:
+        while True:
+            await asyncio.sleep(self.ping_interval)
+            await ws.send("PING")
+
+
+class PolymarketOrderbookRecorder(Indexer):
+    """Records live Polymarket order-book snapshots and price changes."""
+
+    def __init__(self, token_ids: list[str] | None = None, max_markets: int = DISCOVER_MARKET_COUNT):
+        super().__init__(
+            name="polymarket_orderbook",
+            description="Records live CLOB order-book snapshots and price changes to parquet files",
+        )
+        self.token_ids = list(token_ids) if token_ids else None
+        self.max_markets = max_markets
+
+    def run(self) -> None:
+        token_ids = self.token_ids
+        if not token_ids:
+            with PolymarketClient() as client:
+                token_ids = discover_token_ids(client, self.max_markets)
+        if not token_ids:
+            print("No CLOB token IDs to record")
+            return
+
+        print(f"Recording order books for {len(token_ids)} tokens (Ctrl+C to stop)")
+        writer = OrderBookWriter()
+        recorder = OrderBookRecorder(token_ids, writer)
+        try:
+            asyncio.run(recorder.record())
+        except KeyboardInterrupt:
+            writer.flush()
+            print("\nRecording stopped")

--- a/tests/test_orderbook_recorder.py
+++ b/tests/test_orderbook_recorder.py
@@ -1,0 +1,261 @@
+"""Tests for the live orderbook recorder against a mocked market WebSocket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from src.indexers.polymarket.models import OrderBookDelta
+from src.indexers.polymarket.orderbook import OrderBookRecorder, OrderBookWriter
+
+CONDITION_ID = "0x" + "ab" * 32
+
+BOOK_MSG = {
+    "event_type": "book",
+    "asset_id": "111",
+    "market": CONDITION_ID,
+    "bids": [{"price": "0.48", "size": "30"}, {"price": "0.49", "size": "20"}],
+    "asks": [{"price": "0.52", "size": "25"}],
+    "timestamp": "1784254990511",
+    "hash": "0x1234",
+}
+
+PRICE_CHANGE_MSG = {
+    "event_type": "price_change",
+    "market": CONDITION_ID,
+    "price_changes": [
+        {
+            "asset_id": "111",
+            "price": "0.5",
+            "size": "200",
+            "side": "BUY",
+            "hash": "56621a121a47ed93",
+            "best_bid": "0.5",
+            "best_ask": "0.52",
+        },
+        {
+            "asset_id": "111",
+            "price": "0.52",
+            "size": "0",
+            "side": "SELL",
+            "hash": "77731b232b58fe04",
+            "best_bid": "0.5",
+            "best_ask": "0.53",
+        },
+    ],
+    "timestamp": "1784254991000",
+}
+
+
+class FakeSocket:
+    """Mocked market-channel socket: yields scripted frames and records sends."""
+
+    def __init__(self, frames: list[str] = (), error: Exception | None = None, on_drained=None):
+        self.frames = list(frames)
+        self.error = error
+        self.on_drained = on_drained
+        self.sent: list[str] = []
+        self._hold = asyncio.Event()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.frames:
+            return self.frames.pop(0)
+        if self.error is not None:
+            raise self.error
+        if self.on_drained is not None:
+            self.on_drained()
+            raise StopAsyncIteration
+        await self._hold.wait()
+        raise StopAsyncIteration
+
+    async def send(self, data: str):
+        self.sent.append(data)
+
+    def release(self):
+        self._hold.set()
+
+
+def read_table(data_dir: Path, table: str) -> pd.DataFrame:
+    files = sorted((data_dir / table).glob("*.parquet"))
+    assert files, f"no parquet chunks written for {table}"
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+# -- Model parsing -------------------------------------------------------------
+
+
+def test_delta_list_from_message_preserves_raw_strings():
+    deltas = OrderBookDelta.list_from_message(PRICE_CHANGE_MSG)
+
+    assert len(deltas) == 2
+    assert deltas[0].condition_id == CONDITION_ID
+    assert deltas[0].token_id == "111"
+    assert deltas[0].timestamp == 1784254991000
+    assert deltas[0].hash == "56621a121a47ed93"
+    assert (deltas[0].side, deltas[0].price, deltas[0].size) == ("BUY", "0.5", "200")
+    assert (deltas[0].best_bid, deltas[0].best_ask) == ("0.5", "0.52")
+    assert (deltas[1].side, deltas[1].price, deltas[1].size) == ("SELL", "0.52", "0")
+
+
+def test_delta_list_from_legacy_changes_shape():
+    message = {
+        "event_type": "price_change",
+        "market": CONDITION_ID,
+        "asset_id": "222",
+        "hash": "abcd",
+        "changes": [{"price": "0.4", "side": "SELL", "size": "3300"}],
+        "timestamp": "1729084877448",
+    }
+
+    deltas = OrderBookDelta.list_from_message(message)
+
+    assert len(deltas) == 1
+    assert deltas[0].token_id == "222"
+    assert deltas[0].hash == "abcd"
+    assert (deltas[0].side, deltas[0].price, deltas[0].size) == ("SELL", "0.4", "3300")
+    assert deltas[0].best_bid == ""
+
+
+# -- Message handling & persistence ---------------------------------------------
+
+
+def test_book_snapshot_persists_raw_levels_and_hash(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(BOOK_MSG))
+    writer.flush()
+
+    books = read_table(tmp_path, "books")
+    assert len(books) == 1
+    row = books.iloc[0]
+    assert row["token_id"] == "111"
+    assert row["condition_id"] == CONDITION_ID
+    assert row["timestamp"] == 1784254990511  # exchange milliseconds
+    assert row["hash"] == "0x1234"
+    assert json.loads(row["bids"]) == BOOK_MSG["bids"]  # raw levels, string prices intact
+    assert json.loads(row["asks"]) == BOOK_MSG["asks"]
+    assert row["_recorded_at"] is not None
+
+
+def test_price_change_deltas_persist_including_size_zero_removal(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(PRICE_CHANGE_MSG))
+    writer.flush()
+
+    changes = read_table(tmp_path, "price_changes")
+    assert len(changes) == 2
+    assert list(changes["side"]) == ["BUY", "SELL"]
+    assert list(changes["size"]) == ["200", "0"]  # "0" = level removed
+    assert list(changes["price"]) == ["0.5", "0.52"]
+    assert list(changes["best_bid"]) == ["0.5", "0.5"]
+    assert list(changes["best_ask"]) == ["0.52", "0.53"]
+    assert set(changes["timestamp"]) == {1784254991000}
+
+
+def test_non_json_and_unknown_events_are_ignored(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message("PONG")
+    recorder.handle_message(json.dumps({"event_type": "tick_size_change", "asset_id": "111"}))
+    writer.flush()
+
+    assert not (tmp_path / "books").exists()
+    assert not (tmp_path / "price_changes").exists()
+
+
+def test_writer_auto_flushes_at_chunk_size(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path, chunk_size=2)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(BOOK_MSG))
+    assert not (tmp_path / "books").exists()
+    recorder.handle_message(json.dumps(BOOK_MSG))
+
+    files = list((tmp_path / "books").glob("*.parquet"))
+    assert len(files) == 1
+    assert files[0].name == "books_1784254990511_1784254990511.parquet"
+    assert len(pd.read_parquet(files[0])) == 2
+
+
+# -- Live recording over a mocked socket ------------------------------------------
+
+
+def test_record_subscribes_and_persists_stream(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> FakeSocket:
+        # a real feed wraps some frames in a JSON array; both shapes must record
+        socket = FakeSocket(
+            frames=[json.dumps([BOOK_MSG]), json.dumps(PRICE_CHANGE_MSG)],
+            on_drained=lambda: recorder.stop(),
+        )
+        recorder = OrderBookRecorder(["111", "222"], writer, connect=lambda: socket)
+        await recorder.record()
+        return socket
+
+    socket = asyncio.run(main())
+
+    assert json.loads(socket.sent[0]) == {"assets_ids": ["111", "222"], "type": "market"}
+    assert len(read_table(tmp_path, "books")) == 1
+    assert len(read_table(tmp_path, "price_changes")) == 2
+
+
+def test_record_sends_ping_heartbeats(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> FakeSocket:
+        socket = FakeSocket()
+        recorder = OrderBookRecorder(["111"], writer, ping_interval=0.01, connect=lambda: socket)
+        task = asyncio.create_task(recorder.record())
+        await asyncio.sleep(0.06)
+        recorder.stop()
+        socket.release()
+        await task
+        return socket
+
+    socket = asyncio.run(main())
+
+    assert json.loads(socket.sent[0])["type"] == "market"
+    assert socket.sent.count("PING") >= 2
+
+
+def test_record_reconnects_and_resubscribes_after_drop(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> list[FakeSocket]:
+        sockets: list[FakeSocket] = []
+        recorder = OrderBookRecorder(
+            ["111"],
+            writer,
+            initial_reconnect_delay=0,
+            connect=lambda: sockets.pop(0),
+        )
+        sockets.append(FakeSocket(frames=[json.dumps(BOOK_MSG)], error=RuntimeError("connection dropped")))
+        second = FakeSocket(frames=[json.dumps(BOOK_MSG)], on_drained=lambda: recorder.stop())
+        sockets.append(second)
+        first = sockets[0]
+        await recorder.record()
+        return [first, second]
+
+    first, second = asyncio.run(main())
+
+    # both connections must (re)subscribe; the server answers each with a fresh snapshot
+    assert json.loads(first.sent[0]) == {"assets_ids": ["111"], "type": "market"}
+    assert json.loads(second.sent[0]) == {"assets_ids": ["111"], "type": "market"}
+    assert len(read_table(tmp_path, "books")) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -728,7 +728,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -799,7 +799,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1301,7 +1301,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1586,7 +1586,7 @@ name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -1868,16 +1868,16 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "cycler", marker = "python_full_version < '3.10'" },
-    { name = "fonttools", marker = "python_full_version < '3.10'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyparsing", marker = "python_full_version < '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "importlib-resources" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -1933,17 +1933,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.10'" },
-    { name = "fonttools", marker = "python_full_version >= '3.10'" },
-    { name = "kiwisolver", version = "1.4.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver", version = "1.4.9", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "packaging" },
+    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/e2/d2d5295be2f44c678ebaf3544ba32d20c1f9ef08c49fe47f496180e1db15/matplotlib-3.10.7.tar.gz", hash = "sha256:a06ba7e2a2ef9131c79c49e63dad355d2d878413a0376c1727c8b9335ff731c7", size = 34804865, upload-time = "2025-10-09T00:28:00.669Z" }
 wheels = [
@@ -2724,6 +2724,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
     { name = "web3" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -2753,6 +2754,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "web3", specifier = ">=6.0.0" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -3226,13 +3228,13 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -3249,13 +3251,13 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -3525,7 +3527,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -3563,7 +3565,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3623,7 +3625,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [


### PR DESCRIPTION
## What changed? Why?

polymarket has no historical order-book endpoint, so depth data cannot be backfilled after the fact. it only exists if someone was recording it live. this PR adds that recorder, stacked on the polymarket API foundation branch.

- new `src/indexers/polymarket/orderbook.py` with an asyncio `OrderBookRecorder` that subscribes to the CLOB market websocket (`wss://ws-subscriptions-clob.polymarket.com/ws/market`) by `assets_ids`, sends the required `PING` heartbeat every 10 seconds, and reconnects with exponential backoff. reconnects are safe for replay because the server resends a full `book` snapshot on every resubscribe, so gaps only span actual downtime
- persists full `book` snapshots and `price_change` deltas to parquet chunks under `data/polymarket/orderbook/{books,price_changes}/`. prices and sizes are kept as raw strings and the exchange `hash` and millisecond timestamps are preserved, so books can be replayed and verified exactly. `size="0"` rows record level removals
- new `OrderBookDelta` model parses both the documented `price_changes` message shape and the legacy `changes` shape
- `PolymarketOrderbookRecorder` indexer discovers the highest-volume open markets from gamma when no token IDs are given, and shows up in the normal `make index` menu
- since the interactive menu cannot take arguments and a long-lived recorder is usually run headless, there is a minimal explicit entrypoint: `uv run main.py record [token_id ...]` plus a `make record` target
- docs: SCHEMAS.md gains the two orderbook tables (including replay instructions), README gains a live orderbook recording section; both call out that depth must be recorded live
- `websockets` promoted from a transitive dep (via web3) to an explicit dependency; the uv.lock diff is mostly marker normalization from re-locking

## Notes to reviewers

- `src/indexers/polymarket/orderbook.py`: recorder, parquet writer, indexer, and gamma token discovery
- `src/indexers/polymarket/models.py`: new `OrderBookDelta` model
- `tests/test_orderbook_recorder.py`: mocked-websocket tests
- `main.py`, `Makefile`: `record` entrypoint
- `docs/SCHEMAS.md`, `README.md`: schema docs and usage
- no changes to existing API, resolution, storage, or analysis code

## How has it been tested?

- `uv run ruff check .` and `uv run ruff format --check .` pass
- `uv run pytest tests/ -v`: 142 passed, including 9 new mocked-websocket tests covering subscribe payload, book snapshot persistence with raw levels and hash, price_change deltas including `size="0"` removal, PING heartbeat cadence, reconnect + resubscribe after a dropped connection, PONG/unknown-event handling, and chunked parquet flushing
- 25-second live smoke run against the real websocket: 202 book snapshots and 2,088 price_change rows recorded for 200 tokens, parquet contents inspected (raw string levels, int64 millisecond timestamps, non-empty hashes, both sides, 438 removal rows), clean flush on ctrl+c