### PR TITLE
feat(polymarket): condition resolutions indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── resolutions/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -127,6 +127,24 @@ Located at `data/polymarket/fpmm_collateral_lookup.json`, this file maps FPMM co
 | `collateral_address` | string | ERC-20 token address used as collateral |
 | `collateral_symbol` | string | Token symbol (e.g., `USDC`, `USDT`) |
 
+## Polymarket Resolutions
+
+Each row represents a `ConditionResolution` event from the Gnosis ConditionalTokens contract on Polygon, recording the exact on-chain payout for a resolved market.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_number` | int | Polygon block number |
+| `transaction_hash` | string | Blockchain transaction hash |
+| `log_index` | int | Log index within transaction |
+| `condition_id` | string | Condition ID (0x-prefixed hex), joins to `condition_id` in Polymarket Markets |
+| `oracle` | string | Oracle address that reported the payouts |
+| `question_id` | string | Question ID (0x-prefixed hex) |
+| `outcome_slot_count` | int | Number of outcome slots for the condition |
+| `payout_numerators` | string | JSON string of payout numerators, one per outcome slot |
+| `_fetched_at` | datetime | When this record was fetched |
+
+**Note on payout numerators:** `payout_numerators` is stored as a JSON string to avoid integer overflow. The winning outcome is the index of the sole nonzero numerator; conditions with multiple nonzero numerators resolved to split/invalid payouts.
+
 ## Polymarket Blocks
 
 Mapping from Polygon block numbers to timestamps.

--- a/src/indexers/polymarket/resolutions.py
+++ b/src/indexers/polymarket/resolutions.py
@@ -1,0 +1,155 @@
+"""Indexer for Polymarket condition resolutions from the Polygon blockchain."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.blockchain import (
+    CONDITIONAL_TOKENS_START_BLOCK,
+    PolygonClient,
+)
+
+DATA_DIR = Path("data/polymarket/resolutions")
+CURSOR_FILE = Path("data/polymarket/.resolutions_block_cursor")
+
+
+class PolymarketResolutionsIndexer(Indexer):
+    """Fetches and stores Polymarket condition resolutions from the Polygon blockchain."""
+
+    def __init__(
+        self,
+        from_block: Optional[int] = None,
+        to_block: Optional[int] = None,
+        chunk_size: int = 10000,
+    ):
+        super().__init__(
+            name="polymarket_resolutions",
+            description="Backfills Polymarket condition resolutions from Polygon blockchain to parquet files",
+        )
+        self._from_block = from_block
+        self._to_block = to_block
+        self._chunk_size = chunk_size
+
+    def run(self) -> None:
+        """Backfill all Polymarket condition resolutions from the Polygon blockchain.
+
+        This fetches ConditionResolution events from the Gnosis ConditionalTokens
+        contract and saves them to parquet files.
+        """
+        BATCH_SIZE = 10000
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolygonClient()
+        current_block = client.get_block_number()
+
+        # Determine starting block
+        from_block = self._from_block
+        if from_block is None:
+            if CURSOR_FILE.exists():
+                try:
+                    from_block = int(CURSOR_FILE.read_text().strip())
+                    print(f"Resuming from block {from_block}")
+                except (ValueError, TypeError):
+                    from_block = CONDITIONAL_TOKENS_START_BLOCK
+            else:
+                from_block = CONDITIONAL_TOKENS_START_BLOCK
+
+        to_block = self._to_block
+        if to_block is None:
+            to_block = current_block
+
+        print(f"Fetching resolutions from block {from_block} to {to_block}")
+        print(f"Total blocks: {to_block - from_block:,}")
+
+        all_resolutions = []
+        total_saved = 0
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("resolutions_*.parquet"))
+            if not existing:
+                return 0
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + BATCH_SIZE if indices else 0
+
+        def save_batch(resolutions_batch):
+            nonlocal total_saved
+            if not resolutions_batch:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"resolutions_{chunk_idx}_{chunk_idx + BATCH_SIZE}.parquet"
+            df = pd.DataFrame(resolutions_batch)
+            df.to_parquet(chunk_path)
+            total_saved += len(resolutions_batch)
+            tqdm.write(f"Saved {len(resolutions_batch)} resolutions to {chunk_path.name}")
+
+        # Build list of chunk ranges
+        ranges = []
+        current = from_block
+        while current <= to_block:
+            end = min(current + self._chunk_size - 1, to_block)
+            ranges.append((current, end))
+            current = end + 1
+
+        total_chunks = len(ranges)
+        pbar = tqdm(total=total_chunks, desc="Backfilling", unit=" chunks")
+
+        completed = False
+        try:
+            for chunk_start, chunk_end in ranges:
+                fetched_at = datetime.utcnow()
+
+                resolutions = client.get_condition_resolutions(
+                    from_block=chunk_start,
+                    to_block=chunk_end,
+                )
+
+                for resolution in resolutions:
+                    record = asdict(resolution)
+                    # Serialize to a JSON string to avoid parquet overflow
+                    record["payout_numerators"] = json.dumps(record["payout_numerators"])
+                    record["_fetched_at"] = fetched_at
+                    all_resolutions.append(record)
+
+                pbar.update(1)
+                pbar.set_postfix(
+                    block=chunk_end,
+                    buffer=len(all_resolutions),
+                    saved=total_saved,
+                )
+
+                # Save in batches
+                while len(all_resolutions) >= BATCH_SIZE:
+                    save_batch(all_resolutions[:BATCH_SIZE])
+                    all_resolutions = all_resolutions[BATCH_SIZE:]
+
+                # Save cursor after each completed range
+                CURSOR_FILE.write_text(str(chunk_end))
+
+            completed = True
+        except KeyboardInterrupt:
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+            # Flush buffered resolutions so no fetched data is lost on interrupt or error
+            if all_resolutions:
+                save_batch(all_resolutions)
+
+        # Only clean up cursor on successful completion
+        if completed and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        print(f"\nBackfill complete: {total_saved} resolutions saved")

--- a/src/indexers/polymarket/resolutions.py
+++ b/src/indexers/polymarket/resolutions.py
@@ -54,7 +54,9 @@ class PolymarketResolutionsIndexer(Indexer):
         if from_block is None:
             if CURSOR_FILE.exists():
                 try:
-                    from_block = int(CURSOR_FILE.read_text().strip())
+                    # Cursor holds the last completed block; its rows are already
+                    # flushed, so resume at the next block to avoid duplicates
+                    from_block = int(CURSOR_FILE.read_text().strip()) + 1
                     print(f"Resuming from block {from_block}")
                 except (ValueError, TypeError):
                     from_block = CONDITIONAL_TOKENS_START_BLOCK

--- a/tests/test_resolutions_indexer.py
+++ b/tests/test_resolutions_indexer.py
@@ -84,9 +84,12 @@ def test_interrupt_then_resume_completes(isolated_dirs):
         indexer = PolymarketResolutionsIndexer(to_block=5000, chunk_size=1000)
         indexer.run()
 
-    # Should have resumed from the saved cursor, not from the beginning
+    # Should have resumed from the block after the cursor: the cursor block's
+    # rows were already flushed, so re-fetching it would duplicate them
     first_requested = min(start for start, _ in client2.requested_ranges)
-    assert first_requested == saved_block, f"Resume should start from cursor ({saved_block}), not {first_requested}"
+    assert first_requested == saved_block + 1, (
+        f"Resume should start after cursor ({saved_block + 1}), not {first_requested}"
+    )
 
     # Cursor should be cleaned up after successful completion
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"

--- a/tests/test_resolutions_indexer.py
+++ b/tests/test_resolutions_indexer.py
@@ -1,0 +1,149 @@
+"""Test that the resolutions backfill can be interrupted and resumed without losing data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.blockchain import ConditionResolution
+
+
+def make_resolution(block_number: int, payout_numerators: list[int] | None = None) -> ConditionResolution:
+    return ConditionResolution(
+        block_number=block_number,
+        transaction_hash="0xabc",
+        log_index=0,
+        condition_id="0x" + "11" * 32,
+        oracle="0x" + "22" * 20,
+        question_id="0x" + "33" * 32,
+        outcome_slot_count=2,
+        payout_numerators=payout_numerators if payout_numerators is not None else [1, 0],
+    )
+
+
+class FakeClient:
+    """Stub for PolygonClient that tracks which blocks were requested."""
+
+    def __init__(self, *, interrupt_at_block: int | None = None, error_at_block: int | None = None):
+        self._interrupt_at = interrupt_at_block
+        self._error_at = error_at_block
+        self.requested_ranges: list[tuple[int, int]] = []
+
+    def get_block_number(self) -> int:
+        return 5000
+
+    def get_condition_resolutions(self, from_block: int, to_block: int) -> list[ConditionResolution]:
+        if self._interrupt_at is not None and from_block >= self._interrupt_at:
+            raise KeyboardInterrupt
+        if self._error_at is not None and from_block >= self._error_at:
+            raise RuntimeError("rpc exploded")
+        self.requested_ranges.append((from_block, to_block))
+        return [make_resolution(block_number=from_block)]
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "resolutions"
+    cursor_file = tmp_path / ".resolutions_block_cursor"
+    import src.indexers.polymarket.resolutions as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def test_interrupt_then_resume_completes(isolated_dirs):
+    """Interrupt a backfill with Ctrl+C, then resume and finish the job."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    # Run 1: interrupt at block 3000
+    client1 = FakeClient(interrupt_at_block=3000)
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client1):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=5000, chunk_size=1000)
+        indexer.run()
+
+    # Cursor should exist and point to the last completed block
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    saved_block = int(cursor_file.read_text().strip())
+    assert saved_block == 2999, f"Cursor should be at last completed chunk end, got {saved_block}"
+
+    # Buffered rows fetched before the interrupt should have been flushed
+    flushed = pd.concat([pd.read_parquet(f) for f in data_dir.glob("resolutions_*.parquet")])
+    assert len(flushed) == 2, "Resolutions fetched before the interrupt should be flushed to parquet"
+
+    # Run 2: resume with no from_block (reads cursor), no interrupt
+    client2 = FakeClient()
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client2):
+        indexer = PolymarketResolutionsIndexer(to_block=5000, chunk_size=1000)
+        indexer.run()
+
+    # Should have resumed from the saved cursor, not from the beginning
+    first_requested = min(start for start, _ in client2.requested_ranges)
+    assert first_requested == saved_block, f"Resume should start from cursor ({saved_block}), not {first_requested}"
+
+    # Cursor should be cleaned up after successful completion
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_exception_preserves_cursor_and_flushes_buffer(isolated_dirs):
+    """Any exception (not just Ctrl+C) preserves the cursor and flushes buffered rows."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(error_at_block=3000)
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=5000, chunk_size=1000)
+        with pytest.raises(RuntimeError):
+            indexer.run()
+
+    assert cursor_file.exists(), "Cursor file should survive an unexpected exception"
+    assert int(cursor_file.read_text().strip()) == 2999
+
+    flushed = pd.concat([pd.read_parquet(f) for f in data_dir.glob("resolutions_*.parquet")])
+    assert len(flushed) == 2, "Resolutions fetched before the error should be flushed to parquet"
+
+
+def test_parquet_schema_and_winning_outcome_derivable(isolated_dirs):
+    """Saved rows serialize payout_numerators as a JSON string and keep the winning outcome derivable."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient()
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=1999, chunk_size=1000)
+        indexer.run()
+
+    files = list(data_dir.glob("resolutions_*.parquet"))
+    assert len(files) == 1
+    df = pd.read_parquet(files[0])
+    assert list(df.columns) == [
+        "block_number",
+        "transaction_hash",
+        "log_index",
+        "condition_id",
+        "oracle",
+        "question_id",
+        "outcome_slot_count",
+        "payout_numerators",
+        "_fetched_at",
+    ]
+
+    row = df.iloc[0]
+    assert row["block_number"] == 1000
+    assert row["condition_id"] == "0x" + "11" * 32
+    assert row["outcome_slot_count"] == 2
+
+    # payout_numerators is a JSON string from which the winning outcome is derivable
+    numerators = json.loads(row["payout_numerators"])
+    assert numerators == [1, 0]
+    nonzero = [i for i, numerator in enumerate(numerators) if numerator != 0]
+    assert nonzero == [0]


### PR DESCRIPTION
## What changed? Why?

Adds `PolymarketResolutionsIndexer` (`polymarket_resolutions`), a resumable block-range backfill indexer for `ConditionResolution` events from the Gnosis ConditionalTokens contract on Polygon, using the `PolygonClient.get_condition_resolutions` decode support introduced on the foundation branch.

Today the analyses infer market resolution from `outcome_prices` with a `>0.99` / `<0.01` heuristic, silently dropping ambiguously-priced closed markets. This dataset records the exact on-chain payout numerators per condition, keyed by `condition_id` which joins to the markets dataset, so exact resolutions can replace the heuristic in a follow-up PR.

Design follows the existing `PolymarketTradesIndexer` block-cursor pattern:

- Backfills from `CONDITIONAL_TOKENS_START_BLOCK` (contract deployment, block 4023686; env-overridable) with a default chunk size of 10,000 blocks since resolution events are sparse.
- Cursor written to `data/polymarket/.resolutions_block_cursor` after each completed range; preserved on `KeyboardInterrupt` and on any other exception, and deleted only on clean completion.
- Buffered rows are flushed to parquet in a `finally` block, so fetched data is never lost on interrupt or error.
- `payout_numerators` is serialized to a JSON string (the existing parquet big-int convention, cf. legacy trades); every row gets `_fetched_at`.
- Output chunks: `data/polymarket/resolutions/resolutions_{i}_{i+10000}.parquet`.

## Notes to reviewers

- `src/indexers/polymarket/resolutions.py` — new indexer (auto-discovered by `Indexer.load()`, appears in the `make index` menu; zero-arg instantiable).
- `tests/test_resolutions_indexer.py` — new tests: interrupt/resume cursor lifecycle, cursor preservation + buffer flush on unexpected exceptions, and exact parquet schema with the winning outcome derivable from the JSON payout numerators.
- `docs/SCHEMAS.md` — new "Polymarket Resolutions" section documenting every column and the payout-numerator semantics.
- `README.md` — added `resolutions/` to the project-structure tree.

No changes to the decoder, analyses, or the trades indexers. Stacked on `jon-becker/polymarket-resolution-foundation`.

## How has it been tested?

- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- `uv run pytest tests/ -v` — 126 passed (3 new tests in `tests/test_resolutions_indexer.py`; `tests/test_compile.py` auto-covers import and zero-arg instantiation of the new indexer).
- New tests exercise: interrupt at a target block → cursor survives at the last completed range end and buffered rows are flushed; resume starts from the cursor and the cursor is removed on clean completion; a `RuntimeError` mid-run also preserves the cursor and flushes the buffer; saved parquet columns match the documented schema exactly and `payout_numerators` round-trips through JSON.
