### PR TITLE
feat(polymarket): FPMM collateral lookup indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── legacy_trades/
 │       ├── markets/
-│       └── trades/
+│       ├── trades/
+│       └── fpmm_collateral_lookup.json
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)
 ```

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -113,6 +113,8 @@ Each row represents an `FPMMBuy` or `FPMMSell` event from the legacy Fixed Produ
 
 Located at `data/polymarket/fpmm_collateral_lookup.json`, this file maps FPMM contract addresses to their collateral token information. Used to filter legacy trades to only include USDC-collateralized markets.
 
+Produced by the `polymarket_collateral` indexer, which calls `collateralToken()` on each distinct FPMM address found in the legacy trades data and `symbol()` on the returned ERC-20 (recorded as `UNKNOWN` if the symbol cannot be read). The indexer is idempotent: addresses already present in the file are skipped on re-runs.
+
 ```json
 {
   "0x1234...": {

--- a/src/indexers/polymarket/collateral.py
+++ b/src/indexers/polymarket/collateral.py
@@ -1,0 +1,130 @@
+"""Indexer for the Polymarket FPMM collateral token lookup."""
+
+import concurrent.futures
+import json
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+from tqdm import tqdm
+from web3 import Web3
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.blockchain import PolygonClient
+
+# Minimal ABI for FixedProductMarketMaker.collateralToken()
+COLLATERAL_TOKEN_ABI = {
+    "constant": True,
+    "inputs": [],
+    "name": "collateralToken",
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+# Minimal ABI for ERC20.symbol()
+ERC20_SYMBOL_ABI = {
+    "constant": True,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"name": "", "type": "string"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+LEGACY_TRADES_DIR = Path("data/polymarket/legacy_trades")
+LOOKUP_FILE = Path("data/polymarket/fpmm_collateral_lookup.json")
+
+
+class PolymarketCollateralIndexer(Indexer):
+    """Builds the FPMM address -> collateral token lookup from legacy trade data."""
+
+    def __init__(self, max_workers: int = 10):
+        super().__init__(
+            name="polymarket_collateral",
+            description="Builds the FPMM collateral token lookup from Polymarket legacy trades",
+        )
+        self._max_workers = max_workers
+        self._symbol_cache: dict[str, str] = {}
+
+    def _fetch_collateral(self, client: PolygonClient, fpmm_address: str) -> Optional[dict]:
+        """Resolve the collateral token address and symbol for an FPMM contract."""
+        try:
+            fpmm = client.w3.eth.contract(
+                address=Web3.to_checksum_address(fpmm_address),
+                abi=[COLLATERAL_TOKEN_ABI],
+            )
+            collateral_address = fpmm.functions.collateralToken().call()
+        except Exception as e:
+            tqdm.write(f"Error fetching collateral token for {fpmm_address}: {e}")
+            return None
+
+        symbol = self._symbol_cache.get(collateral_address)
+        if symbol is None:
+            try:
+                erc20 = client.w3.eth.contract(
+                    address=Web3.to_checksum_address(collateral_address),
+                    abi=[ERC20_SYMBOL_ABI],
+                )
+                symbol = erc20.functions.symbol().call()
+            except Exception as e:
+                tqdm.write(f"Error fetching symbol for {collateral_address}: {e}")
+                symbol = "UNKNOWN"
+            self._symbol_cache[collateral_address] = symbol
+
+        return {"collateral_address": collateral_address, "collateral_symbol": symbol}
+
+    def run(self) -> None:
+        """Build the FPMM collateral lookup for all distinct FPMM addresses in the legacy trades data.
+
+        The lookup file itself acts as the cursor: known addresses are skipped, and the
+        file is rewritten after each parallel batch so interrupts lose at most one batch.
+        """
+        if not list(LEGACY_TRADES_DIR.glob("trades_*.parquet")):
+            print(f"No legacy trades found in {LEGACY_TRADES_DIR}, nothing to do")
+            return
+
+        LOOKUP_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        lookup: dict[str, dict] = {}
+        if LOOKUP_FILE.exists():
+            try:
+                lookup = json.loads(LOOKUP_FILE.read_text())
+            except ValueError:
+                lookup = {}
+
+        rows = duckdb.sql(f"SELECT DISTINCT fpmm_address FROM '{LEGACY_TRADES_DIR}/trades_*.parquet'").fetchall()
+        addresses = [row[0] for row in rows]
+        to_process = [address for address in addresses if address not in lookup]
+        print(f"Found {len(addresses)} FPMM addresses ({len(to_process)} new)")
+
+        if not to_process:
+            print("Nothing to process")
+            return
+
+        client = PolygonClient()
+        resolved = 0
+        pbar = tqdm(total=len(to_process), desc="Resolving collateral", unit=" fpmm")
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+                for batch_start in range(0, len(to_process), self._max_workers):
+                    batch = to_process[batch_start : batch_start + self._max_workers]
+                    futures = {executor.submit(self._fetch_collateral, client, address): address for address in batch}
+
+                    for future in concurrent.futures.as_completed(futures):
+                        info = future.result()
+                        if info is not None:
+                            lookup[futures[future]] = info
+                            resolved += 1
+                        pbar.update(1)
+
+                    # Persist after each batch so interrupts lose at most one batch
+                    LOOKUP_FILE.write_text(json.dumps(lookup, indent=2))
+
+        except KeyboardInterrupt:
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+
+        print(f"\nCollateral lookup complete: {resolved} new addresses resolved ({len(lookup)} total)")

--- a/tests/test_collateral_indexer.py
+++ b/tests/test_collateral_indexer.py
@@ -1,0 +1,181 @@
+"""Test the FPMM collateral lookup indexer with a stubbed Polygon client."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+USDC = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+DAI = "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+
+FPMM_A = "0x1111111111111111111111111111111111111111"
+FPMM_B = "0x2222222222222222222222222222222222222222"
+FPMM_C = "0x3333333333333333333333333333333333333333"
+
+
+class FakeContractFunction:
+    def __init__(self, result):
+        self._result = result
+
+    def call(self):
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+class FakeEth:
+    """Stub for w3.eth that serves contract calls from canned maps."""
+
+    def __init__(self, client: FakeClient):
+        self._client = client
+
+    def contract(self, address: str, abi: list[dict]):
+        client = self._client
+        if abi[0]["name"] == "collateralToken":
+            client.collateral_calls.append(address)
+            result = client.collateral_map[address]
+            functions = SimpleNamespace(collateralToken=lambda: FakeContractFunction(result))
+        else:
+            client.symbol_calls.append(address)
+            result = client.symbol_map[address]
+            functions = SimpleNamespace(symbol=lambda: FakeContractFunction(result))
+        return SimpleNamespace(functions=functions)
+
+
+class FakeClient:
+    """Stub for PolygonClient that tracks which contracts were queried."""
+
+    def __init__(self, collateral_map: dict, symbol_map: dict):
+        self.collateral_map = collateral_map
+        self.symbol_map = symbol_map
+        self.collateral_calls: list[str] = []
+        self.symbol_calls: list[str] = []
+        self.w3 = SimpleNamespace(eth=FakeEth(self))
+
+
+@pytest.fixture()
+def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point LEGACY_TRADES_DIR and LOOKUP_FILE at temp locations."""
+    trades_dir = tmp_path / "legacy_trades"
+    lookup_file = tmp_path / "fpmm_collateral_lookup.json"
+    import src.indexers.polymarket.collateral as mod
+
+    monkeypatch.setattr(mod, "LEGACY_TRADES_DIR", trades_dir)
+    monkeypatch.setattr(mod, "LOOKUP_FILE", lookup_file)
+    return trades_dir, lookup_file
+
+
+def _write_legacy_trades(trades_dir: Path, addresses: list[str]) -> None:
+    trades_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"fpmm_address": addresses * 2})  # duplicates to exercise DISTINCT
+    df.to_parquet(trades_dir / "trades_0_10000.parquet")
+
+
+def _run_indexer(client: FakeClient, max_workers: int = 10) -> None:
+    from src.indexers.polymarket.collateral import PolymarketCollateralIndexer
+
+    with patch("src.indexers.polymarket.collateral.PolygonClient", return_value=client):
+        PolymarketCollateralIndexer(max_workers=max_workers).run()
+
+
+def test_generates_lookup(isolated_paths):
+    """A fresh run resolves every distinct FPMM address to the documented JSON shape."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B, FPMM_C])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: USDC, FPMM_B: USDC, FPMM_C: DAI},
+        symbol_map={USDC: "USDC", DAI: "DAI"},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {
+        FPMM_A: {"collateral_address": USDC, "collateral_symbol": "USDC"},
+        FPMM_B: {"collateral_address": USDC, "collateral_symbol": "USDC"},
+        FPMM_C: {"collateral_address": DAI, "collateral_symbol": "DAI"},
+    }
+    assert sorted(client.collateral_calls) == sorted([FPMM_A, FPMM_B, FPMM_C])
+
+    # Round-trips with the consumers' USDC filter (cf. polymarket_win_rate_by_price.py)
+    usdc_markets = {addr.lower() for addr, info in lookup.items() if info["collateral_symbol"] == "USDC"}
+    assert usdc_markets == {FPMM_A.lower(), FPMM_B.lower()}
+
+
+def test_idempotent_resume(isolated_paths):
+    """Addresses already in the lookup are skipped; only new ones hit the chain."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B, FPMM_C])
+    lookup_file.write_text(json.dumps({FPMM_A: {"collateral_address": USDC, "collateral_symbol": "USDC"}}))
+
+    client = FakeClient(
+        collateral_map={FPMM_B: USDC, FPMM_C: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client)
+
+    assert len(client.collateral_calls) == 2
+    assert FPMM_A not in client.collateral_calls
+    lookup = json.loads(lookup_file.read_text())
+    assert set(lookup) == {FPMM_A, FPMM_B, FPMM_C}
+
+
+def test_symbol_failure_falls_back_to_unknown(isolated_paths):
+    """A non-standard ERC-20 symbol() failure records UNKNOWN instead of crashing."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: DAI},
+        symbol_map={DAI: Exception("execution reverted")},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {FPMM_A: {"collateral_address": DAI, "collateral_symbol": "UNKNOWN"}}
+
+
+def test_collateral_failure_skips_address(isolated_paths):
+    """An FPMM whose collateralToken() call fails is skipped, not recorded."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: Exception("execution reverted"), FPMM_B: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {FPMM_B: {"collateral_address": USDC, "collateral_symbol": "USDC"}}
+
+
+def test_symbol_cache_deduplicates_token_calls(isolated_paths):
+    """FPMMs sharing a collateral token trigger a single symbol() call."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: USDC, FPMM_B: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client, max_workers=1)
+
+    assert client.symbol_calls == [USDC]
+
+
+def test_empty_data_dir_is_a_noop(isolated_paths):
+    """With no legacy trades parquet files, the indexer returns without touching the lookup."""
+    trades_dir, lookup_file = isolated_paths
+    trades_dir.mkdir(parents=True, exist_ok=True)
+
+    client = FakeClient(collateral_map={}, symbol_map={})
+    _run_indexer(client)
+
+    assert not lookup_file.exists()
+    assert client.collateral_calls == []


### PR DESCRIPTION
## What changed? Why?

`data/polymarket/fpmm_collateral_lookup.json` was an orphaned data artifact: it is documented in `docs/SCHEMAS.md` and consumed by four analyses (plus the test fixtures), but nothing in the repo could regenerate it. This PR adds `PolymarketCollateralIndexer` (`polymarket_collateral`), which makes the file reproducible:

- Discovers distinct `fpmm_address` values from the legacy trades parquet files via duckdb.
- For each new address, calls `collateralToken()` on the FPMM contract (the public getter on the official Gnosis `FixedProductMarketMaker`) and `symbol()` on the returned ERC-20, falling back to `UNKNOWN` for non-standard tokens. Symbols are cached per token address to avoid redundant RPC calls.
- Is idempotent: the JSON file itself is the cursor — known addresses are skipped, and the file is rewritten after each parallel batch so an interrupt loses at most one batch.
- No-ops gracefully when there are no legacy trades parquet files.

The indexer is auto-discovered by `Indexer.load()`, so it appears in the `make index` menu with no registration. Output matches the documented `{collateral_address, collateral_symbol}` shape exactly, including the `collateral_symbol == "USDC"` filter used by the consuming analyses.

## Notes to reviewers

- `src/indexers/polymarket/collateral.py` — new indexer; follows the existing conventions (module-level `LEGACY_TRADES_DIR`/`LOOKUP_FILE` constants for test monkeypatching, minimal event/function ABIs as module constants, `ThreadPoolExecutor` batch fan-out mirroring `fpmm_trades.py`, duckdb `SELECT DISTINCT` mirroring `kalshi/trades.py`).
- `tests/test_collateral_indexer.py` — new mocked tests (no network): fresh generation, idempotent resume with call-count assertions, `symbol()` failure → `UNKNOWN`, `collateralToken()` failure → address skipped, symbol-cache dedup, and empty-data-dir no-op.
- `docs/SCHEMAS.md` — notes that the lookup file is produced by `polymarket_collateral` and how.
- `README.md` — project-structure tree now includes `legacy_trades/` and `fpmm_collateral_lookup.json`.

No changes to markets, CLOB, resolutions, analyses, or shared storage code.

## How has it been tested?

- `make lint` — ruff check and format both pass.
- `make test` — full suite passes: 119 tests, including the 6 new collateral indexer tests and the auto-discovered import/zero-arg instantiation coverage from `test_compile.py`.