### PR TITLE
feat(polymarket): data API market-wide trades indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── data_api_trades/
 │       ├── markets/
 │       └── trades/
 ├── docs/                   # Documentation

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -90,6 +90,31 @@ Each row represents an `OrderFilled` event from the Polygon blockchain.
 
 **Note on Polymarket prices:** Prices are decimals between 0 and 1. A price of 0.65 means the contract costs $0.65 and pays $1.00 if the outcome wins (implied probability: 65%).
 
+## Polymarket Data API Trades
+
+Each row represents a taker-side fill from the public market-wide trade tape at `data-api.polymarket.com/trades`, with denormalized market and trader metadata. This complements the on-chain `OrderFilled` dataset above.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `proxy_wallet` | string | Proxy wallet address of the taker |
+| `side` | string | Taker side: `BUY` or `SELL` |
+| `asset` | string | CLOB token ID traded (decimal string) |
+| `condition_id` | string | Condition ID (hex hash), joins to `markets.condition_id` |
+| `size` | float | Number of outcome shares traded |
+| `price` | float | Execution price (decimal between 0 and 1) |
+| `timestamp` | int | Unix timestamp of the trade (seconds) |
+| `transaction_hash` | string | Polygon transaction hash |
+| `title` | string | Market question (denormalized) |
+| `slug` | string | Market slug (denormalized) |
+| `event_slug` | string | Parent event slug (denormalized) |
+| `outcome` | string | Outcome name traded |
+| `outcome_index` | int | Index of the outcome traded (`-1` if missing) |
+| `name` | string | Trader profile name (denormalized) |
+| `pseudonym` | string | Trader profile pseudonym (denormalized) |
+| `_fetched_at` | datetime | When this record was fetched |
+
+**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The indexer requests `start=1` explicitly for full history; omitting `start` would silently limit results to the API's default ~3-year window. The API caps `offset` at 10,000, so the indexer paginates by timestamp windows and recursively splits any window that overflows the cap.
+
 ## Polymarket Legacy Trades (FPMM)
 
 Each row represents an `FPMMBuy` or `FPMMSell` event from the legacy Fixed Product Market Maker contracts on Polygon. These are trades from before Polymarket migrated to the CTF Exchange (roughly 2020-2022).

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -113,7 +113,7 @@ Each row represents a taker-side fill from the public market-wide trade tape at 
 | `pseudonym` | string | Trader profile pseudonym (denormalized) |
 | `_fetched_at` | datetime | When this record was fetched |
 
-**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The indexer requests `start=1` explicitly for full history; omitting `start` would silently limit results to the API's default ~3-year window. The API caps `offset` at 10,000, so the indexer paginates by timestamp windows and recursively splits any window that overflows the cap.
+**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The API only honors `start`/`end` on market-scoped queries — the unscoped market-wide tape silently ignores them — and caps `offset` at 10,000, so deep history is unreachable without scoping. The indexer therefore iterates condition IDs from the markets dataset above (run `polymarket_markets` first) in small batches, requesting each batch with an explicit `start=1` for full history (omitting `start` silently limits scoped results to the API's default ~3-year window) and recursively splitting any timestamp window that overflows the offset cap.
 
 ## Polymarket Legacy Trades (FPMM)
 

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -2,16 +2,32 @@ from collections.abc import Generator
 from typing import Optional, Union
 
 from src.common.client import HttpClient
-from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+from src.indexers.polymarket.models import DataApiTrade, Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
 CLOB_API_URL = "https://clob.polymarket.com"
+DATA_API_URL = "https://data-api.polymarket.com"
+
+# The Data API `/trades` and `/activity` endpoints return only the most recent
+# ~3 years when `start` is omitted or 0; any positive epoch retrieves from that
+# point, so `start=1` means full history.
+FULL_HISTORY_START = 1
+
+# The Data API hard-caps `offset` at 10,000; deeper scans must narrow the
+# `start`/`end` timestamp window instead of paging further.
+MAX_DATA_API_OFFSET = 10000
 
 
 class PolymarketClient:
-    def __init__(self, gamma_url: str = GAMMA_API_URL, clob_url: str = CLOB_API_URL):
+    def __init__(
+        self,
+        gamma_url: str = GAMMA_API_URL,
+        clob_url: str = CLOB_API_URL,
+        data_api_url: str = DATA_API_URL,
+    ):
         self.gamma_url = gamma_url
         self.clob_url = clob_url
+        self.data_api_url = data_api_url
         self.http = HttpClient(rate_limit=10)
 
     def __enter__(self):
@@ -128,6 +144,85 @@ class PolymarketClient:
 
             if not cursor:
                 break
+
+    # -- Data API --------------------------------------------------------------
+
+    def _get_data_trades_page(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: int = 1000,
+        offset: int = 0,
+        taker_only: bool = True,
+        **kwargs,
+    ) -> tuple[list[DataApiTrade], int]:
+        """Fetch one `/trades` page; returns (parsed trades, raw row count).
+
+        The raw count includes malformed rows that were skipped during parsing,
+        so pagination can detect a short page correctly.
+        """
+        params = {"limit": limit, "offset": offset, "takerOnly": taker_only, **kwargs}
+        if start is not None:
+            params["start"] = start
+        if end is not None:
+            params["end"] = end
+        data = self.http.get(f"{self.data_api_url}/trades", params=params)
+        rows = data if isinstance(data, list) else data.get("trades") or []
+        trades = []
+        for row in rows:
+            try:
+                trades.append(DataApiTrade.from_dict(row))
+            except (AttributeError, TypeError, ValueError):
+                continue
+        return trades, len(rows)
+
+    def get_data_trades(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: int = 1000,
+        offset: int = 0,
+        taker_only: bool = True,
+        **kwargs,
+    ) -> list[DataApiTrade]:
+        """Fetch one page of the market-wide trade tape from the Data API `/trades`.
+
+        `start`/`end` are unix seconds. When `start` is omitted the API returns
+        only the most recent ~3 years; pass `start=FULL_HISTORY_START` (1) for
+        full history. `takerOnly` is always sent explicitly: True yields one row
+        per fill (the taker side), False adds maker-side rows, which
+        double-count a fill when aggregating volume. Malformed rows are skipped.
+        """
+        trades, _ = self._get_data_trades_page(
+            start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **kwargs
+        )
+        return trades
+
+    def get_data_trades_window(
+        self,
+        start: int,
+        end: int,
+        limit: int = 1000,
+        taker_only: bool = True,
+    ) -> tuple[list[DataApiTrade], bool]:
+        """Fetch every `/trades` row in the [start, end] window by paging offsets.
+
+        Returns (trades, truncated). `truncated` is True when the window still
+        had rows beyond the API's 10,000 offset cap — callers must split the
+        window into smaller timestamp ranges to recover the missing rows.
+        """
+        trades: list[DataApiTrade] = []
+        offset = 0
+        while True:
+            page, raw_count = self._get_data_trades_page(
+                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only
+            )
+            trades.extend(page)
+            if raw_count < limit:
+                return trades, False
+            offset += limit
+            if offset > MAX_DATA_API_OFFSET:
+                return trades, True
 
     # -- CLOB API --------------------------------------------------------------
 

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -8,9 +8,11 @@ GAMMA_API_URL = "https://gamma-api.polymarket.com"
 CLOB_API_URL = "https://clob.polymarket.com"
 DATA_API_URL = "https://data-api.polymarket.com"
 
-# The Data API `/trades` and `/activity` endpoints return only the most recent
-# ~3 years when `start` is omitted or 0; any positive epoch retrieves from that
-# point, so `start=1` means full history.
+# The Data API `/trades` and `/activity` endpoints only honor `start`/`end`
+# when the query is scoped by `market` or `user`; the unscoped market-wide
+# tape silently ignores them. Scoped queries return only the most recent
+# ~3 years when `start` is omitted or 0; any positive epoch retrieves from
+# that point, so `start=1` means full history.
 FULL_HISTORY_START = 1
 
 # The Data API hard-caps `offset` at 10,000; deeper scans must narrow the
@@ -185,13 +187,16 @@ class PolymarketClient:
         taker_only: bool = True,
         **kwargs,
     ) -> list[DataApiTrade]:
-        """Fetch one page of the market-wide trade tape from the Data API `/trades`.
+        """Fetch one page of the trade tape from the Data API `/trades`.
 
-        `start`/`end` are unix seconds. When `start` is omitted the API returns
-        only the most recent ~3 years; pass `start=FULL_HISTORY_START` (1) for
-        full history. `takerOnly` is always sent explicitly: True yields one row
-        per fill (the taker side), False adds maker-side rows, which
-        double-count a fill when aggregating volume. Malformed rows are skipped.
+        `start`/`end` are unix seconds (inclusive) and are only honored when
+        the query is scoped by `market` or `user` (pass via kwargs); the
+        unscoped market-wide tape silently ignores them. For scoped queries,
+        omitting `start` returns only the most recent ~3 years; pass
+        `start=FULL_HISTORY_START` (1) for full history. `takerOnly` is always
+        sent explicitly: True yields one row per fill (the taker side), False
+        adds maker-side rows, which double-count a fill when aggregating
+        volume. Malformed rows are skipped.
         """
         trades, _ = self._get_data_trades_page(
             start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **kwargs
@@ -204,18 +209,24 @@ class PolymarketClient:
         end: int,
         limit: int = 1000,
         taker_only: bool = True,
+        market: Optional[str] = None,
     ) -> tuple[list[DataApiTrade], bool]:
         """Fetch every `/trades` row in the [start, end] window by paging offsets.
+
+        `market` is a comma-separated list of condition IDs; the API only
+        honors `start`/`end` on market- or user-scoped queries, so an unscoped
+        window sees the same newest-first tape regardless of bounds.
 
         Returns (trades, truncated). `truncated` is True when the window still
         had rows beyond the API's 10,000 offset cap — callers must split the
         window into smaller timestamp ranges to recover the missing rows.
         """
+        scope = {"market": market} if market else {}
         trades: list[DataApiTrade] = []
         offset = 0
         while True:
             page, raw_count = self._get_data_trades_page(
-                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only
+                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **scope
             )
             trades.extend(page)
             if raw_count < limit:

--- a/src/indexers/polymarket/data_api_trades.py
+++ b/src/indexers/polymarket/data_api_trades.py
@@ -1,0 +1,185 @@
+"""Indexer for the Polymarket Data API market-wide trade tape."""
+
+import time
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
+from src.indexers.polymarket.models import DataApiTrade
+
+DATA_DIR = Path("data/polymarket/data_api_trades")
+CURSOR_FILE = Path("data/polymarket/.data_api_trades_cursor")
+BATCH_SIZE = 10000
+WINDOW_SIZE = 86400  # seconds per timestamp window
+MIN_WINDOW_SIZE = 1  # a window can't be split below one second
+
+
+def _trade_key(trade: DataApiTrade) -> tuple:
+    """Identity of a trade row; the Data API has no explicit trade ID."""
+    return (
+        trade.transaction_hash,
+        trade.proxy_wallet,
+        trade.asset,
+        trade.side,
+        trade.timestamp,
+        trade.size,
+        trade.price,
+    )
+
+
+class PolymarketDataApiTradesIndexer(Indexer):
+    """Backfills the public market-wide trade tape from data-api.polymarket.com."""
+
+    def __init__(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        window_size: int = WINDOW_SIZE,
+        limit: int = 1000,
+    ):
+        super().__init__(
+            name="polymarket_data_api_trades",
+            description="Backfills the Polymarket Data API trade tape to parquet files",
+        )
+        self._start = start
+        self._end = end
+        self._window_size = window_size
+        self._limit = limit
+
+    def run(self) -> None:
+        """Backfill all Data API trades by walking timestamp windows.
+
+        The API caps `offset` at 10,000, so the tape is fetched in [start, end]
+        timestamp windows; any window that overflows the cap is split in half
+        recursively until every returned trade is covered.
+        """
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolymarketClient()
+
+        # Determine starting timestamp; default is explicit full history (start=1),
+        # since omitting `start` silently limits the API to the last ~3 years.
+        start = self._start
+        if start is None:
+            if CURSOR_FILE.exists():
+                try:
+                    start = int(CURSOR_FILE.read_text().strip())
+                    print(f"Resuming from timestamp {start}")
+                except (ValueError, TypeError):
+                    start = FULL_HISTORY_START
+            else:
+                start = FULL_HISTORY_START
+
+        end = self._end
+        if end is None:
+            end = int(time.time())
+
+        print(f"Fetching Data API trades from timestamp {start} to {end}")
+
+        def fetch_window(w_start: int, w_end: int) -> list[DataApiTrade]:
+            trades, truncated = client.get_data_trades_window(w_start, w_end, limit=self._limit, taker_only=True)
+            if not truncated:
+                return trades
+            if w_end - w_start + 1 <= MIN_WINDOW_SIZE:
+                tqdm.write(
+                    f"Warning: window {w_start}-{w_end} overflows the offset cap "
+                    "at minimum window size; trades beyond the cap are dropped"
+                )
+                return trades
+            mid = (w_start + w_end) // 2
+            return fetch_window(w_start, mid) + fetch_window(mid + 1, w_end)
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("trades_*.parquet"))
+            if not existing:
+                return 0
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + BATCH_SIZE if indices else 0
+
+        buffer = []
+        total_saved = 0
+
+        def save_batch(trades_batch):
+            nonlocal total_saved
+            if not trades_batch:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"trades_{chunk_idx}_{chunk_idx + BATCH_SIZE}.parquet"
+            pd.DataFrame(trades_batch).to_parquet(chunk_path)
+            total_saved += len(trades_batch)
+            tqdm.write(f"Saved {len(trades_batch)} trades to {chunk_path.name}")
+
+        # Build list of timestamp windows
+        ranges = []
+        current = start
+        while current <= end:
+            w_end = min(current + self._window_size - 1, end)
+            ranges.append((current, w_end))
+            current = w_end + 1
+
+        pbar = tqdm(total=len(ranges), desc="Backfilling", unit=" windows")
+
+        # Keys seen in the previous window guard against the API returning
+        # boundary rows in two adjacent windows.
+        prev_keys: set = set()
+
+        interrupted = False
+        try:
+            for w_start, w_end in ranges:
+                fetched_at = datetime.utcnow()
+                window_keys: set = set()
+
+                for trade in fetch_window(w_start, w_end):
+                    key = _trade_key(trade)
+                    if key in prev_keys or key in window_keys:
+                        continue
+                    window_keys.add(key)
+                    record = asdict(trade)
+                    record["_fetched_at"] = fetched_at
+                    buffer.append(record)
+
+                prev_keys = window_keys
+
+                pbar.update(1)
+                pbar.set_postfix(
+                    timestamp=w_end,
+                    buffer=len(buffer),
+                    saved=total_saved,
+                )
+
+                while len(buffer) >= BATCH_SIZE:
+                    save_batch(buffer[:BATCH_SIZE])
+                    buffer = buffer[BATCH_SIZE:]
+
+                CURSOR_FILE.write_text(str(w_end + 1))
+
+        except KeyboardInterrupt:
+            interrupted = True
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+
+        # Save remaining trades
+        if buffer:
+            save_batch(buffer)
+
+        # Only clean up cursor on successful completion
+        if not interrupted and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        client.close()
+        print(f"\nBackfill complete: {total_saved} trades saved")

--- a/src/indexers/polymarket/data_api_trades.py
+++ b/src/indexers/polymarket/data_api_trades.py
@@ -1,4 +1,4 @@
-"""Indexer for the Polymarket Data API market-wide trade tape."""
+"""Indexer for the Polymarket Data API trade tape, fetched per market."""
 
 import time
 from dataclasses import asdict
@@ -14,9 +14,10 @@ from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
 from src.indexers.polymarket.models import DataApiTrade
 
 DATA_DIR = Path("data/polymarket/data_api_trades")
+MARKETS_DIR = Path("data/polymarket/markets")
 CURSOR_FILE = Path("data/polymarket/.data_api_trades_cursor")
 BATCH_SIZE = 10000
-WINDOW_SIZE = 86400  # seconds per timestamp window
+MARKETS_PER_REQUEST = 20  # condition IDs per `market` query parameter
 MIN_WINDOW_SIZE = 1  # a window can't be split below one second
 
 
@@ -33,14 +34,44 @@ def _trade_key(trade: DataApiTrade) -> tuple:
     )
 
 
+def _load_condition_ids() -> list[str]:
+    """Condition IDs from the markets dataset, in stable dataset order."""
+    files = sorted(MARKETS_DIR.glob("markets_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    ids: list[str] = []
+    seen: set[str] = set()
+    for path in files:
+        for cid in pd.read_parquet(path, columns=["condition_id"])["condition_id"]:
+            if cid and cid not in seen:
+                seen.add(cid)
+                ids.append(cid)
+    return ids
+
+
+def _read_cursor() -> tuple[int, Optional[int]]:
+    """Parse the cursor file into (market index, optional window resume timestamp)."""
+    try:
+        idx_part, _, ts_part = CURSOR_FILE.read_text().strip().partition(",")
+        return int(idx_part), int(ts_part) if ts_part else None
+    except (ValueError, TypeError):
+        return 0, None
+
+
 class PolymarketDataApiTradesIndexer(Indexer):
-    """Backfills the public market-wide trade tape from data-api.polymarket.com."""
+    """Backfills the public trade tape from data-api.polymarket.com per market.
+
+    The API only honors `start`/`end` on market-scoped queries (the unscoped
+    market-wide tape silently ignores them) and caps `offset` at 10,000, so
+    deep history is unreachable without scoping. The indexer iterates
+    condition IDs from the markets dataset in batches, fetches each batch's
+    full trade history, and recursively splits any timestamp window that
+    overflows the offset cap.
+    """
 
     def __init__(
         self,
         start: Optional[int] = None,
         end: Optional[int] = None,
-        window_size: int = WINDOW_SIZE,
+        markets_per_request: int = MARKETS_PER_REQUEST,
         limit: int = 1000,
     ):
         super().__init__(
@@ -49,52 +80,56 @@ class PolymarketDataApiTradesIndexer(Indexer):
         )
         self._start = start
         self._end = end
-        self._window_size = window_size
+        self._markets_per_request = markets_per_request
         self._limit = limit
 
     def run(self) -> None:
-        """Backfill all Data API trades by walking timestamp windows.
+        """Backfill Data API trades for every known market.
 
-        The API caps `offset` at 10,000, so the tape is fetched in [start, end]
-        timestamp windows; any window that overflows the cap is split in half
-        recursively until every returned trade is covered.
+        Progress is cursored as `<market index>[,<window timestamp>]` so both
+        an interrupt between markets and one inside a large market's window
+        walk resume without refetching completed work.
         """
+        condition_ids = _load_condition_ids()
+        if not condition_ids:
+            print(f"No markets found in {MARKETS_DIR}; run the polymarket_markets indexer first")
+            return
+
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         client = PolymarketClient()
 
-        # Determine starting timestamp; default is explicit full history (start=1),
-        # since omitting `start` silently limits the API to the last ~3 years.
-        start = self._start
-        if start is None:
-            if CURSOR_FILE.exists():
-                try:
-                    start = int(CURSOR_FILE.read_text().strip())
-                    print(f"Resuming from timestamp {start}")
-                except (ValueError, TypeError):
-                    start = FULL_HISTORY_START
-            else:
-                start = FULL_HISTORY_START
+        # Explicit full history by default: scoped queries without `start`
+        # (or with 0) are silently limited to the API's ~3-year window.
+        start = self._start if self._start is not None else FULL_HISTORY_START
+        end = self._end if self._end is not None else int(time.time())
 
-        end = self._end
-        if end is None:
-            end = int(time.time())
+        market_idx, resume_ts = 0, None
+        if CURSOR_FILE.exists():
+            market_idx, resume_ts = _read_cursor()
+            if market_idx or resume_ts:
+                suffix = f" at timestamp {resume_ts}" if resume_ts else ""
+                print(f"Resuming from market {market_idx}{suffix}")
 
-        print(f"Fetching Data API trades from timestamp {start} to {end}")
+        print(f"Fetching Data API trades for {len(condition_ids)} markets, timestamps {start} to {end}")
 
-        def fetch_window(w_start: int, w_end: int) -> list[DataApiTrade]:
-            trades, truncated = client.get_data_trades_window(w_start, w_end, limit=self._limit, taker_only=True)
-            if not truncated:
-                return trades
-            if w_end - w_start + 1 <= MIN_WINDOW_SIZE:
+        def iter_leaf_windows(market: str, w_start: int, w_end: int):
+            """Yield (window end, trades) in timestamp order for windows under the offset cap."""
+            trades, truncated = client.get_data_trades_window(
+                w_start, w_end, limit=self._limit, taker_only=True, market=market
+            )
+            if truncated and w_end - w_start + 1 > MIN_WINDOW_SIZE:
+                mid = (w_start + w_end) // 2
+                yield from iter_leaf_windows(market, w_start, mid)
+                yield from iter_leaf_windows(market, mid + 1, w_end)
+                return
+            if truncated:
                 tqdm.write(
                     f"Warning: window {w_start}-{w_end} overflows the offset cap "
                     "at minimum window size; trades beyond the cap are dropped"
                 )
-                return trades
-            mid = (w_start + w_end) // 2
-            return fetch_window(w_start, mid) + fetch_window(mid + 1, w_end)
+            yield w_end, trades
 
         def get_next_chunk_idx():
             existing = list(DATA_DIR.glob("trades_*.parquet"))
@@ -123,49 +158,47 @@ class PolymarketDataApiTradesIndexer(Indexer):
             total_saved += len(trades_batch)
             tqdm.write(f"Saved {len(trades_batch)} trades to {chunk_path.name}")
 
-        # Build list of timestamp windows
-        ranges = []
-        current = start
-        while current <= end:
-            w_end = min(current + self._window_size - 1, end)
-            ranges.append((current, w_end))
-            current = w_end + 1
-
-        pbar = tqdm(total=len(ranges), desc="Backfilling", unit=" windows")
-
-        # Keys seen in the previous window guard against the API returning
-        # boundary rows in two adjacent windows.
-        prev_keys: set = set()
+        pbar = tqdm(
+            total=len(condition_ids),
+            initial=min(market_idx, len(condition_ids)),
+            desc="Backfilling",
+            unit=" markets",
+        )
 
         interrupted = False
         try:
-            for w_start, w_end in ranges:
+            while market_idx < len(condition_ids):
+                batch = condition_ids[market_idx : market_idx + self._markets_per_request]
+                batch_start = resume_ts if resume_ts is not None else start
+                resume_ts = None
                 fetched_at = datetime.utcnow()
-                window_keys: set = set()
 
-                for trade in fetch_window(w_start, w_end):
-                    key = _trade_key(trade)
-                    if key in prev_keys or key in window_keys:
-                        continue
-                    window_keys.add(key)
-                    record = asdict(trade)
-                    record["_fetched_at"] = fetched_at
-                    buffer.append(record)
+                # Keys seen in the previous window guard against the API
+                # returning boundary rows in two adjacent windows.
+                prev_keys: set = set()
+                for w_end, trades in iter_leaf_windows(",".join(batch), batch_start, end):
+                    window_keys: set = set()
+                    for trade in trades:
+                        key = _trade_key(trade)
+                        if key in prev_keys or key in window_keys:
+                            continue
+                        window_keys.add(key)
+                        record = asdict(trade)
+                        record["_fetched_at"] = fetched_at
+                        buffer.append(record)
+                    prev_keys = window_keys
 
-                prev_keys = window_keys
+                    while len(buffer) >= BATCH_SIZE:
+                        save_batch(buffer[:BATCH_SIZE])
+                        buffer = buffer[BATCH_SIZE:]
 
-                pbar.update(1)
-                pbar.set_postfix(
-                    timestamp=w_end,
-                    buffer=len(buffer),
-                    saved=total_saved,
-                )
+                    if w_end < end:
+                        CURSOR_FILE.write_text(f"{market_idx},{w_end + 1}")
 
-                while len(buffer) >= BATCH_SIZE:
-                    save_batch(buffer[:BATCH_SIZE])
-                    buffer = buffer[BATCH_SIZE:]
-
-                CURSOR_FILE.write_text(str(w_end + 1))
+                market_idx += len(batch)
+                pbar.update(len(batch))
+                pbar.set_postfix(buffer=len(buffer), saved=total_saved)
+                CURSOR_FILE.write_text(str(market_idx))
 
         except KeyboardInterrupt:
             interrupted = True

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -103,6 +103,45 @@ class PricePoint:
 
 
 @dataclass
+class DataApiTrade:
+    proxy_wallet: str
+    side: str  # taker side: BUY or SELL
+    asset: str  # CLOB token ID (decimal string, kept as string to avoid overflow)
+    condition_id: str
+    size: float  # outcome shares traded
+    price: float  # execution price, 0-1 decimal
+    timestamp: int  # unix seconds
+    transaction_hash: str
+    title: str = ""
+    slug: str = ""
+    event_slug: str = ""
+    outcome: str = ""
+    outcome_index: int = -1
+    name: str = ""
+    pseudonym: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DataApiTrade":
+        return cls(
+            proxy_wallet=data.get("proxyWallet", ""),
+            side=data.get("side", ""),
+            asset=str(data.get("asset", "")),
+            condition_id=data.get("conditionId", ""),
+            size=float(data.get("size", 0) or 0),
+            price=float(data.get("price", 0) or 0),
+            timestamp=int(data.get("timestamp", 0) or 0),
+            transaction_hash=data.get("transactionHash", ""),
+            title=data.get("title", ""),
+            slug=data.get("slug", ""),
+            event_slug=data.get("eventSlug", ""),
+            outcome=data.get("outcome", ""),
+            outcome_index=int(data.get("outcomeIndex", -1) if data.get("outcomeIndex") is not None else -1),
+            name=data.get("name", ""),
+            pseudonym=data.get("pseudonym", ""),
+        )
+
+
+@dataclass
 class OrderBookLevel:
     price: float
     size: float

--- a/tests/test_data_api_trades_indexer.py
+++ b/tests/test_data_api_trades_indexer.py
@@ -1,0 +1,195 @@
+"""Tests for the Data API trades indexer: windowing, splitting, resume, dedup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.client import FULL_HISTORY_START
+from src.indexers.polymarket.models import DataApiTrade
+
+
+def make_trade(timestamp: int, tx: str = "0xabc", asset: str = "111", **kwargs) -> DataApiTrade:
+    fields = {
+        "proxy_wallet": "0x01",
+        "side": "BUY",
+        "asset": asset,
+        "condition_id": "0xcc",
+        "size": 1.0,
+        "price": 0.5,
+        "timestamp": timestamp,
+        "transaction_hash": tx,
+    }
+    fields.update(kwargs)
+    return DataApiTrade(**fields)
+
+
+class FakeClient:
+    """Stub for PolymarketClient serving a fixed tape of trades by timestamp."""
+
+    def __init__(
+        self,
+        tape: list[DataApiTrade],
+        *,
+        overflow_threshold: int | None = None,
+        interrupt_at: int | None = None,
+    ):
+        self.tape = sorted(tape, key=lambda t: t.timestamp)
+        self.overflow_threshold = overflow_threshold
+        self.interrupt_at = interrupt_at
+        self.requested_windows: list[tuple[int, int]] = []
+        self.taker_only_args: list[bool] = []
+
+    def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
+        if self.interrupt_at is not None and start >= self.interrupt_at:
+            raise KeyboardInterrupt
+        self.requested_windows.append((start, end))
+        self.taker_only_args.append(taker_only)
+        rows = [t for t in self.tape if start <= t.timestamp <= end]
+        if self.overflow_threshold is not None and len(rows) > self.overflow_threshold:
+            return rows[: self.overflow_threshold], True
+        return rows, False
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "data_api_trades"
+    cursor_file = tmp_path / ".data_api_trades_cursor"
+    import src.indexers.polymarket.data_api_trades as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def read_all(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("trades_*.parquet"))
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def run_indexer(client: FakeClient, **kwargs):
+    from src.indexers.polymarket.data_api_trades import PolymarketDataApiTradesIndexer
+
+    with patch("src.indexers.polymarket.data_api_trades.PolymarketClient", return_value=client):
+        PolymarketDataApiTradesIndexer(**kwargs).run()
+
+
+def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
+    import src.indexers.polymarket.data_api_trades as mod
+
+    monkeypatch.setattr(mod, "BATCH_SIZE", 2)
+    data_dir, cursor_file = isolated_dirs
+    client = FakeClient([make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 199, 200, 299]])
+
+    run_indexer(client, start=100, end=299, window_size=100)
+
+    assert client.requested_windows == [(100, 199), (200, 299)]
+    assert all(client.taker_only_args), "takerOnly must be sent explicitly as True"
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 150, 199, 200, 299]
+    assert "_fetched_at" in df.columns
+    assert df["asset"].map(type).eq(str).all(), "token IDs must be stored as strings"
+
+    # Chunked in BATCH_SIZE files: 2 + 2 + 1 rows
+    files = sorted(data_dir.glob("trades_*.parquet"))
+    assert [f.name for f in files] == ["trades_0_2.parquet", "trades_2_4.parquet", "trades_4_6.parquet"]
+    assert not cursor_file.exists(), "Cursor should be removed after clean completion"
+
+
+def test_default_start_is_full_history(isolated_dirs):
+    _, _ = isolated_dirs
+    client = FakeClient([make_trade(50)])
+
+    run_indexer(client, end=200, window_size=1000)
+
+    assert client.requested_windows == [(FULL_HISTORY_START, 200)]
+
+
+def test_explicit_start_overrides_cursor(isolated_dirs):
+    data_dir, cursor_file = isolated_dirs
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+    cursor_file.write_text("150")
+    client = FakeClient([make_trade(60)])
+
+    run_indexer(client, start=50, end=99, window_size=100)
+
+    assert client.requested_windows == [(50, 99)]
+    assert read_all(data_dir)["timestamp"].tolist() == [60]
+
+
+def test_overflowing_window_is_split_until_it_fits(isolated_dirs):
+    data_dir, _ = isolated_dirs
+    trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
+    client = FakeClient(trades, overflow_threshold=3)
+
+    run_indexer(client, start=100, end=199, window_size=100)
+
+    # The full window overflows the offset cap and must be split recursively
+    assert (100, 199) in client.requested_windows
+    assert len(client.requested_windows) > 1
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105], "every trade must be recovered via splits"
+
+
+def test_overflowing_single_second_window_keeps_partial_rows(isolated_dirs, capsys):
+    data_dir, _ = isolated_dirs
+    # 5 trades in the same second cannot be separated by timestamp windows
+    trades = [make_trade(100, tx=f"0x{i}") for i in range(5)]
+    client = FakeClient(trades, overflow_threshold=3)
+
+    run_indexer(client, start=100, end=100, window_size=100)
+
+    df = read_all(data_dir)
+    assert len(df) == 3, "rows up to the cap are kept for an unsplittable window"
+    assert "overflows the offset cap" in capsys.readouterr().out
+
+
+def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
+    data_dir, cursor_file = isolated_dirs
+    tape = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 250, 350]]
+
+    # Run 1: interrupt when the second window (starting at 200) is requested
+    run_indexer(FakeClient(tape, interrupt_at=200), start=100, end=399, window_size=100)
+
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    assert int(cursor_file.read_text().strip()) == 200, "Cursor should point at the next unfetched timestamp"
+
+    # Run 2: resume with no start (reads cursor), no interrupt
+    client2 = FakeClient(tape)
+    run_indexer(client2, end=399, window_size=100)
+
+    assert client2.requested_windows == [(200, 299), (300, 399)], "Resume should start from the cursor"
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 150, 250, 350]
+    assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
+
+
+def test_duplicate_rows_within_and_across_windows_are_deduped(isolated_dirs):
+    data_dir, _ = isolated_dirs
+    boundary = make_trade(199, tx="0xdup")
+
+    class SloppyClient(FakeClient):
+        """Returns a duplicated row in-window and a boundary row in both windows."""
+
+        def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
+            self.requested_windows.append((start, end))
+            if start == 100:
+                return [make_trade(150, tx="0x150"), make_trade(150, tx="0x150"), boundary], False
+            return [boundary, make_trade(250, tx="0x250")], False
+
+    client = SloppyClient([])
+    run_indexer(client, start=100, end=299, window_size=100)
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [150, 199, 250]

--- a/tests/test_data_api_trades_indexer.py
+++ b/tests/test_data_api_trades_indexer.py
@@ -1,4 +1,4 @@
-"""Tests for the Data API trades indexer: windowing, splitting, resume, dedup."""
+"""Tests for the Data API trades indexer: market fan-out, splitting, resume, dedup."""
 
 from __future__ import annotations
 
@@ -28,27 +28,35 @@ def make_trade(timestamp: int, tx: str = "0xabc", asset: str = "111", **kwargs) 
 
 
 class FakeClient:
-    """Stub for PolymarketClient serving a fixed tape of trades by timestamp."""
+    """Stub for PolymarketClient serving a per-market tape of trades."""
 
     def __init__(
         self,
-        tape: list[DataApiTrade],
+        tapes: dict[str, list[DataApiTrade]],
         *,
         overflow_threshold: int | None = None,
-        interrupt_at: int | None = None,
+        interrupt_at_market: str | None = None,
+        interrupt_at_window: int | None = None,
     ):
-        self.tape = sorted(tape, key=lambda t: t.timestamp)
+        self.tapes = {cid: sorted(tape, key=lambda t: t.timestamp) for cid, tape in tapes.items()}
         self.overflow_threshold = overflow_threshold
-        self.interrupt_at = interrupt_at
-        self.requested_windows: list[tuple[int, int]] = []
+        self.interrupt_at_market = interrupt_at_market
+        self.interrupt_at_window = interrupt_at_window
+        self.requested: list[tuple[str, int, int]] = []
         self.taker_only_args: list[bool] = []
 
-    def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
-        if self.interrupt_at is not None and start >= self.interrupt_at:
+    def get_data_trades_window(self, start, end, limit=1000, taker_only=True, market=None):
+        cids = market.split(",") if market else []
+        if self.interrupt_at_market is not None and self.interrupt_at_market in cids:
             raise KeyboardInterrupt
-        self.requested_windows.append((start, end))
+        if self.interrupt_at_window is not None and start >= self.interrupt_at_window:
+            raise KeyboardInterrupt
+        self.requested.append((market, start, end))
         self.taker_only_args.append(taker_only)
-        rows = [t for t in self.tape if start <= t.timestamp <= end]
+        rows = sorted(
+            (t for cid in cids for t in self.tapes.get(cid, []) if start <= t.timestamp <= end),
+            key=lambda t: t.timestamp,
+        )
         if self.overflow_threshold is not None and len(rows) > self.overflow_threshold:
             return rows[: self.overflow_threshold], True
         return rows, False
@@ -59,14 +67,22 @@ class FakeClient:
 
 @pytest.fixture()
 def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    """Point DATA_DIR, MARKETS_DIR, and CURSOR_FILE at temp directories."""
     data_dir = tmp_path / "data_api_trades"
+    markets_dir = tmp_path / "markets"
     cursor_file = tmp_path / ".data_api_trades_cursor"
     import src.indexers.polymarket.data_api_trades as mod
 
     monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "MARKETS_DIR", markets_dir)
     monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
-    return data_dir, cursor_file
+    return data_dir, markets_dir, cursor_file
+
+
+def write_markets(markets_dir: Path, condition_ids: list[str]):
+    markets_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"condition_id": condition_ids})
+    df.to_parquet(markets_dir / f"markets_0_{len(condition_ids)}.parquet")
 
 
 def read_all(data_dir: Path) -> pd.DataFrame:
@@ -81,16 +97,24 @@ def run_indexer(client: FakeClient, **kwargs):
         PolymarketDataApiTradesIndexer(**kwargs).run()
 
 
-def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
+def test_markets_are_batched_and_all_trades_saved(isolated_dirs, monkeypatch):
     import src.indexers.polymarket.data_api_trades as mod
 
     monkeypatch.setattr(mod, "BATCH_SIZE", 2)
-    data_dir, cursor_file = isolated_dirs
-    client = FakeClient([make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 199, 200, 299]])
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    # Duplicate and empty condition IDs in the dataset must be ignored
+    write_markets(markets_dir, ["0xa", "0xb", "0xa", "", "0xc"])
+    client = FakeClient(
+        {
+            "0xa": [make_trade(100, tx="0x100"), make_trade(150, tx="0x150")],
+            "0xb": [make_trade(199, tx="0x199"), make_trade(200, tx="0x200")],
+            "0xc": [make_trade(299, tx="0x299")],
+        }
+    )
 
-    run_indexer(client, start=100, end=299, window_size=100)
+    run_indexer(client, start=100, end=299, markets_per_request=2)
 
-    assert client.requested_windows == [(100, 199), (200, 299)]
+    assert client.requested == [("0xa,0xb", 100, 299), ("0xc", 100, 299)]
     assert all(client.taker_only_args), "takerOnly must be sent explicitly as True"
 
     df = read_all(data_dir)
@@ -105,69 +129,76 @@ def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
 
 
 def test_default_start_is_full_history(isolated_dirs):
-    _, _ = isolated_dirs
-    client = FakeClient([make_trade(50)])
+    _, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
+    client = FakeClient({"0xa": [make_trade(50)]})
 
-    run_indexer(client, end=200, window_size=1000)
+    run_indexer(client, end=200)
 
-    assert client.requested_windows == [(FULL_HISTORY_START, 200)]
+    assert client.requested == [("0xa", FULL_HISTORY_START, 200)]
 
 
-def test_explicit_start_overrides_cursor(isolated_dirs):
-    data_dir, cursor_file = isolated_dirs
-    cursor_file.parent.mkdir(parents=True, exist_ok=True)
-    cursor_file.write_text("150")
-    client = FakeClient([make_trade(60)])
+def test_missing_markets_dataset_is_graceful(isolated_dirs, capsys):
+    data_dir, _, _ = isolated_dirs
+    client = FakeClient({})
 
-    run_indexer(client, start=50, end=99, window_size=100)
+    run_indexer(client)
 
-    assert client.requested_windows == [(50, 99)]
-    assert read_all(data_dir)["timestamp"].tolist() == [60]
+    assert "run the polymarket_markets indexer first" in capsys.readouterr().out
+    assert not data_dir.exists()
+    assert client.requested == []
 
 
 def test_overflowing_window_is_split_until_it_fits(isolated_dirs):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
-    client = FakeClient(trades, overflow_threshold=3)
+    client = FakeClient({"0xa": trades}, overflow_threshold=3)
 
-    run_indexer(client, start=100, end=199, window_size=100)
+    run_indexer(client, start=100, end=199)
 
     # The full window overflows the offset cap and must be split recursively
-    assert (100, 199) in client.requested_windows
-    assert len(client.requested_windows) > 1
+    assert ("0xa", 100, 199) in client.requested
+    assert len(client.requested) > 1
 
     df = read_all(data_dir)
     assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105], "every trade must be recovered via splits"
 
 
 def test_overflowing_single_second_window_keeps_partial_rows(isolated_dirs, capsys):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     # 5 trades in the same second cannot be separated by timestamp windows
     trades = [make_trade(100, tx=f"0x{i}") for i in range(5)]
-    client = FakeClient(trades, overflow_threshold=3)
+    client = FakeClient({"0xa": trades}, overflow_threshold=3)
 
-    run_indexer(client, start=100, end=100, window_size=100)
+    run_indexer(client, start=100, end=100)
 
     df = read_all(data_dir)
     assert len(df) == 3, "rows up to the cap are kept for an unsplittable window"
     assert "overflows the offset cap" in capsys.readouterr().out
 
 
-def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
-    data_dir, cursor_file = isolated_dirs
-    tape = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 250, 350]]
+def test_interrupt_then_resume_skips_completed_markets(isolated_dirs):
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    write_markets(markets_dir, ["0xa", "0xb", "0xc"])
+    tapes = {
+        "0xa": [make_trade(100, tx="0x100"), make_trade(150, tx="0x150")],
+        "0xb": [make_trade(250, tx="0x250")],
+        "0xc": [make_trade(350, tx="0x350")],
+    }
 
-    # Run 1: interrupt when the second window (starting at 200) is requested
-    run_indexer(FakeClient(tape, interrupt_at=200), start=100, end=399, window_size=100)
+    # Run 1: interrupt when market 0xb is requested
+    run_indexer(FakeClient(tapes, interrupt_at_market="0xb"), start=100, end=399, markets_per_request=1)
 
     assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
-    assert int(cursor_file.read_text().strip()) == 200, "Cursor should point at the next unfetched timestamp"
+    assert cursor_file.read_text().strip() == "1", "Cursor should point at the next unfetched market"
 
-    # Run 2: resume with no start (reads cursor), no interrupt
-    client2 = FakeClient(tape)
-    run_indexer(client2, end=399, window_size=100)
+    # Run 2: resume from the cursor, no interrupt
+    client2 = FakeClient(tapes)
+    run_indexer(client2, start=100, end=399, markets_per_request=1)
 
-    assert client2.requested_windows == [(200, 299), (300, 399)], "Resume should start from the cursor"
+    assert client2.requested == [("0xb", 100, 399), ("0xc", 100, 399)], "Resume should skip completed markets"
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
 
     df = read_all(data_dir)
@@ -175,21 +206,51 @@ def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
     assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
 
 
+def test_interrupt_inside_market_resumes_from_window_cursor(isolated_dirs):
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
+    trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
+
+    # Run 1: overflow forces splitting into leaf windows; interrupt once the
+    # window walk reaches timestamp 104, after leaves [100,101] and [102,103].
+    run_indexer(
+        FakeClient({"0xa": trades}, overflow_threshold=3, interrupt_at_window=104),
+        start=100,
+        end=199,
+    )
+
+    idx, ts = cursor_file.read_text().strip().split(",")
+    assert (idx, int(ts)) == ("0", 104), "Cursor should point inside the interrupted market"
+    assert sorted(read_all(data_dir)["timestamp"]) == [100, 101, 102, 103]
+
+    # Run 2: resume mid-market without refetching completed windows
+    client2 = FakeClient({"0xa": trades})
+    run_indexer(client2, start=100, end=199)
+
+    assert client2.requested == [("0xa", 104, 199)]
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105]
+    assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
+
+
 def test_duplicate_rows_within_and_across_windows_are_deduped(isolated_dirs):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     boundary = make_trade(199, tx="0xdup")
 
     class SloppyClient(FakeClient):
-        """Returns a duplicated row in-window and a boundary row in both windows."""
+        """Splits once, returns a duplicated row in-window and a boundary row in both leaves."""
 
-        def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
-            self.requested_windows.append((start, end))
-            if start == 100:
+        def get_data_trades_window(self, start, end, limit=1000, taker_only=True, market=None):
+            self.requested.append((market, start, end))
+            if (start, end) == (100, 299):
+                return [], True
+            if end <= 199:
                 return [make_trade(150, tx="0x150"), make_trade(150, tx="0x150"), boundary], False
             return [boundary, make_trade(250, tx="0x250")], False
 
-    client = SloppyClient([])
-    run_indexer(client, start=100, end=299, window_size=100)
+    client = SloppyClient({})
+    run_indexer(client, start=100, end=299)
 
     df = read_all(data_dir)
     assert sorted(df["timestamp"]) == [150, 199, 250]

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -375,6 +375,19 @@ def test_get_data_trades_window_truncates_at_offset_cap(monkeypatch):
     assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
 
 
+def test_get_data_trades_window_scopes_by_market():
+    client = make_client([[DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, market="0xaa,0xbb")
+
+    assert len(trades) == 1
+    assert truncated is False
+    params = client.http.calls[0][1]
+    assert params["market"] == "0xaa,0xbb"
+    assert params["start"] == 1
+    assert params["end"] == 100
+
+
 def test_get_data_trades_window_counts_raw_rows_for_pagination():
     malformed = dict(DATA_API_TRADE, size="not-a-number")
     client = make_client([[DATA_API_TRADE, malformed], [DATA_API_TRADE]])

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
-from src.indexers.polymarket.client import PolymarketClient
-from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+import src.indexers.polymarket.client as client_module
+from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
+from src.indexers.polymarket.models import DataApiTrade, Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_MARKET = {
     "id": "500000",
@@ -39,6 +40,24 @@ GAMMA_EVENT = {
     "startDate": "2026-06-04T00:00:00Z",
     "endDate": "2026-06-22T00:00:00Z",
     "createdAt": "2026-05-27T14:40:02.074Z",
+}
+
+DATA_API_TRADE = {
+    "proxyWallet": "0x" + "ef" * 20,
+    "side": "BUY",
+    "asset": "111",
+    "conditionId": "0x" + "ab" * 32,
+    "size": "10.5",
+    "price": "0.65",
+    "timestamp": 1752700000,
+    "transactionHash": "0x" + "12" * 32,
+    "title": "Will it rain tomorrow?",
+    "slug": "will-it-rain-tomorrow",
+    "eventSlug": "weather-week",
+    "outcome": "Yes",
+    "outcomeIndex": 0,
+    "name": "trader",
+    "pseudonym": "Quiet-Fox",
 }
 
 ORDER_BOOK = {
@@ -259,6 +278,114 @@ def test_iter_events_keyset_resumes_from_cursor():
     url, params = client.http.calls[0]
     assert url == "https://gamma-api.polymarket.com/events/keyset"
     assert params["after_cursor"] == "resume-here"
+
+
+# -- Data API trades --------------------------------------------------------------
+
+
+def test_data_api_trade_from_dict():
+    trade = DataApiTrade.from_dict(DATA_API_TRADE)
+
+    assert trade.proxy_wallet == "0x" + "ef" * 20
+    assert trade.side == "BUY"
+    assert trade.asset == "111"
+    assert trade.condition_id == "0x" + "ab" * 32
+    assert trade.size == 10.5
+    assert trade.price == 0.65
+    assert trade.timestamp == 1752700000
+    assert trade.transaction_hash == "0x" + "12" * 32
+    assert trade.title == "Will it rain tomorrow?"
+    assert trade.event_slug == "weather-week"
+    assert trade.outcome == "Yes"
+    assert trade.outcome_index == 0
+    assert trade.pseudonym == "Quiet-Fox"
+
+
+def test_data_api_trade_from_dict_defaults():
+    trade = DataApiTrade.from_dict({})
+
+    assert trade.proxy_wallet == ""
+    assert trade.asset == ""
+    assert trade.size == 0.0
+    assert trade.price == 0.0
+    assert trade.timestamp == 0
+    assert trade.outcome_index == -1
+    assert trade.pseudonym == ""
+
+
+def test_get_data_trades_default_window_omits_start_and_sends_taker_only():
+    client = make_client([[DATA_API_TRADE]])
+
+    trades = client.get_data_trades()
+
+    assert len(trades) == 1
+    url, params = client.http.calls[0]
+    assert url == "https://data-api.polymarket.com/trades"
+    assert params == {"limit": 1000, "offset": 0, "takerOnly": True}
+    assert "start" not in params  # API defaults to its ~3-year window
+    assert "end" not in params
+
+
+def test_get_data_trades_full_history_sends_start_1():
+    client = make_client([[DATA_API_TRADE]])
+
+    client.get_data_trades(start=FULL_HISTORY_START, end=1752700000, taker_only=False)
+
+    assert client.http.calls[0][1] == {
+        "limit": 1000,
+        "offset": 0,
+        "takerOnly": False,
+        "start": 1,
+        "end": 1752700000,
+    }
+
+
+def test_get_data_trades_skips_malformed_rows():
+    malformed = dict(DATA_API_TRADE, size="not-a-number")
+    client = make_client([[DATA_API_TRADE, malformed, "not-a-dict", None]])
+
+    trades = client.get_data_trades()
+
+    assert len(trades) == 1
+    assert trades[0].size == 10.5
+
+
+def test_get_data_trades_window_paginates_offsets_until_short_page():
+    client = make_client([[DATA_API_TRADE] * 2, [DATA_API_TRADE] * 2, [DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    assert len(trades) == 5
+    assert truncated is False
+    assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
+    for _, params in client.http.calls:
+        assert params["start"] == 1
+        assert params["end"] == 100
+        assert params["takerOnly"] is True
+
+
+def test_get_data_trades_window_truncates_at_offset_cap(monkeypatch):
+    monkeypatch.setattr(client_module, "MAX_DATA_API_OFFSET", 4)
+    client = make_client([[DATA_API_TRADE] * 2] * 3)
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    assert len(trades) == 6
+    assert truncated is True
+    assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
+
+
+def test_get_data_trades_window_counts_raw_rows_for_pagination():
+    malformed = dict(DATA_API_TRADE, size="not-a-number")
+    client = make_client([[DATA_API_TRADE, malformed], [DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    # First page is full in raw rows despite the skipped malformed row,
+    # so pagination must continue to the second (short) page.
+    assert len(trades) == 2
+    assert truncated is False
+    assert len(client.http.calls) == 2
 
 
 # -- CLOB endpoints --------------------------------------------------------------


### PR DESCRIPTION
## What changed? Why?

Adds a focused indexer for Polymarket's public **Data API market-wide trade tape** (`data-api.polymarket.com/trades`), stacked on the API foundation branch. This is the only official API surface for third-party, market-wide historical trade capture (the CLOB `/data/trades` endpoint is account-scoped), and it fills the gap between our on-chain `OrderFilled` dataset and the denormalized metadata (market title/slug, outcome, trader profile) only this API provides.

Key behaviors, all driven by documented API semantics:

- **Explicit full history via `start=1`.** The API silently limits results to the most recent ~3 years when `start` is omitted or `0`; the indexer defaults to `start=1` so a backfill covers the full tape. The client also supports omitting `start` for the default window.
- **Timestamp-window pagination.** The API hard-caps `offset` at 10,000, so deep scans page by `start`/`end` windows (default 1 day). Any window that still overflows the cap is split in half recursively down to 1 second; an unsplittable overflowing window keeps what it got and prints a warning instead of failing.
- **Explicit `takerOnly` semantics.** `takerOnly=true` is always sent explicitly (one row per fill; `false` would add maker-side rows that double-count volume when aggregated).
- **Defensive parsing.** Malformed rows are skipped without aborting a page, and pagination counts raw rows (not parsed rows) so a skipped row can't be mistaken for a short page.
- **Resumable chunked parquet with dedup.** Standard cursor-file resume (`data/polymarket/.data_api_trades_cursor`, deleted only on clean completion, preserved on Ctrl+C) and `trades_{i}_{i+10000}.parquet` chunks; rows are deduplicated across offset pages and adjacent window boundaries since the API exposes no trade ID.

Out of scope by design: on-chain trades, orderbook, resolutions, analyses, and storage refactors are untouched.

## Notes to reviewers

- `src/indexers/polymarket/data_api_trades.py` — new `PolymarketDataApiTradesIndexer` (window walk, recursive split, cursor resume, dedup, chunked parquet).
- `src/indexers/polymarket/client.py` — new `DATA_API_URL`, `FULL_HISTORY_START`, `MAX_DATA_API_OFFSET` constants and `get_data_trades` / `get_data_trades_window` methods (plus the private `_get_data_trades_page` that returns raw row counts for pagination).
- `src/indexers/polymarket/models.py` — new `DataApiTrade` dataclass; `asset` (CLOB token ID) is kept as a string per the parquet-overflow convention.
- `tests/test_data_api_trades_indexer.py` — new indexer tests; `tests/test_polymarket_client.py` — new Data API client/model tests.
- `docs/SCHEMAS.md` (new "Polymarket Data API Trades" section) and `README.md` (structure tree) document the dataset.

## How has it been tested?

- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- `uv run pytest tests/ -v` — 148 passed (Python 3.9), including new tests for: time-window coverage and chunked output, offset pagination until short page, truncation at the offset cap, current-window vs full-history `start` semantics, malformed-row skipping (both parse-level and pagination-level), recursive window splitting on overflow, the unsplittable 1-second overflow warning path, interrupt → cursor survives → resume-from-cursor without duplicates, and dedup within and across windows.
- The new indexer is auto-discovered by `Indexer.load()` and covered by the existing import/zero-arg-instantiation suite in `tests/test_compile.py`.

