### PR TITLE
feat(polymarket): assemble complete data stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: analyze run index package lint format test setup
+.PHONY: analyze run index record package lint format test setup
 
 RUN = uv run main.py
 
@@ -10,6 +10,9 @@ run:
 
 index:
 	$(RUN) index
+
+record:
+	$(RUN) record $(filter-out $@,$(MAKECMDGOALS))
 
 package:
 	$(RUN) package

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── events/
 │       ├── markets/
 │       └── trades/
 ├── docs/                   # Documentation

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── data_api_trades/
 │       ├── markets/
 │       └── trades/
 ├── docs/                   # Documentation

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   │   └── trades/
 │   └── polymarket/
 │       ├── blocks/
+│       ├── legacy_trades/
 │       ├── markets/
-│       └── trades/
+│       ├── trades/
+│       └── fpmm_collateral_lookup.json
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project enables research and analysis of prediction markets by providing:
 Currently supported features:
 - Market metadata collection (Kalshi & Polymarket)
 - Trade history collection via API and blockchain
+- Live order-book recording via the Polymarket CLOB WebSocket
 - Parquet-based storage with automatic progress saving
 - Extensible analysis script framework
 
@@ -40,6 +41,17 @@ make index
 ```
 
 This opens an interactive menu to select which indexer to run. Data is saved to `data/kalshi/` and `data/polymarket/` directories. Progress is saved automatically, so you can interrupt and resume collection.
+
+### Live Orderbook Recording
+
+**Polymarket provides no API for historical order-book depth — it cannot be backfilled after the fact and must be recorded live.** The recorder subscribes to the CLOB market WebSocket channel and persists full book snapshots plus incremental price changes (see [docs/SCHEMAS.md](docs/SCHEMAS.md)):
+
+```bash
+make record                            # record the highest-volume open markets
+uv run main.py record <token_id> ...   # record specific CLOB token IDs
+```
+
+Recording runs until interrupted with Ctrl+C; buffered rows are flushed to `data/polymarket/orderbook/` on exit and every 10,000 rows. The recorder heartbeats every 10 seconds and reconnects automatically — after a reconnect the exchange re-sends full snapshots, so gaps only span the time actually spent offline.
 
 ### Running Analyses
 
@@ -77,6 +89,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── orderbook/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── resolutions/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This creates a zstd-compressed tar archive (`data.tar.zst`) and removes the `dat
 │   └── polymarket/
 │       ├── blocks/
 │       ├── markets/
+│       ├── price_history/
 │       └── trades/
 ├── docs/                   # Documentation
 └── output/                 # Analysis outputs (figures, CSVs)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -113,6 +113,8 @@ Each row represents an `FPMMBuy` or `FPMMSell` event from the legacy Fixed Produ
 
 Located at `data/polymarket/fpmm_collateral_lookup.json`, this file maps FPMM contract addresses to their collateral token information. Used to filter legacy trades to only include USDC-collateralized markets.
 
+Produced by the `polymarket_collateral` indexer, which calls `collateralToken()` on each distinct FPMM address found in the legacy trades data and `symbol()` on the returned ERC-20 (recorded as `UNKNOWN` if the symbol cannot be read). The indexer is idempotent: addresses already present in the file are skipped on re-runs.
+
 ```json
 {
   "0x1234...": {

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -68,6 +68,27 @@ Each row represents a prediction market.
 | `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
+## Polymarket Events
+
+Each row represents an event, the top-level question grouping one or more markets. Events are fetched from the Gamma API with keyset pagination in two passes (`closed=false`, then `closed=true`), since Gamma excludes closed events by default. An event that closes mid-backfill can appear in both passes; deduplicate on `id`, keeping the latest `_fetched_at`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Event ID |
+| `slug` | string | URL slug |
+| `title` | string | Event title |
+| `category` | string (nullable) | Event category |
+| `tags` | string | JSON string of tag slugs, used for categorization |
+| `market_ids` | string | JSON string of child market IDs (joins to `markets.id`) |
+| `volume` | float | Total volume in USD |
+| `liquidity` | float | Current liquidity in USD |
+| `active` | bool | Is event active |
+| `closed` | bool | Is event closed |
+| `start_date` | datetime (nullable) | When event starts |
+| `end_date` | datetime (nullable) | When event ends |
+| `created_at` | datetime (nullable) | When event was created |
+| `_fetched_at` | datetime | When this record was fetched |
+
 ## Polymarket Trades
 
 Each row represents an `OrderFilled` event from the Polygon blockchain.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -58,12 +58,14 @@ Each row represents a prediction market.
 | `slug` | string | URL slug |
 | `outcomes` | string | JSON string of outcome names |
 | `outcome_prices` | string | JSON string of outcome prices |
+| `clob_token_ids` | string | JSON string of CLOB token IDs, one per outcome |
 | `volume` | float | Total volume in USD |
 | `liquidity` | float | Current liquidity in USD |
 | `active` | bool | Is market active |
 | `closed` | bool | Is market closed |
 | `end_date` | datetime (nullable) | When market ends |
 | `created_at` | datetime (nullable) | When market was created |
+| `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
 ## Polymarket Trades

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -90,6 +90,31 @@ Each row represents an `OrderFilled` event from the Polygon blockchain.
 
 **Note on Polymarket prices:** Prices are decimals between 0 and 1. A price of 0.65 means the contract costs $0.65 and pays $1.00 if the outcome wins (implied probability: 65%).
 
+## Polymarket Data API Trades
+
+Each row represents a taker-side fill from the public market-wide trade tape at `data-api.polymarket.com/trades`, with denormalized market and trader metadata. This complements the on-chain `OrderFilled` dataset above.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `proxy_wallet` | string | Proxy wallet address of the taker |
+| `side` | string | Taker side: `BUY` or `SELL` |
+| `asset` | string | CLOB token ID traded (decimal string) |
+| `condition_id` | string | Condition ID (hex hash), joins to `markets.condition_id` |
+| `size` | float | Number of outcome shares traded |
+| `price` | float | Execution price (decimal between 0 and 1) |
+| `timestamp` | int | Unix timestamp of the trade (seconds) |
+| `transaction_hash` | string | Polygon transaction hash |
+| `title` | string | Market question (denormalized) |
+| `slug` | string | Market slug (denormalized) |
+| `event_slug` | string | Parent event slug (denormalized) |
+| `outcome` | string | Outcome name traded |
+| `outcome_index` | int | Index of the outcome traded (`-1` if missing) |
+| `name` | string | Trader profile name (denormalized) |
+| `pseudonym` | string | Trader profile pseudonym (denormalized) |
+| `_fetched_at` | datetime | When this record was fetched |
+
+**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The indexer requests `start=1` explicitly for full history; omitting `start` would silently limit results to the API's default ~3-year window. The API caps `offset` at 10,000, so the indexer paginates by timestamp windows and recursively splits any window that overflows the cap.
+
 ## Polymarket Legacy Trades (FPMM)
 
 Each row represents an `FPMMBuy` or `FPMMSell` event from the legacy Fixed Product Market Maker contracts on Polygon. These are trades from before Polymarket migrated to the CTF Exchange (roughly 2020-2022).

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -113,7 +113,7 @@ Each row represents a taker-side fill from the public market-wide trade tape at 
 | `pseudonym` | string | Trader profile pseudonym (denormalized) |
 | `_fetched_at` | datetime | When this record was fetched |
 
-**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The indexer requests `start=1` explicitly for full history; omitting `start` would silently limit results to the API's default ~3-year window. The API caps `offset` at 10,000, so the indexer paginates by timestamp windows and recursively splits any window that overflows the cap.
+**Note on coverage:** Rows are taker-side only (`takerOnly=true`), so each fill appears once and sizes sum to traded volume without double-counting. The API only honors `start`/`end` on market-scoped queries — the unscoped market-wide tape silently ignores them — and caps `offset` at 10,000, so deep history is unreachable without scoping. The indexer therefore iterates condition IDs from the markets dataset above (run `polymarket_markets` first) in small batches, requesting each batch with an explicit `start=1` for full history (omitting `start` silently limits scoped results to the API's default ~3-year window) and recursively splitting any timestamp window that overflows the offset cap.
 
 ## Polymarket Legacy Trades (FPMM)
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -127,6 +127,24 @@ Located at `data/polymarket/fpmm_collateral_lookup.json`, this file maps FPMM co
 | `collateral_address` | string | ERC-20 token address used as collateral |
 | `collateral_symbol` | string | Token symbol (e.g., `USDC`, `USDT`) |
 
+## Polymarket Resolutions
+
+Each row represents a `ConditionResolution` event from the Gnosis ConditionalTokens contract on Polygon, recording the exact on-chain payout for a resolved market.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `block_number` | int | Polygon block number |
+| `transaction_hash` | string | Blockchain transaction hash |
+| `log_index` | int | Log index within transaction |
+| `condition_id` | string | Condition ID (0x-prefixed hex), joins to `condition_id` in Polymarket Markets |
+| `oracle` | string | Oracle address that reported the payouts |
+| `question_id` | string | Question ID (0x-prefixed hex) |
+| `outcome_slot_count` | int | Number of outcome slots for the condition |
+| `payout_numerators` | string | JSON string of payout numerators, one per outcome slot |
+| `_fetched_at` | datetime | When this record was fetched |
+
+**Note on payout numerators:** `payout_numerators` is stored as a JSON string to avoid integer overflow. The winning outcome is the index of the sole nonzero numerator; conditions with multiple nonzero numerators resolved to split/invalid payouts.
+
 ## Polymarket Blocks
 
 Mapping from Polygon block numbers to timestamps.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -137,3 +137,40 @@ Mapping from Polygon block numbers to timestamps.
 |--------|------|-------------|
 | `block_number` | int | Polygon block number |
 | `timestamp` | string | ISO 8601 timestamp (e.g., `2024-01-15T12:30:00Z`) |
+
+## Polymarket Orderbook (live recording)
+
+Located in `data/polymarket/orderbook/{books,price_changes}/`.
+
+**Polymarket exposes no historical order-book endpoint — depth data cannot be fetched retroactively.** These tables only cover periods when the live recorder (`uv run main.py record`) was running against the CLOB market WebSocket channel. Prices and sizes are stored as raw strings exactly as sent by the exchange so books can be replayed and verified against the `hash` field.
+
+### Orderbook Book Snapshots (`books/`)
+
+Each row is a full L2 `book` snapshot for one token. The server sends a snapshot on every (re)subscribe and after each trade that affects the book, so a reconnect always re-baselines the state — deltas missed while disconnected are superseded by the next snapshot.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID (`asset_id` in the message) |
+| `condition_id` | string | Condition ID (`market` in the message) |
+| `timestamp` | int | Exchange timestamp in unix **milliseconds** |
+| `hash` | string | Book integrity hash from the exchange |
+| `bids` | string | Raw JSON array of `{price, size}` levels, as sent |
+| `asks` | string | Raw JSON array of `{price, size}` levels, as sent |
+| `_recorded_at` | datetime | When the message was received locally |
+
+### Orderbook Price Changes (`price_changes/`)
+
+Each row is one changed level from a `price_change` message (order placements/cancellations). To reconstruct the book at time T: take the latest snapshot at or before T and apply subsequent deltas in `timestamp` order.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID |
+| `condition_id` | string | Condition ID |
+| `timestamp` | int | Exchange timestamp in unix **milliseconds** |
+| `hash` | string | Book hash after this change |
+| `side` | string | `BUY` (bid level) or `SELL` (ask level) |
+| `price` | string | Price level that changed (raw string) |
+| `size` | string | New total size at that level; `"0"` means the level was removed |
+| `best_bid` | string | Best bid after this change |
+| `best_ask` | string | Best ask after this change |
+| `_recorded_at` | datetime | When the message was received locally |

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -68,6 +68,17 @@ Each row represents a prediction market.
 | `market_maker_address` | string (nullable) | FPMM contract address for legacy markets |
 | `_fetched_at` | datetime | When this record was fetched |
 
+## Polymarket Price History
+
+Each row represents one point in the price time series of a single outcome token, fetched from the CLOB `/prices-history` endpoint at hourly fidelity. Both outcome tokens of every market in the markets dataset are covered.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `token_id` | string | CLOB token ID (joins to an entry of `clob_token_ids` in Polymarket Markets) |
+| `timestamp` | int | Unix timestamp of the price point (seconds) |
+| `price` | float | Token price (decimal between 0 and 1, see the note on Polymarket prices below) |
+| `_fetched_at` | datetime | When this record was fetched |
+
 ## Polymarket Trades
 
 Each row represents an `OrderFilled` event from the Polygon blockchain.

--- a/main.py
+++ b/main.py
@@ -126,6 +126,13 @@ def index():
     print("\nIndexer complete.")
 
 
+def record(token_ids: list[str] | None = None):
+    """Run the live Polymarket orderbook recorder until interrupted."""
+    from src.indexers.polymarket.orderbook import PolymarketOrderbookRecorder
+
+    PolymarketOrderbookRecorder(token_ids=token_ids).run()
+
+
 def package():
     """Package the data directory into a zstd-compressed tar archive."""
     success = package_data()
@@ -135,7 +142,7 @@ def package():
 def main():
     if len(sys.argv) < 2:
         print("\nUsage: uv run main.py <command>")
-        print("Commands: analyze, index, package")
+        print("Commands: analyze, index, record, package")
         sys.exit(0)
 
     command = sys.argv[1]
@@ -149,12 +156,16 @@ def main():
         index()
         sys.exit(0)
 
+    if command == "record":
+        record(sys.argv[2:] or None)
+        sys.exit(0)
+
     if command == "package":
         package()
         sys.exit(0)
 
     print(f"Unknown command: {command}")
-    print("Commands: analyze, index, package")
+    print("Commands: analyze, index, record, package")
     sys.exit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "simple-term-menu>=1.6.0",
     "python-dotenv>=1.2.1",
     "requests>=2.32.5",
+    "websockets>=15.0.1",
 ]
 
 [dependency-groups]

--- a/src/indexers/polymarket/blockchain.py
+++ b/src/indexers/polymarket/blockchain.py
@@ -36,6 +36,30 @@ ORDER_FILLED_ABI = {
     "type": "event",
 }
 
+# Gnosis ConditionalTokens contract used by Polymarket
+CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+
+# ConditionResolution event signature
+# ConditionResolution(bytes32 indexed conditionId, address indexed oracle, bytes32 indexed questionId,
+#                     uint256 outcomeSlotCount, uint256[] payoutNumerators)
+CONDITION_RESOLUTION_TOPIC = (
+    "0x" + Web3.keccak(text="ConditionResolution(bytes32,address,bytes32,uint256,uint256[])").hex()
+)
+
+# ABI for ConditionResolution event
+CONDITION_RESOLUTION_ABI = {
+    "anonymous": False,
+    "inputs": [
+        {"indexed": True, "name": "conditionId", "type": "bytes32"},
+        {"indexed": True, "name": "oracle", "type": "address"},
+        {"indexed": True, "name": "questionId", "type": "bytes32"},
+        {"indexed": False, "name": "outcomeSlotCount", "type": "uint256"},
+        {"indexed": False, "name": "payoutNumerators", "type": "uint256[]"},
+    ],
+    "name": "ConditionResolution",
+    "type": "event",
+}
+
 # Public Polygon RPC
 POLYGON_RPC = os.getenv("POLYGON_RPC", "")
 
@@ -99,6 +123,28 @@ class BlockchainTrade:
         return hex(asset_id)
 
 
+@dataclass
+class ConditionResolution:
+    """A ConditionResolution event decoded from the blockchain."""
+
+    block_number: int
+    transaction_hash: str
+    log_index: int
+    condition_id: str  # 0x-prefixed hex, joins to markets.condition_id
+    oracle: str
+    question_id: str  # 0x-prefixed hex
+    outcome_slot_count: int
+    payout_numerators: list[int]
+
+    @property
+    def winning_outcome(self) -> Optional[int]:
+        """Index of the sole winning outcome, or None for split/invalid payouts."""
+        nonzero = [i for i, numerator in enumerate(self.payout_numerators) if numerator != 0]
+        if len(nonzero) == 1:
+            return nonzero[0]
+        return None
+
+
 class PolygonClient:
     """Client for fetching Polymarket trades from Polygon blockchain."""
 
@@ -112,6 +158,10 @@ class PolygonClient:
         self.negrisk_exchange = self.w3.eth.contract(
             address=Web3.to_checksum_address(NEGRISK_CTF_EXCHANGE),
             abi=[ORDER_FILLED_ABI],
+        )
+        self.conditional_tokens = self.w3.eth.contract(
+            address=Web3.to_checksum_address(CONDITIONAL_TOKENS),
+            abi=[CONDITION_RESOLUTION_ABI],
         )
 
     def get_block_number(self) -> int:
@@ -169,6 +219,43 @@ class PolygonClient:
                 print(f"Error decoding log: {e}")
 
         return trades
+
+    def _decode_condition_resolution(self, log: dict) -> ConditionResolution:
+        """Decode a ConditionResolution event log."""
+        decoded = self.conditional_tokens.events.ConditionResolution().process_log(log)
+        args = decoded["args"]
+
+        return ConditionResolution(
+            block_number=log["blockNumber"],
+            transaction_hash=log["transactionHash"].hex(),
+            log_index=log["logIndex"],
+            condition_id="0x" + bytes(args["conditionId"]).hex(),
+            oracle=args["oracle"],
+            question_id="0x" + bytes(args["questionId"]).hex(),
+            outcome_slot_count=args["outcomeSlotCount"],
+            payout_numerators=list(args["payoutNumerators"]),
+        )
+
+    def get_condition_resolutions(self, from_block: int, to_block: int) -> list[ConditionResolution]:
+        """Fetch ConditionResolution events from a block range."""
+        logs = self.w3.eth.get_logs(
+            {
+                "address": Web3.to_checksum_address(CONDITIONAL_TOKENS),
+                "topics": [CONDITION_RESOLUTION_TOPIC],
+                "fromBlock": from_block,
+                "toBlock": to_block,
+            }
+        )
+
+        resolutions = []
+        for log in logs:
+            try:
+                resolution = self._decode_condition_resolution(log)
+                resolutions.append(resolution)
+            except Exception as e:
+                print(f"Error decoding log: {e}")
+
+        return resolutions
 
     def _fetch_chunk(self, start: int, end: int, contract_address: str) -> tuple[list[BlockchainTrade], int, int]:
         """Fetch a single chunk of trades. Used by thread pool."""
@@ -238,6 +325,9 @@ class PolygonClient:
 
 # Polymarket CTF Exchange created at block 33605403
 POLYMARKET_START_BLOCK = int(os.getenv("POLYMARKET_START_BLOCK", "33605403"))
+
+# Gnosis ConditionalTokens deployed at block 4023686
+CONDITIONAL_TOKENS_START_BLOCK = int(os.getenv("CONDITIONAL_TOKENS_START_BLOCK", "4023686"))
 
 
 def get_deployment_block() -> int:

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -171,6 +171,6 @@ class PolymarketClient:
         return float(data.get("spread", 0) or 0)
 
     def get_price(self, token_id: str, side: str) -> float:
-        """Fetch the best price for a token; `side` is BUY (best ask) or SELL (best bid)."""
+        """Fetch the best price for a token; `side` is BUY (best bid) or SELL (best ask)."""
         data = self.http.get(f"{self.clob_url}/price", params={"token_id": token_id, "side": side})
         return float(data.get("price", 0) or 0)

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -2,16 +2,32 @@ from collections.abc import Generator
 from typing import Optional, Union
 
 from src.common.client import HttpClient
-from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+from src.indexers.polymarket.models import DataApiTrade, Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
 CLOB_API_URL = "https://clob.polymarket.com"
+DATA_API_URL = "https://data-api.polymarket.com"
+
+# The Data API `/trades` and `/activity` endpoints return only the most recent
+# ~3 years when `start` is omitted or 0; any positive epoch retrieves from that
+# point, so `start=1` means full history.
+FULL_HISTORY_START = 1
+
+# The Data API hard-caps `offset` at 10,000; deeper scans must narrow the
+# `start`/`end` timestamp window instead of paging further.
+MAX_DATA_API_OFFSET = 10000
 
 
 class PolymarketClient:
-    def __init__(self, gamma_url: str = GAMMA_API_URL, clob_url: str = CLOB_API_URL):
+    def __init__(
+        self,
+        gamma_url: str = GAMMA_API_URL,
+        clob_url: str = CLOB_API_URL,
+        data_api_url: str = DATA_API_URL,
+    ):
         self.gamma_url = gamma_url
         self.clob_url = clob_url
+        self.data_api_url = data_api_url
         self.http = HttpClient(rate_limit=10)
 
     def __enter__(self):
@@ -128,6 +144,85 @@ class PolymarketClient:
 
             if not cursor:
                 break
+
+    # -- Data API --------------------------------------------------------------
+
+    def _get_data_trades_page(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: int = 1000,
+        offset: int = 0,
+        taker_only: bool = True,
+        **kwargs,
+    ) -> tuple[list[DataApiTrade], int]:
+        """Fetch one `/trades` page; returns (parsed trades, raw row count).
+
+        The raw count includes malformed rows that were skipped during parsing,
+        so pagination can detect a short page correctly.
+        """
+        params = {"limit": limit, "offset": offset, "takerOnly": taker_only, **kwargs}
+        if start is not None:
+            params["start"] = start
+        if end is not None:
+            params["end"] = end
+        data = self.http.get(f"{self.data_api_url}/trades", params=params)
+        rows = data if isinstance(data, list) else data.get("trades") or []
+        trades = []
+        for row in rows:
+            try:
+                trades.append(DataApiTrade.from_dict(row))
+            except (AttributeError, TypeError, ValueError):
+                continue
+        return trades, len(rows)
+
+    def get_data_trades(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: int = 1000,
+        offset: int = 0,
+        taker_only: bool = True,
+        **kwargs,
+    ) -> list[DataApiTrade]:
+        """Fetch one page of the market-wide trade tape from the Data API `/trades`.
+
+        `start`/`end` are unix seconds. When `start` is omitted the API returns
+        only the most recent ~3 years; pass `start=FULL_HISTORY_START` (1) for
+        full history. `takerOnly` is always sent explicitly: True yields one row
+        per fill (the taker side), False adds maker-side rows, which
+        double-count a fill when aggregating volume. Malformed rows are skipped.
+        """
+        trades, _ = self._get_data_trades_page(
+            start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **kwargs
+        )
+        return trades
+
+    def get_data_trades_window(
+        self,
+        start: int,
+        end: int,
+        limit: int = 1000,
+        taker_only: bool = True,
+    ) -> tuple[list[DataApiTrade], bool]:
+        """Fetch every `/trades` row in the [start, end] window by paging offsets.
+
+        Returns (trades, truncated). `truncated` is True when the window still
+        had rows beyond the API's 10,000 offset cap — callers must split the
+        window into smaller timestamp ranges to recover the missing rows.
+        """
+        trades: list[DataApiTrade] = []
+        offset = 0
+        while True:
+            page, raw_count = self._get_data_trades_page(
+                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only
+            )
+            trades.extend(page)
+            if raw_count < limit:
+                return trades, False
+            offset += limit
+            if offset > MAX_DATA_API_OFFSET:
+                return trades, True
 
     # -- CLOB API --------------------------------------------------------------
 

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -8,9 +8,11 @@ GAMMA_API_URL = "https://gamma-api.polymarket.com"
 CLOB_API_URL = "https://clob.polymarket.com"
 DATA_API_URL = "https://data-api.polymarket.com"
 
-# The Data API `/trades` and `/activity` endpoints return only the most recent
-# ~3 years when `start` is omitted or 0; any positive epoch retrieves from that
-# point, so `start=1` means full history.
+# The Data API `/trades` and `/activity` endpoints only honor `start`/`end`
+# when the query is scoped by `market` or `user`; the unscoped market-wide
+# tape silently ignores them. Scoped queries return only the most recent
+# ~3 years when `start` is omitted or 0; any positive epoch retrieves from
+# that point, so `start=1` means full history.
 FULL_HISTORY_START = 1
 
 # The Data API hard-caps `offset` at 10,000; deeper scans must narrow the
@@ -185,13 +187,16 @@ class PolymarketClient:
         taker_only: bool = True,
         **kwargs,
     ) -> list[DataApiTrade]:
-        """Fetch one page of the market-wide trade tape from the Data API `/trades`.
+        """Fetch one page of the trade tape from the Data API `/trades`.
 
-        `start`/`end` are unix seconds. When `start` is omitted the API returns
-        only the most recent ~3 years; pass `start=FULL_HISTORY_START` (1) for
-        full history. `takerOnly` is always sent explicitly: True yields one row
-        per fill (the taker side), False adds maker-side rows, which
-        double-count a fill when aggregating volume. Malformed rows are skipped.
+        `start`/`end` are unix seconds (inclusive) and are only honored when
+        the query is scoped by `market` or `user` (pass via kwargs); the
+        unscoped market-wide tape silently ignores them. For scoped queries,
+        omitting `start` returns only the most recent ~3 years; pass
+        `start=FULL_HISTORY_START` (1) for full history. `takerOnly` is always
+        sent explicitly: True yields one row per fill (the taker side), False
+        adds maker-side rows, which double-count a fill when aggregating
+        volume. Malformed rows are skipped.
         """
         trades, _ = self._get_data_trades_page(
             start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **kwargs
@@ -204,18 +209,24 @@ class PolymarketClient:
         end: int,
         limit: int = 1000,
         taker_only: bool = True,
+        market: Optional[str] = None,
     ) -> tuple[list[DataApiTrade], bool]:
         """Fetch every `/trades` row in the [start, end] window by paging offsets.
+
+        `market` is a comma-separated list of condition IDs; the API only
+        honors `start`/`end` on market- or user-scoped queries, so an unscoped
+        window sees the same newest-first tape regardless of bounds.
 
         Returns (trades, truncated). `truncated` is True when the window still
         had rows beyond the API's 10,000 offset cap — callers must split the
         window into smaller timestamp ranges to recover the missing rows.
         """
+        scope = {"market": market} if market else {}
         trades: list[DataApiTrade] = []
         offset = 0
         while True:
             page, raw_count = self._get_data_trades_page(
-                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only
+                start=start, end=end, limit=limit, offset=offset, taker_only=taker_only, **scope
             )
             trades.extend(page)
             if raw_count < limit:

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -1,15 +1,17 @@
 from collections.abc import Generator
-from typing import Union
+from typing import Optional, Union
 
 from src.common.client import HttpClient
-from src.indexers.polymarket.models import Market
+from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_API_URL = "https://gamma-api.polymarket.com"
+CLOB_API_URL = "https://clob.polymarket.com"
 
 
 class PolymarketClient:
-    def __init__(self, gamma_url: str = GAMMA_API_URL):
+    def __init__(self, gamma_url: str = GAMMA_API_URL, clob_url: str = CLOB_API_URL):
         self.gamma_url = gamma_url
+        self.clob_url = clob_url
         self.http = HttpClient(rate_limit=10)
 
     def __enter__(self):
@@ -20,6 +22,8 @@ class PolymarketClient:
 
     def close(self):
         self.http.close()
+
+    # -- Gamma API (offset pagination) ----------------------------------------
 
     def get_markets(self, limit: int = 500, offset: int = 0, **kwargs) -> list[Market]:
         params = {"limit": limit, "offset": offset, **kwargs}
@@ -45,3 +49,128 @@ class PolymarketClient:
                 break
 
             current_offset = next_offset
+
+    def get_events(self, limit: int = 500, offset: int = 0, **kwargs) -> list[Event]:
+        params = {"limit": limit, "offset": offset, **kwargs}
+        data: Union[dict, list] = self.http.get(f"{self.gamma_url}/events", params=params)
+        if isinstance(data, list):
+            return [Event.from_dict(e) for e in data]
+        return [Event.from_dict(e) for e in data.get("events", data)]
+
+    def iter_events(self, limit: int = 500, offset: int = 0) -> Generator[tuple[list[Event], int], None, None]:
+        current_offset = offset
+
+        while True:
+            events = self.get_events(limit=limit, offset=current_offset)
+
+            if not events:
+                yield [], -1
+                break
+
+            next_offset = current_offset + len(events)
+            yield events, next_offset
+
+            if len(events) < limit:
+                break
+
+            current_offset = next_offset
+
+    # -- Gamma API (keyset pagination) -----------------------------------------
+
+    def get_markets_keyset(
+        self, limit: int = 100, after_cursor: Optional[str] = None, **kwargs
+    ) -> tuple[list[Market], Optional[str]]:
+        """Fetch one page of `/markets/keyset`; returns (markets, next_cursor).
+
+        `next_cursor` is None on the final page. `limit` is capped at 100 by the API.
+        """
+        params = {"limit": limit, **kwargs}
+        if after_cursor:
+            params["after_cursor"] = after_cursor
+        data = self.http.get(f"{self.gamma_url}/markets/keyset", params=params)
+        markets = [Market.from_dict(m) for m in data.get("markets", [])]
+        return markets, data.get("next_cursor")
+
+    def iter_markets_keyset(
+        self, limit: int = 100, after_cursor: Optional[str] = None, **kwargs
+    ) -> Generator[tuple[list[Market], Optional[str]], None, None]:
+        cursor = after_cursor
+
+        while True:
+            markets, cursor = self.get_markets_keyset(limit=limit, after_cursor=cursor, **kwargs)
+            yield markets, cursor
+
+            if not cursor:
+                break
+
+    def get_events_keyset(
+        self, limit: int = 500, after_cursor: Optional[str] = None, **kwargs
+    ) -> tuple[list[Event], Optional[str]]:
+        """Fetch one page of `/events/keyset`; returns (events, next_cursor).
+
+        `next_cursor` is None on the final page. `limit` is capped at 500 by the API.
+        """
+        params = {"limit": limit, **kwargs}
+        if after_cursor:
+            params["after_cursor"] = after_cursor
+        data = self.http.get(f"{self.gamma_url}/events/keyset", params=params)
+        events = [Event.from_dict(e) for e in data.get("events", [])]
+        return events, data.get("next_cursor")
+
+    def iter_events_keyset(
+        self, limit: int = 500, after_cursor: Optional[str] = None, **kwargs
+    ) -> Generator[tuple[list[Event], Optional[str]], None, None]:
+        cursor = after_cursor
+
+        while True:
+            events, cursor = self.get_events_keyset(limit=limit, after_cursor=cursor, **kwargs)
+            yield events, cursor
+
+            if not cursor:
+                break
+
+    # -- CLOB API --------------------------------------------------------------
+
+    def get_price_history(
+        self,
+        token_id: str,
+        interval: Optional[str] = "max",
+        fidelity: Optional[int] = None,
+        start_ts: Optional[int] = None,
+        end_ts: Optional[int] = None,
+    ) -> list[PricePoint]:
+        """Fetch the price time series for a CLOB token from `/prices-history`.
+
+        `interval` is one of max, all, 1m, 1w, 1d, 6h, 1h; `fidelity` is the
+        resolution in minutes; `start_ts`/`end_ts` are unix seconds. Pass
+        `interval=None` when querying by explicit timestamp bounds.
+        """
+        params: dict = {"market": token_id}
+        if interval:
+            params["interval"] = interval
+        if fidelity is not None:
+            params["fidelity"] = fidelity
+        if start_ts is not None:
+            params["startTs"] = start_ts
+        if end_ts is not None:
+            params["endTs"] = end_ts
+        data = self.http.get(f"{self.clob_url}/prices-history", params=params)
+        history = data.get("history") or [] if isinstance(data, dict) else []
+        return [PricePoint.from_dict(token_id, point) for point in history]
+
+    def get_order_book(self, token_id: str) -> OrderBookSnapshot:
+        data = self.http.get(f"{self.clob_url}/book", params={"token_id": token_id})
+        return OrderBookSnapshot.from_dict(data)
+
+    def get_midpoint(self, token_id: str) -> float:
+        data = self.http.get(f"{self.clob_url}/midpoint", params={"token_id": token_id})
+        return float(data.get("mid", 0) or 0)
+
+    def get_spread(self, token_id: str) -> float:
+        data = self.http.get(f"{self.clob_url}/spread", params={"token_id": token_id})
+        return float(data.get("spread", 0) or 0)
+
+    def get_price(self, token_id: str, side: str) -> float:
+        """Fetch the best price for a token; `side` is BUY (best ask) or SELL (best bid)."""
+        data = self.http.get(f"{self.clob_url}/price", params={"token_id": token_id, "side": side})
+        return float(data.get("price", 0) or 0)

--- a/src/indexers/polymarket/collateral.py
+++ b/src/indexers/polymarket/collateral.py
@@ -1,0 +1,130 @@
+"""Indexer for the Polymarket FPMM collateral token lookup."""
+
+import concurrent.futures
+import json
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+from tqdm import tqdm
+from web3 import Web3
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.blockchain import PolygonClient
+
+# Minimal ABI for FixedProductMarketMaker.collateralToken()
+COLLATERAL_TOKEN_ABI = {
+    "constant": True,
+    "inputs": [],
+    "name": "collateralToken",
+    "outputs": [{"name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+# Minimal ABI for ERC20.symbol()
+ERC20_SYMBOL_ABI = {
+    "constant": True,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"name": "", "type": "string"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+LEGACY_TRADES_DIR = Path("data/polymarket/legacy_trades")
+LOOKUP_FILE = Path("data/polymarket/fpmm_collateral_lookup.json")
+
+
+class PolymarketCollateralIndexer(Indexer):
+    """Builds the FPMM address -> collateral token lookup from legacy trade data."""
+
+    def __init__(self, max_workers: int = 10):
+        super().__init__(
+            name="polymarket_collateral",
+            description="Builds the FPMM collateral token lookup from Polymarket legacy trades",
+        )
+        self._max_workers = max_workers
+        self._symbol_cache: dict[str, str] = {}
+
+    def _fetch_collateral(self, client: PolygonClient, fpmm_address: str) -> Optional[dict]:
+        """Resolve the collateral token address and symbol for an FPMM contract."""
+        try:
+            fpmm = client.w3.eth.contract(
+                address=Web3.to_checksum_address(fpmm_address),
+                abi=[COLLATERAL_TOKEN_ABI],
+            )
+            collateral_address = fpmm.functions.collateralToken().call()
+        except Exception as e:
+            tqdm.write(f"Error fetching collateral token for {fpmm_address}: {e}")
+            return None
+
+        symbol = self._symbol_cache.get(collateral_address)
+        if symbol is None:
+            try:
+                erc20 = client.w3.eth.contract(
+                    address=Web3.to_checksum_address(collateral_address),
+                    abi=[ERC20_SYMBOL_ABI],
+                )
+                symbol = erc20.functions.symbol().call()
+            except Exception as e:
+                tqdm.write(f"Error fetching symbol for {collateral_address}: {e}")
+                symbol = "UNKNOWN"
+            self._symbol_cache[collateral_address] = symbol
+
+        return {"collateral_address": collateral_address, "collateral_symbol": symbol}
+
+    def run(self) -> None:
+        """Build the FPMM collateral lookup for all distinct FPMM addresses in the legacy trades data.
+
+        The lookup file itself acts as the cursor: known addresses are skipped, and the
+        file is rewritten after each parallel batch so interrupts lose at most one batch.
+        """
+        if not list(LEGACY_TRADES_DIR.glob("trades_*.parquet")):
+            print(f"No legacy trades found in {LEGACY_TRADES_DIR}, nothing to do")
+            return
+
+        LOOKUP_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        lookup: dict[str, dict] = {}
+        if LOOKUP_FILE.exists():
+            try:
+                lookup = json.loads(LOOKUP_FILE.read_text())
+            except ValueError:
+                lookup = {}
+
+        rows = duckdb.sql(f"SELECT DISTINCT fpmm_address FROM '{LEGACY_TRADES_DIR}/trades_*.parquet'").fetchall()
+        addresses = [row[0] for row in rows]
+        to_process = [address for address in addresses if address not in lookup]
+        print(f"Found {len(addresses)} FPMM addresses ({len(to_process)} new)")
+
+        if not to_process:
+            print("Nothing to process")
+            return
+
+        client = PolygonClient()
+        resolved = 0
+        pbar = tqdm(total=len(to_process), desc="Resolving collateral", unit=" fpmm")
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+                for batch_start in range(0, len(to_process), self._max_workers):
+                    batch = to_process[batch_start : batch_start + self._max_workers]
+                    futures = {executor.submit(self._fetch_collateral, client, address): address for address in batch}
+
+                    for future in concurrent.futures.as_completed(futures):
+                        info = future.result()
+                        if info is not None:
+                            lookup[futures[future]] = info
+                            resolved += 1
+                        pbar.update(1)
+
+                    # Persist after each batch so interrupts lose at most one batch
+                    LOOKUP_FILE.write_text(json.dumps(lookup, indent=2))
+
+        except KeyboardInterrupt:
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+
+        print(f"\nCollateral lookup complete: {resolved} new addresses resolved ({len(lookup)} total)")

--- a/src/indexers/polymarket/data_api_trades.py
+++ b/src/indexers/polymarket/data_api_trades.py
@@ -1,0 +1,185 @@
+"""Indexer for the Polymarket Data API market-wide trade tape."""
+
+import time
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
+from src.indexers.polymarket.models import DataApiTrade
+
+DATA_DIR = Path("data/polymarket/data_api_trades")
+CURSOR_FILE = Path("data/polymarket/.data_api_trades_cursor")
+BATCH_SIZE = 10000
+WINDOW_SIZE = 86400  # seconds per timestamp window
+MIN_WINDOW_SIZE = 1  # a window can't be split below one second
+
+
+def _trade_key(trade: DataApiTrade) -> tuple:
+    """Identity of a trade row; the Data API has no explicit trade ID."""
+    return (
+        trade.transaction_hash,
+        trade.proxy_wallet,
+        trade.asset,
+        trade.side,
+        trade.timestamp,
+        trade.size,
+        trade.price,
+    )
+
+
+class PolymarketDataApiTradesIndexer(Indexer):
+    """Backfills the public market-wide trade tape from data-api.polymarket.com."""
+
+    def __init__(
+        self,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        window_size: int = WINDOW_SIZE,
+        limit: int = 1000,
+    ):
+        super().__init__(
+            name="polymarket_data_api_trades",
+            description="Backfills the Polymarket Data API trade tape to parquet files",
+        )
+        self._start = start
+        self._end = end
+        self._window_size = window_size
+        self._limit = limit
+
+    def run(self) -> None:
+        """Backfill all Data API trades by walking timestamp windows.
+
+        The API caps `offset` at 10,000, so the tape is fetched in [start, end]
+        timestamp windows; any window that overflows the cap is split in half
+        recursively until every returned trade is covered.
+        """
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolymarketClient()
+
+        # Determine starting timestamp; default is explicit full history (start=1),
+        # since omitting `start` silently limits the API to the last ~3 years.
+        start = self._start
+        if start is None:
+            if CURSOR_FILE.exists():
+                try:
+                    start = int(CURSOR_FILE.read_text().strip())
+                    print(f"Resuming from timestamp {start}")
+                except (ValueError, TypeError):
+                    start = FULL_HISTORY_START
+            else:
+                start = FULL_HISTORY_START
+
+        end = self._end
+        if end is None:
+            end = int(time.time())
+
+        print(f"Fetching Data API trades from timestamp {start} to {end}")
+
+        def fetch_window(w_start: int, w_end: int) -> list[DataApiTrade]:
+            trades, truncated = client.get_data_trades_window(w_start, w_end, limit=self._limit, taker_only=True)
+            if not truncated:
+                return trades
+            if w_end - w_start + 1 <= MIN_WINDOW_SIZE:
+                tqdm.write(
+                    f"Warning: window {w_start}-{w_end} overflows the offset cap "
+                    "at minimum window size; trades beyond the cap are dropped"
+                )
+                return trades
+            mid = (w_start + w_end) // 2
+            return fetch_window(w_start, mid) + fetch_window(mid + 1, w_end)
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("trades_*.parquet"))
+            if not existing:
+                return 0
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + BATCH_SIZE if indices else 0
+
+        buffer = []
+        total_saved = 0
+
+        def save_batch(trades_batch):
+            nonlocal total_saved
+            if not trades_batch:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"trades_{chunk_idx}_{chunk_idx + BATCH_SIZE}.parquet"
+            pd.DataFrame(trades_batch).to_parquet(chunk_path)
+            total_saved += len(trades_batch)
+            tqdm.write(f"Saved {len(trades_batch)} trades to {chunk_path.name}")
+
+        # Build list of timestamp windows
+        ranges = []
+        current = start
+        while current <= end:
+            w_end = min(current + self._window_size - 1, end)
+            ranges.append((current, w_end))
+            current = w_end + 1
+
+        pbar = tqdm(total=len(ranges), desc="Backfilling", unit=" windows")
+
+        # Keys seen in the previous window guard against the API returning
+        # boundary rows in two adjacent windows.
+        prev_keys: set = set()
+
+        interrupted = False
+        try:
+            for w_start, w_end in ranges:
+                fetched_at = datetime.utcnow()
+                window_keys: set = set()
+
+                for trade in fetch_window(w_start, w_end):
+                    key = _trade_key(trade)
+                    if key in prev_keys or key in window_keys:
+                        continue
+                    window_keys.add(key)
+                    record = asdict(trade)
+                    record["_fetched_at"] = fetched_at
+                    buffer.append(record)
+
+                prev_keys = window_keys
+
+                pbar.update(1)
+                pbar.set_postfix(
+                    timestamp=w_end,
+                    buffer=len(buffer),
+                    saved=total_saved,
+                )
+
+                while len(buffer) >= BATCH_SIZE:
+                    save_batch(buffer[:BATCH_SIZE])
+                    buffer = buffer[BATCH_SIZE:]
+
+                CURSOR_FILE.write_text(str(w_end + 1))
+
+        except KeyboardInterrupt:
+            interrupted = True
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+
+        # Save remaining trades
+        if buffer:
+            save_batch(buffer)
+
+        # Only clean up cursor on successful completion
+        if not interrupted and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        client.close()
+        print(f"\nBackfill complete: {total_saved} trades saved")

--- a/src/indexers/polymarket/data_api_trades.py
+++ b/src/indexers/polymarket/data_api_trades.py
@@ -1,4 +1,4 @@
-"""Indexer for the Polymarket Data API market-wide trade tape."""
+"""Indexer for the Polymarket Data API trade tape, fetched per market."""
 
 import time
 from dataclasses import asdict
@@ -14,9 +14,10 @@ from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
 from src.indexers.polymarket.models import DataApiTrade
 
 DATA_DIR = Path("data/polymarket/data_api_trades")
+MARKETS_DIR = Path("data/polymarket/markets")
 CURSOR_FILE = Path("data/polymarket/.data_api_trades_cursor")
 BATCH_SIZE = 10000
-WINDOW_SIZE = 86400  # seconds per timestamp window
+MARKETS_PER_REQUEST = 20  # condition IDs per `market` query parameter
 MIN_WINDOW_SIZE = 1  # a window can't be split below one second
 
 
@@ -33,14 +34,44 @@ def _trade_key(trade: DataApiTrade) -> tuple:
     )
 
 
+def _load_condition_ids() -> list[str]:
+    """Condition IDs from the markets dataset, in stable dataset order."""
+    files = sorted(MARKETS_DIR.glob("markets_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    ids: list[str] = []
+    seen: set[str] = set()
+    for path in files:
+        for cid in pd.read_parquet(path, columns=["condition_id"])["condition_id"]:
+            if cid and cid not in seen:
+                seen.add(cid)
+                ids.append(cid)
+    return ids
+
+
+def _read_cursor() -> tuple[int, Optional[int]]:
+    """Parse the cursor file into (market index, optional window resume timestamp)."""
+    try:
+        idx_part, _, ts_part = CURSOR_FILE.read_text().strip().partition(",")
+        return int(idx_part), int(ts_part) if ts_part else None
+    except (ValueError, TypeError):
+        return 0, None
+
+
 class PolymarketDataApiTradesIndexer(Indexer):
-    """Backfills the public market-wide trade tape from data-api.polymarket.com."""
+    """Backfills the public trade tape from data-api.polymarket.com per market.
+
+    The API only honors `start`/`end` on market-scoped queries (the unscoped
+    market-wide tape silently ignores them) and caps `offset` at 10,000, so
+    deep history is unreachable without scoping. The indexer iterates
+    condition IDs from the markets dataset in batches, fetches each batch's
+    full trade history, and recursively splits any timestamp window that
+    overflows the offset cap.
+    """
 
     def __init__(
         self,
         start: Optional[int] = None,
         end: Optional[int] = None,
-        window_size: int = WINDOW_SIZE,
+        markets_per_request: int = MARKETS_PER_REQUEST,
         limit: int = 1000,
     ):
         super().__init__(
@@ -49,52 +80,56 @@ class PolymarketDataApiTradesIndexer(Indexer):
         )
         self._start = start
         self._end = end
-        self._window_size = window_size
+        self._markets_per_request = markets_per_request
         self._limit = limit
 
     def run(self) -> None:
-        """Backfill all Data API trades by walking timestamp windows.
+        """Backfill Data API trades for every known market.
 
-        The API caps `offset` at 10,000, so the tape is fetched in [start, end]
-        timestamp windows; any window that overflows the cap is split in half
-        recursively until every returned trade is covered.
+        Progress is cursored as `<market index>[,<window timestamp>]` so both
+        an interrupt between markets and one inside a large market's window
+        walk resume without refetching completed work.
         """
+        condition_ids = _load_condition_ids()
+        if not condition_ids:
+            print(f"No markets found in {MARKETS_DIR}; run the polymarket_markets indexer first")
+            return
+
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
 
         client = PolymarketClient()
 
-        # Determine starting timestamp; default is explicit full history (start=1),
-        # since omitting `start` silently limits the API to the last ~3 years.
-        start = self._start
-        if start is None:
-            if CURSOR_FILE.exists():
-                try:
-                    start = int(CURSOR_FILE.read_text().strip())
-                    print(f"Resuming from timestamp {start}")
-                except (ValueError, TypeError):
-                    start = FULL_HISTORY_START
-            else:
-                start = FULL_HISTORY_START
+        # Explicit full history by default: scoped queries without `start`
+        # (or with 0) are silently limited to the API's ~3-year window.
+        start = self._start if self._start is not None else FULL_HISTORY_START
+        end = self._end if self._end is not None else int(time.time())
 
-        end = self._end
-        if end is None:
-            end = int(time.time())
+        market_idx, resume_ts = 0, None
+        if CURSOR_FILE.exists():
+            market_idx, resume_ts = _read_cursor()
+            if market_idx or resume_ts:
+                suffix = f" at timestamp {resume_ts}" if resume_ts else ""
+                print(f"Resuming from market {market_idx}{suffix}")
 
-        print(f"Fetching Data API trades from timestamp {start} to {end}")
+        print(f"Fetching Data API trades for {len(condition_ids)} markets, timestamps {start} to {end}")
 
-        def fetch_window(w_start: int, w_end: int) -> list[DataApiTrade]:
-            trades, truncated = client.get_data_trades_window(w_start, w_end, limit=self._limit, taker_only=True)
-            if not truncated:
-                return trades
-            if w_end - w_start + 1 <= MIN_WINDOW_SIZE:
+        def iter_leaf_windows(market: str, w_start: int, w_end: int):
+            """Yield (window end, trades) in timestamp order for windows under the offset cap."""
+            trades, truncated = client.get_data_trades_window(
+                w_start, w_end, limit=self._limit, taker_only=True, market=market
+            )
+            if truncated and w_end - w_start + 1 > MIN_WINDOW_SIZE:
+                mid = (w_start + w_end) // 2
+                yield from iter_leaf_windows(market, w_start, mid)
+                yield from iter_leaf_windows(market, mid + 1, w_end)
+                return
+            if truncated:
                 tqdm.write(
                     f"Warning: window {w_start}-{w_end} overflows the offset cap "
                     "at minimum window size; trades beyond the cap are dropped"
                 )
-                return trades
-            mid = (w_start + w_end) // 2
-            return fetch_window(w_start, mid) + fetch_window(mid + 1, w_end)
+            yield w_end, trades
 
         def get_next_chunk_idx():
             existing = list(DATA_DIR.glob("trades_*.parquet"))
@@ -123,49 +158,47 @@ class PolymarketDataApiTradesIndexer(Indexer):
             total_saved += len(trades_batch)
             tqdm.write(f"Saved {len(trades_batch)} trades to {chunk_path.name}")
 
-        # Build list of timestamp windows
-        ranges = []
-        current = start
-        while current <= end:
-            w_end = min(current + self._window_size - 1, end)
-            ranges.append((current, w_end))
-            current = w_end + 1
-
-        pbar = tqdm(total=len(ranges), desc="Backfilling", unit=" windows")
-
-        # Keys seen in the previous window guard against the API returning
-        # boundary rows in two adjacent windows.
-        prev_keys: set = set()
+        pbar = tqdm(
+            total=len(condition_ids),
+            initial=min(market_idx, len(condition_ids)),
+            desc="Backfilling",
+            unit=" markets",
+        )
 
         interrupted = False
         try:
-            for w_start, w_end in ranges:
+            while market_idx < len(condition_ids):
+                batch = condition_ids[market_idx : market_idx + self._markets_per_request]
+                batch_start = resume_ts if resume_ts is not None else start
+                resume_ts = None
                 fetched_at = datetime.utcnow()
-                window_keys: set = set()
 
-                for trade in fetch_window(w_start, w_end):
-                    key = _trade_key(trade)
-                    if key in prev_keys or key in window_keys:
-                        continue
-                    window_keys.add(key)
-                    record = asdict(trade)
-                    record["_fetched_at"] = fetched_at
-                    buffer.append(record)
+                # Keys seen in the previous window guard against the API
+                # returning boundary rows in two adjacent windows.
+                prev_keys: set = set()
+                for w_end, trades in iter_leaf_windows(",".join(batch), batch_start, end):
+                    window_keys: set = set()
+                    for trade in trades:
+                        key = _trade_key(trade)
+                        if key in prev_keys or key in window_keys:
+                            continue
+                        window_keys.add(key)
+                        record = asdict(trade)
+                        record["_fetched_at"] = fetched_at
+                        buffer.append(record)
+                    prev_keys = window_keys
 
-                prev_keys = window_keys
+                    while len(buffer) >= BATCH_SIZE:
+                        save_batch(buffer[:BATCH_SIZE])
+                        buffer = buffer[BATCH_SIZE:]
 
-                pbar.update(1)
-                pbar.set_postfix(
-                    timestamp=w_end,
-                    buffer=len(buffer),
-                    saved=total_saved,
-                )
+                    if w_end < end:
+                        CURSOR_FILE.write_text(f"{market_idx},{w_end + 1}")
 
-                while len(buffer) >= BATCH_SIZE:
-                    save_batch(buffer[:BATCH_SIZE])
-                    buffer = buffer[BATCH_SIZE:]
-
-                CURSOR_FILE.write_text(str(w_end + 1))
+                market_idx += len(batch)
+                pbar.update(len(batch))
+                pbar.set_postfix(buffer=len(buffer), saved=total_saved)
+                CURSOR_FILE.write_text(str(market_idx))
 
         except KeyboardInterrupt:
             interrupted = True

--- a/src/indexers/polymarket/events.py
+++ b/src/indexers/polymarket/events.py
@@ -1,0 +1,120 @@
+"""Indexer for Polymarket events data."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+
+DATA_DIR = Path("data/polymarket/events")
+CURSOR_FILE = Path("data/polymarket/.events_backfill_cursor")
+CHUNK_SIZE = 10000
+PAGE_LIMIT = 500
+
+# Gamma excludes closed events unless closed=true is requested, so full coverage
+# needs one pass per closed value. The open pass runs first so events that close
+# mid-crawl are still picked up by the closed pass.
+PHASES = [("open", False), ("closed", True)]
+
+
+class PolymarketEventsIndexer(Indexer):
+    """Fetches and stores Polymarket events data."""
+
+    def __init__(self):
+        super().__init__(
+            name="polymarket_events",
+            description="Backfills Polymarket events data to parquet files",
+        )
+
+    def run(self) -> None:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolymarketClient()
+
+        resume_phase = None
+        resume_cursor = None
+        if CURSOR_FILE.exists():
+            try:
+                state = json.loads(CURSOR_FILE.read_text())
+                resume_phase = state.get("phase")
+                resume_cursor = state.get("cursor")
+                print(f"Resuming from {resume_phase} phase")
+            except (ValueError, TypeError):
+                pass
+
+        phase_names = [name for name, _ in PHASES]
+        start_idx = phase_names.index(resume_phase) if resume_phase in phase_names else 0
+
+        buffer = []
+        total = 0
+        total_saved = 0
+        interrupted = False
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("events_*.parquet"))
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + CHUNK_SIZE if indices else 0
+
+        def save_chunk(records):
+            nonlocal total_saved
+            if not records:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"events_{chunk_idx}_{chunk_idx + CHUNK_SIZE}.parquet"
+            pd.DataFrame(records).to_parquet(chunk_path)
+            total_saved += len(records)
+            print(f"Saved {len(records)} events to {chunk_path.name}")
+
+        try:
+            for idx in range(start_idx, len(PHASES)):
+                phase, closed = PHASES[idx]
+                after_cursor = resume_cursor if phase == resume_phase else None
+                print(f"Fetching {phase} events (closed={closed})")
+
+                for events, next_cursor in client.iter_events_keyset(
+                    limit=PAGE_LIMIT, after_cursor=after_cursor, closed=closed
+                ):
+                    if events:
+                        fetched_at = datetime.utcnow()
+                        for event in events:
+                            record = asdict(event)
+                            record["_fetched_at"] = fetched_at
+                            buffer.append(record)
+
+                        total += len(events)
+                        print(f"Fetched {len(events)} {phase} events (total: {total})")
+
+                        while len(buffer) >= CHUNK_SIZE:
+                            save_chunk(buffer[:CHUNK_SIZE])
+                            buffer = buffer[CHUNK_SIZE:]
+
+                    if next_cursor:
+                        CURSOR_FILE.write_text(json.dumps({"phase": phase, "cursor": next_cursor}))
+
+                if idx + 1 < len(PHASES):
+                    CURSOR_FILE.write_text(json.dumps({"phase": PHASES[idx + 1][0], "cursor": None}))
+        except KeyboardInterrupt:
+            interrupted = True
+            print("\nInterrupted. Progress saved.")
+
+        # Save remaining events
+        save_chunk(buffer)
+
+        # Only clean up cursor on successful completion
+        if not interrupted and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        client.close()
+        print(f"\nBackfill complete: {total} events fetched")

--- a/src/indexers/polymarket/events.py
+++ b/src/indexers/polymarket/events.py
@@ -108,9 +108,10 @@ class PolymarketEventsIndexer(Indexer):
         except KeyboardInterrupt:
             interrupted = True
             print("\nInterrupted. Progress saved.")
-
-        # Save remaining events
-        save_chunk(buffer)
+        finally:
+            # Flush on any exit: the cursor may already point past buffered events,
+            # so losing the buffer would leave a silent gap on resume.
+            save_chunk(buffer)
 
         # Only clean up cursor on successful completion
         if not interrupted and CURSOR_FILE.exists():

--- a/src/indexers/polymarket/fpmm_trades.py
+++ b/src/indexers/polymarket/fpmm_trades.py
@@ -251,6 +251,7 @@ class PolymarketLegacyTradesIndexer(Indexer):
         pbar = tqdm(total=total_chunks, desc="Backfilling Legacy", unit=" chunks")
         last_block_processed = from_block
 
+        interrupted = False
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers) as executor:
                 for batch_start in range(0, len(ranges), self._max_workers):
@@ -298,6 +299,7 @@ class PolymarketLegacyTradesIndexer(Indexer):
                     CURSOR_FILE.write_text(str(last_block_processed))
 
         except KeyboardInterrupt:
+            interrupted = True
             print("\nInterrupted. Progress saved.")
         finally:
             pbar.close()
@@ -306,7 +308,8 @@ class PolymarketLegacyTradesIndexer(Indexer):
         if all_trades:
             save_batch(all_trades)
 
-        if CURSOR_FILE.exists():
+        # Only clean up cursor on successful completion
+        if not interrupted and CURSOR_FILE.exists():
             CURSOR_FILE.unlink()
 
         print(f"\nFPMM backfill complete: {total_saved} trades saved")

--- a/src/indexers/polymarket/markets.py
+++ b/src/indexers/polymarket/markets.py
@@ -41,29 +41,35 @@ class PolymarketMarketsIndexer(Indexer):
         all_markets = []
         total = offset
 
-        for markets, next_offset in client.iter_markets(offset=offset):
-            if markets:
-                fetched_at = datetime.utcnow()
-                for market in markets:
-                    record = asdict(market)
-                    record["_fetched_at"] = fetched_at
-                    all_markets.append(record)
+        interrupted = False
+        try:
+            for markets, next_offset in client.iter_markets(offset=offset):
+                if markets:
+                    fetched_at = datetime.utcnow()
+                    for market in markets:
+                        record = asdict(market)
+                        record["_fetched_at"] = fetched_at
+                        all_markets.append(record)
 
-                total += len(markets)
-                print(f"Fetched {len(markets)} markets (total: {total})")
+                    total += len(markets)
+                    print(f"Fetched {len(markets)} markets (total: {total})")
 
-                # Save in chunks
-                while len(all_markets) >= CHUNK_SIZE:
-                    chunk = all_markets[:CHUNK_SIZE]
-                    chunk_start = total - len(all_markets)
-                    chunk_path = DATA_DIR / f"markets_{chunk_start}_{chunk_start + CHUNK_SIZE}.parquet"
-                    pd.DataFrame(chunk).to_parquet(chunk_path)
-                    all_markets = all_markets[CHUNK_SIZE:]
+                    # Save in chunks
+                    while len(all_markets) >= CHUNK_SIZE:
+                        chunk = all_markets[:CHUNK_SIZE]
+                        chunk_start = total - len(all_markets)
+                        chunk_path = DATA_DIR / f"markets_{chunk_start}_{chunk_start + CHUNK_SIZE}.parquet"
+                        pd.DataFrame(chunk).to_parquet(chunk_path)
+                        all_markets = all_markets[CHUNK_SIZE:]
 
-            if next_offset > 0:
-                OFFSET_FILE.write_text(str(next_offset))
-            else:
-                break
+                if next_offset > 0:
+                    OFFSET_FILE.write_text(str(next_offset))
+                else:
+                    break
+
+        except KeyboardInterrupt:
+            interrupted = True
+            print("\nInterrupted. Progress saved.")
 
         # Save remaining markets
         if all_markets:
@@ -71,7 +77,8 @@ class PolymarketMarketsIndexer(Indexer):
             chunk_path = DATA_DIR / f"markets_{chunk_start}_{chunk_start + len(all_markets)}.parquet"
             pd.DataFrame(all_markets).to_parquet(chunk_path)
 
-        if OFFSET_FILE.exists():
+        # Only clean up offset on successful completion
+        if not interrupted and OFFSET_FILE.exists():
             OFFSET_FILE.unlink()
 
         client.close()

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -1,6 +1,18 @@
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
+
+
+def parse_time(val: Optional[str]) -> Optional[datetime]:
+    if not val:
+        return None
+    try:
+        # Handle ISO format with Z suffix
+        val = val.replace("Z", "+00:00")
+        return datetime.fromisoformat(val)
+    except (ValueError, TypeError):
+        return None
 
 
 @dataclass
@@ -22,16 +34,6 @@ class Market:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Market":
-        def parse_time(val: Optional[str]) -> Optional[datetime]:
-            if not val:
-                return None
-            try:
-                # Handle ISO format with Z suffix
-                val = val.replace("Z", "+00:00")
-                return datetime.fromisoformat(val)
-            except (ValueError, TypeError):
-                return None
-
         return cls(
             id=data.get("id", ""),
             condition_id=data.get("conditionId", ""),
@@ -47,4 +49,96 @@ class Market:
             end_date=parse_time(data.get("endDate")),
             created_at=parse_time(data.get("createdAt")),
             market_maker_address=data.get("marketMakerAddress"),
+        )
+
+
+@dataclass
+class Event:
+    id: str
+    slug: str
+    title: str
+    category: Optional[str]
+    tags: str  # JSON string of tag slugs
+    market_ids: str  # JSON string of child market IDs
+    volume: float
+    liquidity: float
+    active: bool
+    closed: bool
+    start_date: Optional[datetime]
+    end_date: Optional[datetime]
+    created_at: Optional[datetime]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Event":
+        return cls(
+            id=data.get("id", ""),
+            slug=data.get("slug", ""),
+            title=data.get("title", ""),
+            category=data.get("category"),
+            tags=json.dumps([t.get("slug", "") for t in data.get("tags") or []]),
+            market_ids=json.dumps([m.get("id", "") for m in data.get("markets") or []]),
+            volume=float(data.get("volume", 0) or 0),
+            liquidity=float(data.get("liquidity", 0) or 0),
+            active=data.get("active", False),
+            closed=data.get("closed", False),
+            start_date=parse_time(data.get("startDate")),
+            end_date=parse_time(data.get("endDate")),
+            created_at=parse_time(data.get("createdAt")),
+        )
+
+
+@dataclass
+class PricePoint:
+    token_id: str
+    timestamp: int  # unix seconds
+    price: float
+
+    @classmethod
+    def from_dict(cls, token_id: str, data: dict) -> "PricePoint":
+        return cls(
+            token_id=token_id,
+            timestamp=int(data.get("t", 0) or 0),
+            price=float(data.get("p", 0) or 0),
+        )
+
+
+@dataclass
+class OrderBookLevel:
+    price: float
+    size: float
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OrderBookLevel":
+        return cls(
+            price=float(data.get("price", 0) or 0),
+            size=float(data.get("size", 0) or 0),
+        )
+
+
+@dataclass
+class OrderBookSnapshot:
+    condition_id: str  # `market` in the API response
+    token_id: str  # `asset_id` in the API response
+    timestamp: int  # unix milliseconds
+    hash: str
+    bids: list[OrderBookLevel] = field(default_factory=list)
+    asks: list[OrderBookLevel] = field(default_factory=list)
+    min_order_size: float = 0.0
+    tick_size: float = 0.0
+    neg_risk: bool = False
+    last_trade_price: float = 0.0
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "OrderBookSnapshot":
+        return cls(
+            condition_id=data.get("market", ""),
+            token_id=data.get("asset_id", ""),
+            timestamp=int(data.get("timestamp", 0) or 0),
+            hash=data.get("hash", ""),
+            bids=[OrderBookLevel.from_dict(level) for level in data.get("bids") or []],
+            asks=[OrderBookLevel.from_dict(level) for level in data.get("asks") or []],
+            min_order_size=float(data.get("min_order_size", 0) or 0),
+            tick_size=float(data.get("tick_size", 0) or 0),
+            neg_risk=data.get("neg_risk", False),
+            last_trade_price=float(data.get("last_trade_price", 0) or 0),
         )

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -103,6 +103,45 @@ class PricePoint:
 
 
 @dataclass
+class DataApiTrade:
+    proxy_wallet: str
+    side: str  # taker side: BUY or SELL
+    asset: str  # CLOB token ID (decimal string, kept as string to avoid overflow)
+    condition_id: str
+    size: float  # outcome shares traded
+    price: float  # execution price, 0-1 decimal
+    timestamp: int  # unix seconds
+    transaction_hash: str
+    title: str = ""
+    slug: str = ""
+    event_slug: str = ""
+    outcome: str = ""
+    outcome_index: int = -1
+    name: str = ""
+    pseudonym: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DataApiTrade":
+        return cls(
+            proxy_wallet=data.get("proxyWallet", ""),
+            side=data.get("side", ""),
+            asset=str(data.get("asset", "")),
+            condition_id=data.get("conditionId", ""),
+            size=float(data.get("size", 0) or 0),
+            price=float(data.get("price", 0) or 0),
+            timestamp=int(data.get("timestamp", 0) or 0),
+            transaction_hash=data.get("transactionHash", ""),
+            title=data.get("title", ""),
+            slug=data.get("slug", ""),
+            event_slug=data.get("eventSlug", ""),
+            outcome=data.get("outcome", ""),
+            outcome_index=int(data.get("outcomeIndex", -1) if data.get("outcomeIndex") is not None else -1),
+            name=data.get("name", ""),
+            pseudonym=data.get("pseudonym", ""),
+        )
+
+
+@dataclass
 class OrderBookLevel:
     price: float
     size: float

--- a/src/indexers/polymarket/models.py
+++ b/src/indexers/polymarket/models.py
@@ -116,6 +116,44 @@ class OrderBookLevel:
 
 
 @dataclass
+class OrderBookDelta:
+    condition_id: str
+    token_id: str
+    timestamp: int  # unix milliseconds
+    hash: str
+    side: str  # BUY (bid level) or SELL (ask level)
+    price: str  # raw string, preserved for exact replay
+    size: str  # raw string; "0" means the level was removed
+    best_bid: str
+    best_ask: str
+
+    @classmethod
+    def list_from_message(cls, data: dict) -> list["OrderBookDelta"]:
+        """Parse a market-channel `price_change` message into one delta per changed level.
+
+        Handles both the current shape (`price_changes` with per-change `asset_id`
+        and `hash`) and the legacy shape (`changes` with top-level `asset_id`).
+        """
+        condition_id = data.get("market", "")
+        timestamp = int(data.get("timestamp", 0) or 0)
+        changes = data.get("price_changes") or data.get("changes") or []
+        return [
+            cls(
+                condition_id=condition_id,
+                token_id=str(change.get("asset_id") or data.get("asset_id") or ""),
+                timestamp=timestamp,
+                hash=change.get("hash") or data.get("hash") or "",
+                side=change.get("side", ""),
+                price=str(change.get("price", "")),
+                size=str(change.get("size", "")),
+                best_bid=str(change.get("best_bid", "")),
+                best_ask=str(change.get("best_ask", "")),
+            )
+            for change in changes
+        ]
+
+
+@dataclass
 class OrderBookSnapshot:
     condition_id: str  # `market` in the API response
     token_id: str  # `asset_id` in the API response

--- a/src/indexers/polymarket/orderbook.py
+++ b/src/indexers/polymarket/orderbook.py
@@ -1,0 +1,216 @@
+"""Live recorder for the Polymarket CLOB market WebSocket channel.
+
+Polymarket exposes no historical order-book endpoint: depth data cannot be
+fetched retroactively and only exists for the periods this recorder was
+running. It subscribes to the market channel by CLOB token IDs, persists
+full `book` snapshots and `price_change` deltas with their raw string
+levels and integrity hashes (millisecond exchange timestamps preserved),
+sends the required `PING` heartbeat every 10 seconds, and reconnects with
+backoff on disconnect. Reconnects are safe for replay because the server
+re-sends a full `book` snapshot for every subscribed token on subscribe,
+superseding any deltas missed while offline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import websockets
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+from src.indexers.polymarket.models import OrderBookDelta
+
+WS_MARKET_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+DATA_DIR = Path("data/polymarket/orderbook")
+CHUNK_SIZE = 10000
+PING_INTERVAL_SECONDS = 10.0
+INITIAL_RECONNECT_DELAY_SECONDS = 1.0
+MAX_RECONNECT_DELAY_SECONDS = 60.0
+DISCOVER_MARKET_COUNT = 100
+
+
+def discover_token_ids(client: PolymarketClient, max_markets: int = DISCOVER_MARKET_COUNT) -> list[str]:
+    """Resolve CLOB token IDs for the highest-volume open markets on Gamma."""
+    markets = client.get_markets(limit=max_markets, active=True, closed=False, order="volume", ascending=False)
+    token_ids: list[str] = []
+    for market in markets:
+        try:
+            ids = json.loads(market.clob_token_ids)
+        except (TypeError, ValueError):
+            continue
+        token_ids.extend(str(token_id) for token_id in ids if token_id)
+    return list(dict.fromkeys(token_ids))
+
+
+class OrderBookWriter:
+    """Buffers recorded rows and flushes them to timestamp-ranged parquet chunks."""
+
+    def __init__(self, data_dir: Path = DATA_DIR, chunk_size: int = CHUNK_SIZE):
+        self.data_dir = Path(data_dir)
+        self.chunk_size = chunk_size
+        self._buffers: dict[str, list[dict]] = {"books": [], "price_changes": []}
+
+    def add_book(self, row: dict) -> None:
+        self._append("books", [row])
+
+    def add_price_changes(self, rows: list[dict]) -> None:
+        self._append("price_changes", rows)
+
+    def flush(self) -> None:
+        for table in self._buffers:
+            self._flush_table(table)
+
+    def _append(self, table: str, rows: list[dict]) -> None:
+        self._buffers[table].extend(rows)
+        if len(self._buffers[table]) >= self.chunk_size:
+            self._flush_table(table)
+
+    def _flush_table(self, table: str) -> None:
+        buffer = self._buffers[table]
+        if not buffer:
+            return
+        directory = self.data_dir / table
+        directory.mkdir(parents=True, exist_ok=True)
+        start, end = buffer[0]["timestamp"], buffer[-1]["timestamp"]
+        path = directory / f"{table}_{start}_{end}.parquet"
+        suffix = 1
+        while path.exists():
+            path = directory / f"{table}_{start}_{end}_{suffix}.parquet"
+            suffix += 1
+        pd.DataFrame(buffer).to_parquet(path)
+        self._buffers[table] = []
+        print(f"Flushed {len(buffer)} rows to {path}")
+
+
+class OrderBookRecorder:
+    """Consumes the CLOB market channel and persists book snapshots and deltas."""
+
+    def __init__(
+        self,
+        token_ids: list[str],
+        writer: OrderBookWriter,
+        ws_url: str = WS_MARKET_URL,
+        ping_interval: float = PING_INTERVAL_SECONDS,
+        initial_reconnect_delay: float = INITIAL_RECONNECT_DELAY_SECONDS,
+        connect: Callable | None = None,
+    ):
+        self.token_ids = list(token_ids)
+        self.writer = writer
+        self.ws_url = ws_url
+        self.ping_interval = ping_interval
+        self.initial_reconnect_delay = initial_reconnect_delay
+        self._connect = connect or (lambda: websockets.connect(self.ws_url))
+        self._stop: asyncio.Event | None = None
+
+    def stop(self) -> None:
+        if self._stop is not None:
+            self._stop.set()
+
+    async def record(self) -> None:
+        """Connect, subscribe, and record until stopped; reconnects on disconnect."""
+        self._stop = asyncio.Event()
+        delay = self.initial_reconnect_delay
+        try:
+            while not self._stop.is_set():
+                try:
+                    async with self._connect() as ws:
+                        await self._subscribe(ws)
+                        ping_task = asyncio.create_task(self._ping_loop(ws))
+                        try:
+                            async for raw in ws:
+                                self.handle_message(raw)
+                                delay = self.initial_reconnect_delay
+                                if self._stop.is_set():
+                                    break
+                        finally:
+                            ping_task.cancel()
+                            with contextlib.suppress(Exception, asyncio.CancelledError):
+                                await ping_task
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    print(f"WebSocket error: {exc}")
+                if self._stop.is_set():
+                    break
+                print(f"Disconnected; reconnecting in {delay:.0f}s")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, MAX_RECONNECT_DELAY_SECONDS)
+        finally:
+            self.writer.flush()
+
+    def handle_message(self, raw: str) -> None:
+        """Parse one WebSocket frame and persist any book/price_change events."""
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            return  # PONG heartbeat replies and other non-JSON frames
+        messages = payload if isinstance(payload, list) else [payload]
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            event_type = message.get("event_type")
+            if event_type == "book":
+                self.writer.add_book(self._book_row(message))
+            elif event_type == "price_change":
+                deltas = OrderBookDelta.list_from_message(message)
+                if deltas:
+                    recorded_at = datetime.now(timezone.utc)
+                    self.writer.add_price_changes([{**asdict(delta), "_recorded_at": recorded_at} for delta in deltas])
+
+    @staticmethod
+    def _book_row(message: dict) -> dict:
+        return {
+            "token_id": message.get("asset_id", ""),
+            "condition_id": message.get("market", ""),
+            "timestamp": int(message.get("timestamp", 0) or 0),
+            "hash": message.get("hash", ""),
+            "bids": json.dumps(message.get("bids") or []),
+            "asks": json.dumps(message.get("asks") or []),
+            "_recorded_at": datetime.now(timezone.utc),
+        }
+
+    async def _subscribe(self, ws) -> None:
+        await ws.send(json.dumps({"assets_ids": self.token_ids, "type": "market"}))
+
+    async def _ping_loop(self, ws) -> None:
+        while True:
+            await asyncio.sleep(self.ping_interval)
+            await ws.send("PING")
+
+
+class PolymarketOrderbookRecorder(Indexer):
+    """Records live Polymarket order-book snapshots and price changes."""
+
+    def __init__(self, token_ids: list[str] | None = None, max_markets: int = DISCOVER_MARKET_COUNT):
+        super().__init__(
+            name="polymarket_orderbook",
+            description="Records live CLOB order-book snapshots and price changes to parquet files",
+        )
+        self.token_ids = list(token_ids) if token_ids else None
+        self.max_markets = max_markets
+
+    def run(self) -> None:
+        token_ids = self.token_ids
+        if not token_ids:
+            with PolymarketClient() as client:
+                token_ids = discover_token_ids(client, self.max_markets)
+        if not token_ids:
+            print("No CLOB token IDs to record")
+            return
+
+        print(f"Recording order books for {len(token_ids)} tokens (Ctrl+C to stop)")
+        writer = OrderBookWriter()
+        recorder = OrderBookRecorder(token_ids, writer)
+        try:
+            asyncio.run(recorder.record())
+        except KeyboardInterrupt:
+            writer.flush()
+            print("\nRecording stopped")

--- a/src/indexers/polymarket/price_history.py
+++ b/src/indexers/polymarket/price_history.py
@@ -18,7 +18,7 @@ DATA_DIR = Path("data/polymarket/price_history")
 MARKETS_DIR = Path("data/polymarket/markets")
 BATCH_SIZE = 10000
 FIDELITY_MINUTES = 60
-WINDOW_SECONDS = 30 * 24 * 60 * 60  # max span per /prices-history request; longer ranges get truncated
+WINDOW_SECONDS = 15 * 24 * 60 * 60  # max span per /prices-history request; the API 400s on longer ranges
 END_PADDING_SECONDS = 7 * 24 * 60 * 60  # markets can keep trading past their scheduled end until resolution
 EARLIEST_TS = 1577836800  # 2020-01-01, before the first Polymarket market
 

--- a/src/indexers/polymarket/price_history.py
+++ b/src/indexers/polymarket/price_history.py
@@ -1,0 +1,196 @@
+"""Indexer for Polymarket CLOB price history data."""
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import duckdb
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.client import PolymarketClient
+
+DATA_DIR = Path("data/polymarket/price_history")
+MARKETS_DIR = Path("data/polymarket/markets")
+BATCH_SIZE = 10000
+FIDELITY_MINUTES = 60
+WINDOW_SECONDS = 30 * 24 * 60 * 60  # max span per /prices-history request; longer ranges get truncated
+END_PADDING_SECONDS = 7 * 24 * 60 * 60  # markets can keep trading past their scheduled end until resolution
+EARLIEST_TS = 1577836800  # 2020-01-01, before the first Polymarket market
+
+
+def _to_epoch_seconds(value: Optional[datetime], default: int) -> int:
+    try:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp())
+    except (AttributeError, TypeError, ValueError, OverflowError):
+        return default
+
+
+def _discover_token_windows() -> dict[str, tuple[int, int]]:
+    """Map every CLOB token ID in the markets dataset to its (start_ts, end_ts) fetch window."""
+    rows = duckdb.sql(f"SELECT clob_token_ids, created_at, end_date FROM '{MARKETS_DIR}/markets_*.parquet'").fetchall()
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+
+    windows: dict[str, tuple[int, int]] = {}
+    for clob_token_ids, created_at, end_date in rows:
+        try:
+            token_ids = json.loads(clob_token_ids)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(token_ids, list):
+            continue
+
+        start_ts = _to_epoch_seconds(created_at, EARLIEST_TS)
+        end_ts = min(_to_epoch_seconds(end_date, now_ts) + END_PADDING_SECONDS, now_ts)
+        end_ts = max(end_ts, start_ts + 1)
+
+        for token_id in token_ids:
+            if not isinstance(token_id, str) or not token_id:
+                continue
+            if token_id in windows:
+                prev_start, prev_end = windows[token_id]
+                windows[token_id] = (min(prev_start, start_ts), max(prev_end, end_ts))
+            else:
+                windows[token_id] = (start_ts, end_ts)
+
+    return windows
+
+
+class PolymarketPriceHistoryIndexer(Indexer):
+    """Fetches and stores Polymarket CLOB price history data."""
+
+    def __init__(self, max_workers: int = 10):
+        super().__init__(
+            name="polymarket_price_history",
+            description="Backfills Polymarket price history data to parquet files",
+        )
+        self._max_workers = max_workers
+
+    def run(self) -> None:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        if not list(MARKETS_DIR.glob("markets_*.parquet")):
+            print(f"No markets data found in {MARKETS_DIR}, run the polymarket_markets indexer first")
+            return
+
+        token_windows = _discover_token_windows()
+        print(f"Found {len(token_windows)} unique tokens across all markets")
+
+        # Load existing token IDs for deduplication (this is also the resume mechanism)
+        existing_tokens: set[str] = set()
+        parquet_files = list(DATA_DIR.glob("prices_*.parquet"))
+        if parquet_files:
+            print("Loading existing tokens for deduplication...")
+            try:
+                result = duckdb.sql(f"SELECT DISTINCT token_id FROM '{DATA_DIR}/prices_*.parquet'").fetchall()
+                existing_tokens = {row[0] for row in result}
+                print(f"Found {len(existing_tokens)} existing tokens")
+            except Exception:
+                pass
+
+        tokens_to_process = [(t, w) for t, w in sorted(token_windows.items()) if t not in existing_tokens]
+        print(
+            f"Skipped {len(token_windows) - len(tokens_to_process)} already processed, "
+            f"{len(tokens_to_process)} to fetch"
+        )
+
+        if not tokens_to_process:
+            print("Nothing to process")
+            return
+
+        all_points: list[dict] = []
+        total_points_saved = 0
+        next_chunk_idx = 0
+
+        # Calculate next chunk index
+        if parquet_files:
+            indices = []
+            for f in parquet_files:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            if indices:
+                next_chunk_idx = max(indices) + BATCH_SIZE
+
+        def save_batch(points_batch: list[dict]) -> int:
+            nonlocal next_chunk_idx
+            if not points_batch:
+                return 0
+            chunk_path = DATA_DIR / f"prices_{next_chunk_idx}_{next_chunk_idx + BATCH_SIZE}.parquet"
+            pd.DataFrame(points_batch).to_parquet(chunk_path)
+            next_chunk_idx += BATCH_SIZE
+            return len(points_batch)
+
+        def fetch_token_history(token_id: str, start_ts: int, end_ts: int) -> list[dict]:
+            """Fetch the full price history for a single token in bounded windows."""
+            client = PolymarketClient()
+            try:
+                fetched_at = datetime.utcnow()
+                records: list[dict] = []
+                seen_ts: set[int] = set()
+                cursor = start_ts
+                while cursor < end_ts:
+                    window_end = min(cursor + WINDOW_SECONDS, end_ts)
+                    points = client.get_price_history(
+                        token_id,
+                        interval=None,
+                        fidelity=FIDELITY_MINUTES,
+                        start_ts=cursor,
+                        end_ts=window_end,
+                    )
+                    for point in points:
+                        if point.timestamp not in seen_ts:
+                            seen_ts.add(point.timestamp)
+                            records.append({**asdict(point), "_fetched_at": fetched_at})
+                    cursor = window_end
+                return records
+            finally:
+                client.close()
+
+        # Concurrent fetching
+        pbar = tqdm(total=len(tokens_to_process), desc="Fetching price history")
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {
+                executor.submit(fetch_token_history, token, start, end): token
+                for token, (start, end) in tokens_to_process
+            }
+
+            for future in as_completed(futures):
+                token = futures[future]
+                try:
+                    points_data = future.result()
+                    if points_data:
+                        all_points.extend(points_data)
+
+                    pbar.update(1)
+                    pbar.set_postfix(buffer=len(all_points), saved=total_points_saved, last=token[-20:])
+
+                    # Save in batches
+                    while len(all_points) >= BATCH_SIZE:
+                        saved = save_batch(all_points[:BATCH_SIZE])
+                        total_points_saved += saved
+                        all_points = all_points[BATCH_SIZE:]
+
+                except Exception as e:
+                    pbar.update(1)
+                    tqdm.write(f"Error fetching {token}: {e}")
+
+        pbar.close()
+
+        # Save remaining
+        if all_points:
+            total_points_saved += save_batch(all_points)
+
+        print(
+            f"\nBackfill price history complete: {len(tokens_to_process)} tokens processed, "
+            f"{total_points_saved} points saved"
+        )

--- a/src/indexers/polymarket/resolutions.py
+++ b/src/indexers/polymarket/resolutions.py
@@ -1,0 +1,155 @@
+"""Indexer for Polymarket condition resolutions from the Polygon blockchain."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from tqdm import tqdm
+
+from src.common.indexer import Indexer
+from src.indexers.polymarket.blockchain import (
+    CONDITIONAL_TOKENS_START_BLOCK,
+    PolygonClient,
+)
+
+DATA_DIR = Path("data/polymarket/resolutions")
+CURSOR_FILE = Path("data/polymarket/.resolutions_block_cursor")
+
+
+class PolymarketResolutionsIndexer(Indexer):
+    """Fetches and stores Polymarket condition resolutions from the Polygon blockchain."""
+
+    def __init__(
+        self,
+        from_block: Optional[int] = None,
+        to_block: Optional[int] = None,
+        chunk_size: int = 10000,
+    ):
+        super().__init__(
+            name="polymarket_resolutions",
+            description="Backfills Polymarket condition resolutions from Polygon blockchain to parquet files",
+        )
+        self._from_block = from_block
+        self._to_block = to_block
+        self._chunk_size = chunk_size
+
+    def run(self) -> None:
+        """Backfill all Polymarket condition resolutions from the Polygon blockchain.
+
+        This fetches ConditionResolution events from the Gnosis ConditionalTokens
+        contract and saves them to parquet files.
+        """
+        BATCH_SIZE = 10000
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        CURSOR_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+        client = PolygonClient()
+        current_block = client.get_block_number()
+
+        # Determine starting block
+        from_block = self._from_block
+        if from_block is None:
+            if CURSOR_FILE.exists():
+                try:
+                    from_block = int(CURSOR_FILE.read_text().strip())
+                    print(f"Resuming from block {from_block}")
+                except (ValueError, TypeError):
+                    from_block = CONDITIONAL_TOKENS_START_BLOCK
+            else:
+                from_block = CONDITIONAL_TOKENS_START_BLOCK
+
+        to_block = self._to_block
+        if to_block is None:
+            to_block = current_block
+
+        print(f"Fetching resolutions from block {from_block} to {to_block}")
+        print(f"Total blocks: {to_block - from_block:,}")
+
+        all_resolutions = []
+        total_saved = 0
+
+        def get_next_chunk_idx():
+            existing = list(DATA_DIR.glob("resolutions_*.parquet"))
+            if not existing:
+                return 0
+            indices = []
+            for f in existing:
+                parts = f.stem.split("_")
+                if len(parts) >= 2:
+                    try:
+                        indices.append(int(parts[1]))
+                    except ValueError:
+                        pass
+            return max(indices) + BATCH_SIZE if indices else 0
+
+        def save_batch(resolutions_batch):
+            nonlocal total_saved
+            if not resolutions_batch:
+                return
+            chunk_idx = get_next_chunk_idx()
+            chunk_path = DATA_DIR / f"resolutions_{chunk_idx}_{chunk_idx + BATCH_SIZE}.parquet"
+            df = pd.DataFrame(resolutions_batch)
+            df.to_parquet(chunk_path)
+            total_saved += len(resolutions_batch)
+            tqdm.write(f"Saved {len(resolutions_batch)} resolutions to {chunk_path.name}")
+
+        # Build list of chunk ranges
+        ranges = []
+        current = from_block
+        while current <= to_block:
+            end = min(current + self._chunk_size - 1, to_block)
+            ranges.append((current, end))
+            current = end + 1
+
+        total_chunks = len(ranges)
+        pbar = tqdm(total=total_chunks, desc="Backfilling", unit=" chunks")
+
+        completed = False
+        try:
+            for chunk_start, chunk_end in ranges:
+                fetched_at = datetime.utcnow()
+
+                resolutions = client.get_condition_resolutions(
+                    from_block=chunk_start,
+                    to_block=chunk_end,
+                )
+
+                for resolution in resolutions:
+                    record = asdict(resolution)
+                    # Serialize to a JSON string to avoid parquet overflow
+                    record["payout_numerators"] = json.dumps(record["payout_numerators"])
+                    record["_fetched_at"] = fetched_at
+                    all_resolutions.append(record)
+
+                pbar.update(1)
+                pbar.set_postfix(
+                    block=chunk_end,
+                    buffer=len(all_resolutions),
+                    saved=total_saved,
+                )
+
+                # Save in batches
+                while len(all_resolutions) >= BATCH_SIZE:
+                    save_batch(all_resolutions[:BATCH_SIZE])
+                    all_resolutions = all_resolutions[BATCH_SIZE:]
+
+                # Save cursor after each completed range
+                CURSOR_FILE.write_text(str(chunk_end))
+
+            completed = True
+        except KeyboardInterrupt:
+            print("\nInterrupted. Progress saved.")
+        finally:
+            pbar.close()
+            # Flush buffered resolutions so no fetched data is lost on interrupt or error
+            if all_resolutions:
+                save_batch(all_resolutions)
+
+        # Only clean up cursor on successful completion
+        if completed and CURSOR_FILE.exists():
+            CURSOR_FILE.unlink()
+
+        print(f"\nBackfill complete: {total_saved} resolutions saved")

--- a/src/indexers/polymarket/resolutions.py
+++ b/src/indexers/polymarket/resolutions.py
@@ -54,7 +54,9 @@ class PolymarketResolutionsIndexer(Indexer):
         if from_block is None:
             if CURSOR_FILE.exists():
                 try:
-                    from_block = int(CURSOR_FILE.read_text().strip())
+                    # Cursor holds the last completed block; its rows are already
+                    # flushed, so resume at the next block to avoid duplicates
+                    from_block = int(CURSOR_FILE.read_text().strip()) + 1
                     print(f"Resuming from block {from_block}")
                 except (ValueError, TypeError):
                     from_block = CONDITIONAL_TOKENS_START_BLOCK

--- a/tests/test_backfill_cursor.py
+++ b/tests/test_backfill_cursor.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 
@@ -73,6 +75,155 @@ def test_interrupt_then_resume_completes(isolated_dirs):
     client2 = FakeClient()
     with patch("src.indexers.polymarket.trades.PolygonClient", return_value=client2):
         indexer = PolymarketTradesIndexer(to_block=5000, chunk_size=1000)
+        indexer.run()
+
+    # Should have resumed from the saved cursor, not from the beginning
+    first_requested = min(start for start, _ in client2.requested_ranges)
+    assert first_requested == saved_block, f"Resume should start from cursor ({saved_block}), not {first_requested}"
+
+    # Cursor should be cleaned up after successful completion
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+@dataclass
+class FakeMarket:
+    id: str = "0"
+    question: str = "test?"
+
+
+class FakeMarketsClient:
+    """Stub for PolymarketClient that serves paginated markets."""
+
+    def __init__(self, total: int = 20, page_size: int = 5, *, interrupt_at_offset: int | None = None):
+        self._total = total
+        self._page_size = page_size
+        self._interrupt_at = interrupt_at_offset
+        self.requested_offsets: list[int] = []
+
+    def iter_markets(self, offset: int = 0):
+        current_offset = offset
+        while True:
+            if self._interrupt_at is not None and current_offset >= self._interrupt_at:
+                raise KeyboardInterrupt
+            self.requested_offsets.append(current_offset)
+            markets = [
+                FakeMarket(id=str(i)) for i in range(current_offset, min(current_offset + self._page_size, self._total))
+            ]
+            if not markets:
+                yield [], -1
+                break
+            next_offset = current_offset + len(markets)
+            yield markets, next_offset
+            if len(markets) < self._page_size:
+                break
+            current_offset = next_offset
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def isolated_markets_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the markets indexer's DATA_DIR and OFFSET_FILE at temp directories."""
+    data_dir = tmp_path / "markets"
+    offset_file = tmp_path / ".backfill_offset"
+    import src.indexers.polymarket.markets as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "OFFSET_FILE", offset_file)
+    return data_dir, offset_file
+
+
+def test_markets_interrupt_then_resume_completes(isolated_markets_dirs):
+    """Interrupt a markets backfill with Ctrl+C: buffered rows must be flushed, then resume finishes the job."""
+    from src.indexers.polymarket.markets import PolymarketMarketsIndexer
+
+    data_dir, offset_file = isolated_markets_dirs
+
+    # Run 1: interrupt after two pages (10 markets fetched, buffer below CHUNK_SIZE)
+    client1 = FakeMarketsClient(interrupt_at_offset=10)
+    with patch("src.indexers.polymarket.markets.PolymarketClient", return_value=client1):
+        PolymarketMarketsIndexer().run()
+
+    # Offset file should exist and point past the fetched pages
+    assert offset_file.exists(), "Offset file should survive Ctrl+C"
+    saved_offset = int(offset_file.read_text().strip())
+    assert saved_offset == 10, f"Offset should be at last completed page, got {saved_offset}"
+
+    # Every market the offset claims was fetched must be on disk
+    persisted = pd.concat([pd.read_parquet(f) for f in data_dir.glob("markets_*.parquet")])
+    assert len(persisted) == saved_offset, "Markets fetched before the interrupt must be flushed to parquet"
+
+    # Run 2: resume (reads offset file), no interrupt
+    client2 = FakeMarketsClient()
+    with patch("src.indexers.polymarket.markets.PolymarketClient", return_value=client2):
+        PolymarketMarketsIndexer().run()
+
+    # Should have resumed from the saved offset, not from the beginning
+    assert client2.requested_offsets[0] == saved_offset, (
+        f"Resume should start from offset ({saved_offset}), not {client2.requested_offsets[0]}"
+    )
+
+    # Offset file should be cleaned up after successful completion
+    assert not offset_file.exists(), "Offset file should be deleted after successful completion"
+
+    # All markets present exactly once across both runs
+    persisted = pd.concat([pd.read_parquet(f) for f in data_dir.glob("markets_*.parquet")])
+    assert sorted(persisted["id"].astype(int).tolist()) == list(range(20))
+
+
+class FakeLegacyClient:
+    """Stub for PolygonClient used by the legacy FPMM indexer."""
+
+    def __init__(self, *, interrupt_at_block: int | None = None):
+        self._interrupt_at = interrupt_at_block
+        self.requested_ranges: list[tuple[int, int]] = []
+        self.w3 = SimpleNamespace(eth=SimpleNamespace(get_logs=self._get_logs))
+
+    def get_block_number(self) -> int:
+        return 5000
+
+    def _get_logs(self, params: dict) -> list:
+        from_block = params["fromBlock"]
+        if self._interrupt_at is not None and from_block >= self._interrupt_at:
+            raise KeyboardInterrupt
+        self.requested_ranges.append((from_block, params["toBlock"]))
+        return []
+
+
+@pytest.fixture()
+def isolated_legacy_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the legacy indexer's DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "legacy_trades"
+    cursor_file = tmp_path / ".legacy_backfill_block_cursor"
+    import src.indexers.polymarket.fpmm_trades as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def test_legacy_interrupt_then_resume_completes(isolated_legacy_dirs):
+    """Interrupt a legacy FPMM backfill with Ctrl+C: cursor must survive, then resume finishes the job."""
+    from src.indexers.polymarket.fpmm_trades import PolymarketLegacyTradesIndexer
+
+    data_dir, cursor_file = isolated_legacy_dirs
+
+    # Run 1: interrupt at block 3000
+    client1 = FakeLegacyClient(interrupt_at_block=3000)
+    with patch("src.indexers.polymarket.fpmm_trades.PolygonClient", return_value=client1):
+        indexer = PolymarketLegacyTradesIndexer(from_block=1000, to_block=5000, chunk_size=1000, max_workers=1)
+        indexer.run()
+
+    # Cursor should exist and point to the last completed block
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    saved_block = int(cursor_file.read_text().strip())
+    assert saved_block == 2999, f"Cursor should be at last completed chunk end, got {saved_block}"
+
+    # Run 2: resume with no from_block (reads cursor), no interrupt
+    client2 = FakeLegacyClient()
+    with patch("src.indexers.polymarket.fpmm_trades.PolygonClient", return_value=client2):
+        indexer = PolymarketLegacyTradesIndexer(to_block=5000, chunk_size=1000, max_workers=1)
         indexer.run()
 
     # Should have resumed from the saved cursor, not from the beginning

--- a/tests/test_blockchain_decode.py
+++ b/tests/test_blockchain_decode.py
@@ -1,0 +1,126 @@
+"""Unit tests for decoding ConditionResolution events from hand-built logs."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from eth_abi import encode
+from hexbytes import HexBytes
+from web3 import Web3
+
+from src.indexers.polymarket.blockchain import (
+    CONDITION_RESOLUTION_TOPIC,
+    CONDITIONAL_TOKENS,
+    ConditionResolution,
+    PolygonClient,
+)
+
+CONDITION_ID = "0x" + "11" * 32
+QUESTION_ID = "0x" + "22" * 32
+ORACLE = Web3.to_checksum_address("0x" + "ab" * 20)
+TX_HASH = "0x" + "cd" * 32
+
+
+def build_log(
+    payout_numerators: list[int],
+    outcome_slot_count: int | None = None,
+    block_number: int = 12345,
+    log_index: int = 7,
+) -> dict:
+    """Build a raw eth_getLogs-style entry for a ConditionResolution event."""
+    if outcome_slot_count is None:
+        outcome_slot_count = len(payout_numerators)
+    data = encode(["uint256", "uint256[]"], [outcome_slot_count, payout_numerators])
+    return {
+        "address": Web3.to_checksum_address(CONDITIONAL_TOKENS),
+        "topics": [
+            HexBytes(CONDITION_RESOLUTION_TOPIC),
+            HexBytes(CONDITION_ID),
+            HexBytes("0x" + "00" * 12 + ORACLE[2:]),
+            HexBytes(QUESTION_ID),
+        ],
+        "data": HexBytes(data),
+        "blockNumber": block_number,
+        "blockHash": HexBytes("0x" + "ef" * 32),
+        "transactionHash": HexBytes(TX_HASH),
+        "transactionIndex": 0,
+        "logIndex": log_index,
+    }
+
+
+@pytest.fixture()
+def client() -> PolygonClient:
+    return PolygonClient(rpc_url="http://localhost:8545")
+
+
+def test_decode_condition_resolution(client: PolygonClient):
+    log = build_log([1, 0])
+
+    resolution = client._decode_condition_resolution(log)
+
+    assert resolution.block_number == 12345
+    assert resolution.transaction_hash == HexBytes(TX_HASH).hex()
+    assert resolution.log_index == 7
+    assert resolution.condition_id == CONDITION_ID
+    assert resolution.oracle == ORACLE
+    assert resolution.question_id == QUESTION_ID
+    assert resolution.outcome_slot_count == 2
+    assert resolution.payout_numerators == [1, 0]
+
+
+@pytest.mark.parametrize(
+    ("payout_numerators", "expected"),
+    [
+        ([1, 0], 0),
+        ([0, 1], 1),
+        ([1, 1], None),  # split/invalid resolution (e.g. 50/50)
+        ([0, 0, 1], 2),
+        ([2, 3], None),
+        ([0, 0], None),
+        ([], None),
+    ],
+)
+def test_winning_outcome(payout_numerators: list[int], expected: int | None):
+    resolution = ConditionResolution(
+        block_number=1,
+        transaction_hash="0x00",
+        log_index=0,
+        condition_id=CONDITION_ID,
+        oracle=ORACLE,
+        question_id=QUESTION_ID,
+        outcome_slot_count=max(len(payout_numerators), 2),
+        payout_numerators=payout_numerators,
+    )
+    assert resolution.winning_outcome == expected
+
+
+def test_get_condition_resolutions_filters_and_decodes(client: PolygonClient):
+    logs = [build_log([1, 0], block_number=100, log_index=1), build_log([0, 1], block_number=200, log_index=2)]
+    captured = {}
+
+    def fake_get_logs(params):
+        captured.update(params)
+        return logs
+
+    with patch.object(client.w3.eth, "get_logs", side_effect=fake_get_logs):
+        resolutions = client.get_condition_resolutions(from_block=100, to_block=200)
+
+    assert captured["address"] == Web3.to_checksum_address(CONDITIONAL_TOKENS)
+    assert captured["topics"] == [CONDITION_RESOLUTION_TOPIC]
+    assert captured["fromBlock"] == 100
+    assert captured["toBlock"] == 200
+    assert [r.block_number for r in resolutions] == [100, 200]
+    assert [r.winning_outcome for r in resolutions] == [0, 1]
+
+
+def test_get_condition_resolutions_skips_undecodable_logs(client: PolygonClient, capsys: pytest.CaptureFixture):
+    bad_log = build_log([1, 0])
+    bad_log["data"] = HexBytes("0x")  # truncated payload
+
+    with patch.object(client.w3.eth, "get_logs", return_value=[bad_log, build_log([0, 1])]):
+        resolutions = client.get_condition_resolutions(from_block=0, to_block=10)
+
+    assert len(resolutions) == 1
+    assert resolutions[0].winning_outcome == 1
+    assert "Error decoding log" in capsys.readouterr().out

--- a/tests/test_collateral_indexer.py
+++ b/tests/test_collateral_indexer.py
@@ -1,0 +1,181 @@
+"""Test the FPMM collateral lookup indexer with a stubbed Polygon client."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+USDC = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+DAI = "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063"
+
+FPMM_A = "0x1111111111111111111111111111111111111111"
+FPMM_B = "0x2222222222222222222222222222222222222222"
+FPMM_C = "0x3333333333333333333333333333333333333333"
+
+
+class FakeContractFunction:
+    def __init__(self, result):
+        self._result = result
+
+    def call(self):
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+class FakeEth:
+    """Stub for w3.eth that serves contract calls from canned maps."""
+
+    def __init__(self, client: FakeClient):
+        self._client = client
+
+    def contract(self, address: str, abi: list[dict]):
+        client = self._client
+        if abi[0]["name"] == "collateralToken":
+            client.collateral_calls.append(address)
+            result = client.collateral_map[address]
+            functions = SimpleNamespace(collateralToken=lambda: FakeContractFunction(result))
+        else:
+            client.symbol_calls.append(address)
+            result = client.symbol_map[address]
+            functions = SimpleNamespace(symbol=lambda: FakeContractFunction(result))
+        return SimpleNamespace(functions=functions)
+
+
+class FakeClient:
+    """Stub for PolygonClient that tracks which contracts were queried."""
+
+    def __init__(self, collateral_map: dict, symbol_map: dict):
+        self.collateral_map = collateral_map
+        self.symbol_map = symbol_map
+        self.collateral_calls: list[str] = []
+        self.symbol_calls: list[str] = []
+        self.w3 = SimpleNamespace(eth=FakeEth(self))
+
+
+@pytest.fixture()
+def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point LEGACY_TRADES_DIR and LOOKUP_FILE at temp locations."""
+    trades_dir = tmp_path / "legacy_trades"
+    lookup_file = tmp_path / "fpmm_collateral_lookup.json"
+    import src.indexers.polymarket.collateral as mod
+
+    monkeypatch.setattr(mod, "LEGACY_TRADES_DIR", trades_dir)
+    monkeypatch.setattr(mod, "LOOKUP_FILE", lookup_file)
+    return trades_dir, lookup_file
+
+
+def _write_legacy_trades(trades_dir: Path, addresses: list[str]) -> None:
+    trades_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"fpmm_address": addresses * 2})  # duplicates to exercise DISTINCT
+    df.to_parquet(trades_dir / "trades_0_10000.parquet")
+
+
+def _run_indexer(client: FakeClient, max_workers: int = 10) -> None:
+    from src.indexers.polymarket.collateral import PolymarketCollateralIndexer
+
+    with patch("src.indexers.polymarket.collateral.PolygonClient", return_value=client):
+        PolymarketCollateralIndexer(max_workers=max_workers).run()
+
+
+def test_generates_lookup(isolated_paths):
+    """A fresh run resolves every distinct FPMM address to the documented JSON shape."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B, FPMM_C])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: USDC, FPMM_B: USDC, FPMM_C: DAI},
+        symbol_map={USDC: "USDC", DAI: "DAI"},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {
+        FPMM_A: {"collateral_address": USDC, "collateral_symbol": "USDC"},
+        FPMM_B: {"collateral_address": USDC, "collateral_symbol": "USDC"},
+        FPMM_C: {"collateral_address": DAI, "collateral_symbol": "DAI"},
+    }
+    assert sorted(client.collateral_calls) == sorted([FPMM_A, FPMM_B, FPMM_C])
+
+    # Round-trips with the consumers' USDC filter (cf. polymarket_win_rate_by_price.py)
+    usdc_markets = {addr.lower() for addr, info in lookup.items() if info["collateral_symbol"] == "USDC"}
+    assert usdc_markets == {FPMM_A.lower(), FPMM_B.lower()}
+
+
+def test_idempotent_resume(isolated_paths):
+    """Addresses already in the lookup are skipped; only new ones hit the chain."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B, FPMM_C])
+    lookup_file.write_text(json.dumps({FPMM_A: {"collateral_address": USDC, "collateral_symbol": "USDC"}}))
+
+    client = FakeClient(
+        collateral_map={FPMM_B: USDC, FPMM_C: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client)
+
+    assert len(client.collateral_calls) == 2
+    assert FPMM_A not in client.collateral_calls
+    lookup = json.loads(lookup_file.read_text())
+    assert set(lookup) == {FPMM_A, FPMM_B, FPMM_C}
+
+
+def test_symbol_failure_falls_back_to_unknown(isolated_paths):
+    """A non-standard ERC-20 symbol() failure records UNKNOWN instead of crashing."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: DAI},
+        symbol_map={DAI: Exception("execution reverted")},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {FPMM_A: {"collateral_address": DAI, "collateral_symbol": "UNKNOWN"}}
+
+
+def test_collateral_failure_skips_address(isolated_paths):
+    """An FPMM whose collateralToken() call fails is skipped, not recorded."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: Exception("execution reverted"), FPMM_B: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client)
+
+    lookup = json.loads(lookup_file.read_text())
+    assert lookup == {FPMM_B: {"collateral_address": USDC, "collateral_symbol": "USDC"}}
+
+
+def test_symbol_cache_deduplicates_token_calls(isolated_paths):
+    """FPMMs sharing a collateral token trigger a single symbol() call."""
+    trades_dir, lookup_file = isolated_paths
+    _write_legacy_trades(trades_dir, [FPMM_A, FPMM_B])
+
+    client = FakeClient(
+        collateral_map={FPMM_A: USDC, FPMM_B: USDC},
+        symbol_map={USDC: "USDC"},
+    )
+    _run_indexer(client, max_workers=1)
+
+    assert client.symbol_calls == [USDC]
+
+
+def test_empty_data_dir_is_a_noop(isolated_paths):
+    """With no legacy trades parquet files, the indexer returns without touching the lookup."""
+    trades_dir, lookup_file = isolated_paths
+    trades_dir.mkdir(parents=True, exist_ok=True)
+
+    client = FakeClient(collateral_map={}, symbol_map={})
+    _run_indexer(client)
+
+    assert not lookup_file.exists()
+    assert client.collateral_calls == []

--- a/tests/test_data_api_trades_indexer.py
+++ b/tests/test_data_api_trades_indexer.py
@@ -1,0 +1,195 @@
+"""Tests for the Data API trades indexer: windowing, splitting, resume, dedup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.client import FULL_HISTORY_START
+from src.indexers.polymarket.models import DataApiTrade
+
+
+def make_trade(timestamp: int, tx: str = "0xabc", asset: str = "111", **kwargs) -> DataApiTrade:
+    fields = {
+        "proxy_wallet": "0x01",
+        "side": "BUY",
+        "asset": asset,
+        "condition_id": "0xcc",
+        "size": 1.0,
+        "price": 0.5,
+        "timestamp": timestamp,
+        "transaction_hash": tx,
+    }
+    fields.update(kwargs)
+    return DataApiTrade(**fields)
+
+
+class FakeClient:
+    """Stub for PolymarketClient serving a fixed tape of trades by timestamp."""
+
+    def __init__(
+        self,
+        tape: list[DataApiTrade],
+        *,
+        overflow_threshold: int | None = None,
+        interrupt_at: int | None = None,
+    ):
+        self.tape = sorted(tape, key=lambda t: t.timestamp)
+        self.overflow_threshold = overflow_threshold
+        self.interrupt_at = interrupt_at
+        self.requested_windows: list[tuple[int, int]] = []
+        self.taker_only_args: list[bool] = []
+
+    def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
+        if self.interrupt_at is not None and start >= self.interrupt_at:
+            raise KeyboardInterrupt
+        self.requested_windows.append((start, end))
+        self.taker_only_args.append(taker_only)
+        rows = [t for t in self.tape if start <= t.timestamp <= end]
+        if self.overflow_threshold is not None and len(rows) > self.overflow_threshold:
+            return rows[: self.overflow_threshold], True
+        return rows, False
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "data_api_trades"
+    cursor_file = tmp_path / ".data_api_trades_cursor"
+    import src.indexers.polymarket.data_api_trades as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def read_all(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("trades_*.parquet"))
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def run_indexer(client: FakeClient, **kwargs):
+    from src.indexers.polymarket.data_api_trades import PolymarketDataApiTradesIndexer
+
+    with patch("src.indexers.polymarket.data_api_trades.PolymarketClient", return_value=client):
+        PolymarketDataApiTradesIndexer(**kwargs).run()
+
+
+def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
+    import src.indexers.polymarket.data_api_trades as mod
+
+    monkeypatch.setattr(mod, "BATCH_SIZE", 2)
+    data_dir, cursor_file = isolated_dirs
+    client = FakeClient([make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 199, 200, 299]])
+
+    run_indexer(client, start=100, end=299, window_size=100)
+
+    assert client.requested_windows == [(100, 199), (200, 299)]
+    assert all(client.taker_only_args), "takerOnly must be sent explicitly as True"
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 150, 199, 200, 299]
+    assert "_fetched_at" in df.columns
+    assert df["asset"].map(type).eq(str).all(), "token IDs must be stored as strings"
+
+    # Chunked in BATCH_SIZE files: 2 + 2 + 1 rows
+    files = sorted(data_dir.glob("trades_*.parquet"))
+    assert [f.name for f in files] == ["trades_0_2.parquet", "trades_2_4.parquet", "trades_4_6.parquet"]
+    assert not cursor_file.exists(), "Cursor should be removed after clean completion"
+
+
+def test_default_start_is_full_history(isolated_dirs):
+    _, _ = isolated_dirs
+    client = FakeClient([make_trade(50)])
+
+    run_indexer(client, end=200, window_size=1000)
+
+    assert client.requested_windows == [(FULL_HISTORY_START, 200)]
+
+
+def test_explicit_start_overrides_cursor(isolated_dirs):
+    data_dir, cursor_file = isolated_dirs
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+    cursor_file.write_text("150")
+    client = FakeClient([make_trade(60)])
+
+    run_indexer(client, start=50, end=99, window_size=100)
+
+    assert client.requested_windows == [(50, 99)]
+    assert read_all(data_dir)["timestamp"].tolist() == [60]
+
+
+def test_overflowing_window_is_split_until_it_fits(isolated_dirs):
+    data_dir, _ = isolated_dirs
+    trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
+    client = FakeClient(trades, overflow_threshold=3)
+
+    run_indexer(client, start=100, end=199, window_size=100)
+
+    # The full window overflows the offset cap and must be split recursively
+    assert (100, 199) in client.requested_windows
+    assert len(client.requested_windows) > 1
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105], "every trade must be recovered via splits"
+
+
+def test_overflowing_single_second_window_keeps_partial_rows(isolated_dirs, capsys):
+    data_dir, _ = isolated_dirs
+    # 5 trades in the same second cannot be separated by timestamp windows
+    trades = [make_trade(100, tx=f"0x{i}") for i in range(5)]
+    client = FakeClient(trades, overflow_threshold=3)
+
+    run_indexer(client, start=100, end=100, window_size=100)
+
+    df = read_all(data_dir)
+    assert len(df) == 3, "rows up to the cap are kept for an unsplittable window"
+    assert "overflows the offset cap" in capsys.readouterr().out
+
+
+def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
+    data_dir, cursor_file = isolated_dirs
+    tape = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 250, 350]]
+
+    # Run 1: interrupt when the second window (starting at 200) is requested
+    run_indexer(FakeClient(tape, interrupt_at=200), start=100, end=399, window_size=100)
+
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    assert int(cursor_file.read_text().strip()) == 200, "Cursor should point at the next unfetched timestamp"
+
+    # Run 2: resume with no start (reads cursor), no interrupt
+    client2 = FakeClient(tape)
+    run_indexer(client2, end=399, window_size=100)
+
+    assert client2.requested_windows == [(200, 299), (300, 399)], "Resume should start from the cursor"
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 150, 250, 350]
+    assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
+
+
+def test_duplicate_rows_within_and_across_windows_are_deduped(isolated_dirs):
+    data_dir, _ = isolated_dirs
+    boundary = make_trade(199, tx="0xdup")
+
+    class SloppyClient(FakeClient):
+        """Returns a duplicated row in-window and a boundary row in both windows."""
+
+        def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
+            self.requested_windows.append((start, end))
+            if start == 100:
+                return [make_trade(150, tx="0x150"), make_trade(150, tx="0x150"), boundary], False
+            return [boundary, make_trade(250, tx="0x250")], False
+
+    client = SloppyClient([])
+    run_indexer(client, start=100, end=299, window_size=100)
+
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [150, 199, 250]

--- a/tests/test_data_api_trades_indexer.py
+++ b/tests/test_data_api_trades_indexer.py
@@ -1,4 +1,4 @@
-"""Tests for the Data API trades indexer: windowing, splitting, resume, dedup."""
+"""Tests for the Data API trades indexer: market fan-out, splitting, resume, dedup."""
 
 from __future__ import annotations
 
@@ -28,27 +28,35 @@ def make_trade(timestamp: int, tx: str = "0xabc", asset: str = "111", **kwargs) 
 
 
 class FakeClient:
-    """Stub for PolymarketClient serving a fixed tape of trades by timestamp."""
+    """Stub for PolymarketClient serving a per-market tape of trades."""
 
     def __init__(
         self,
-        tape: list[DataApiTrade],
+        tapes: dict[str, list[DataApiTrade]],
         *,
         overflow_threshold: int | None = None,
-        interrupt_at: int | None = None,
+        interrupt_at_market: str | None = None,
+        interrupt_at_window: int | None = None,
     ):
-        self.tape = sorted(tape, key=lambda t: t.timestamp)
+        self.tapes = {cid: sorted(tape, key=lambda t: t.timestamp) for cid, tape in tapes.items()}
         self.overflow_threshold = overflow_threshold
-        self.interrupt_at = interrupt_at
-        self.requested_windows: list[tuple[int, int]] = []
+        self.interrupt_at_market = interrupt_at_market
+        self.interrupt_at_window = interrupt_at_window
+        self.requested: list[tuple[str, int, int]] = []
         self.taker_only_args: list[bool] = []
 
-    def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
-        if self.interrupt_at is not None and start >= self.interrupt_at:
+    def get_data_trades_window(self, start, end, limit=1000, taker_only=True, market=None):
+        cids = market.split(",") if market else []
+        if self.interrupt_at_market is not None and self.interrupt_at_market in cids:
             raise KeyboardInterrupt
-        self.requested_windows.append((start, end))
+        if self.interrupt_at_window is not None and start >= self.interrupt_at_window:
+            raise KeyboardInterrupt
+        self.requested.append((market, start, end))
         self.taker_only_args.append(taker_only)
-        rows = [t for t in self.tape if start <= t.timestamp <= end]
+        rows = sorted(
+            (t for cid in cids for t in self.tapes.get(cid, []) if start <= t.timestamp <= end),
+            key=lambda t: t.timestamp,
+        )
         if self.overflow_threshold is not None and len(rows) > self.overflow_threshold:
             return rows[: self.overflow_threshold], True
         return rows, False
@@ -59,14 +67,22 @@ class FakeClient:
 
 @pytest.fixture()
 def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    """Point DATA_DIR, MARKETS_DIR, and CURSOR_FILE at temp directories."""
     data_dir = tmp_path / "data_api_trades"
+    markets_dir = tmp_path / "markets"
     cursor_file = tmp_path / ".data_api_trades_cursor"
     import src.indexers.polymarket.data_api_trades as mod
 
     monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "MARKETS_DIR", markets_dir)
     monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
-    return data_dir, cursor_file
+    return data_dir, markets_dir, cursor_file
+
+
+def write_markets(markets_dir: Path, condition_ids: list[str]):
+    markets_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"condition_id": condition_ids})
+    df.to_parquet(markets_dir / f"markets_0_{len(condition_ids)}.parquet")
 
 
 def read_all(data_dir: Path) -> pd.DataFrame:
@@ -81,16 +97,24 @@ def run_indexer(client: FakeClient, **kwargs):
         PolymarketDataApiTradesIndexer(**kwargs).run()
 
 
-def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
+def test_markets_are_batched_and_all_trades_saved(isolated_dirs, monkeypatch):
     import src.indexers.polymarket.data_api_trades as mod
 
     monkeypatch.setattr(mod, "BATCH_SIZE", 2)
-    data_dir, cursor_file = isolated_dirs
-    client = FakeClient([make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 199, 200, 299]])
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    # Duplicate and empty condition IDs in the dataset must be ignored
+    write_markets(markets_dir, ["0xa", "0xb", "0xa", "", "0xc"])
+    client = FakeClient(
+        {
+            "0xa": [make_trade(100, tx="0x100"), make_trade(150, tx="0x150")],
+            "0xb": [make_trade(199, tx="0x199"), make_trade(200, tx="0x200")],
+            "0xc": [make_trade(299, tx="0x299")],
+        }
+    )
 
-    run_indexer(client, start=100, end=299, window_size=100)
+    run_indexer(client, start=100, end=299, markets_per_request=2)
 
-    assert client.requested_windows == [(100, 199), (200, 299)]
+    assert client.requested == [("0xa,0xb", 100, 299), ("0xc", 100, 299)]
     assert all(client.taker_only_args), "takerOnly must be sent explicitly as True"
 
     df = read_all(data_dir)
@@ -105,69 +129,76 @@ def test_windows_cover_range_and_all_trades_saved(isolated_dirs, monkeypatch):
 
 
 def test_default_start_is_full_history(isolated_dirs):
-    _, _ = isolated_dirs
-    client = FakeClient([make_trade(50)])
+    _, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
+    client = FakeClient({"0xa": [make_trade(50)]})
 
-    run_indexer(client, end=200, window_size=1000)
+    run_indexer(client, end=200)
 
-    assert client.requested_windows == [(FULL_HISTORY_START, 200)]
+    assert client.requested == [("0xa", FULL_HISTORY_START, 200)]
 
 
-def test_explicit_start_overrides_cursor(isolated_dirs):
-    data_dir, cursor_file = isolated_dirs
-    cursor_file.parent.mkdir(parents=True, exist_ok=True)
-    cursor_file.write_text("150")
-    client = FakeClient([make_trade(60)])
+def test_missing_markets_dataset_is_graceful(isolated_dirs, capsys):
+    data_dir, _, _ = isolated_dirs
+    client = FakeClient({})
 
-    run_indexer(client, start=50, end=99, window_size=100)
+    run_indexer(client)
 
-    assert client.requested_windows == [(50, 99)]
-    assert read_all(data_dir)["timestamp"].tolist() == [60]
+    assert "run the polymarket_markets indexer first" in capsys.readouterr().out
+    assert not data_dir.exists()
+    assert client.requested == []
 
 
 def test_overflowing_window_is_split_until_it_fits(isolated_dirs):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
-    client = FakeClient(trades, overflow_threshold=3)
+    client = FakeClient({"0xa": trades}, overflow_threshold=3)
 
-    run_indexer(client, start=100, end=199, window_size=100)
+    run_indexer(client, start=100, end=199)
 
     # The full window overflows the offset cap and must be split recursively
-    assert (100, 199) in client.requested_windows
-    assert len(client.requested_windows) > 1
+    assert ("0xa", 100, 199) in client.requested
+    assert len(client.requested) > 1
 
     df = read_all(data_dir)
     assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105], "every trade must be recovered via splits"
 
 
 def test_overflowing_single_second_window_keeps_partial_rows(isolated_dirs, capsys):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     # 5 trades in the same second cannot be separated by timestamp windows
     trades = [make_trade(100, tx=f"0x{i}") for i in range(5)]
-    client = FakeClient(trades, overflow_threshold=3)
+    client = FakeClient({"0xa": trades}, overflow_threshold=3)
 
-    run_indexer(client, start=100, end=100, window_size=100)
+    run_indexer(client, start=100, end=100)
 
     df = read_all(data_dir)
     assert len(df) == 3, "rows up to the cap are kept for an unsplittable window"
     assert "overflows the offset cap" in capsys.readouterr().out
 
 
-def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
-    data_dir, cursor_file = isolated_dirs
-    tape = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 150, 250, 350]]
+def test_interrupt_then_resume_skips_completed_markets(isolated_dirs):
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    write_markets(markets_dir, ["0xa", "0xb", "0xc"])
+    tapes = {
+        "0xa": [make_trade(100, tx="0x100"), make_trade(150, tx="0x150")],
+        "0xb": [make_trade(250, tx="0x250")],
+        "0xc": [make_trade(350, tx="0x350")],
+    }
 
-    # Run 1: interrupt when the second window (starting at 200) is requested
-    run_indexer(FakeClient(tape, interrupt_at=200), start=100, end=399, window_size=100)
+    # Run 1: interrupt when market 0xb is requested
+    run_indexer(FakeClient(tapes, interrupt_at_market="0xb"), start=100, end=399, markets_per_request=1)
 
     assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
-    assert int(cursor_file.read_text().strip()) == 200, "Cursor should point at the next unfetched timestamp"
+    assert cursor_file.read_text().strip() == "1", "Cursor should point at the next unfetched market"
 
-    # Run 2: resume with no start (reads cursor), no interrupt
-    client2 = FakeClient(tape)
-    run_indexer(client2, end=399, window_size=100)
+    # Run 2: resume from the cursor, no interrupt
+    client2 = FakeClient(tapes)
+    run_indexer(client2, start=100, end=399, markets_per_request=1)
 
-    assert client2.requested_windows == [(200, 299), (300, 399)], "Resume should start from the cursor"
+    assert client2.requested == [("0xb", 100, 399), ("0xc", 100, 399)], "Resume should skip completed markets"
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
 
     df = read_all(data_dir)
@@ -175,21 +206,51 @@ def test_interrupt_then_resume_completes_without_duplicates(isolated_dirs):
     assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
 
 
+def test_interrupt_inside_market_resumes_from_window_cursor(isolated_dirs):
+    data_dir, markets_dir, cursor_file = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
+    trades = [make_trade(ts, tx=f"0x{ts}") for ts in [100, 101, 102, 103, 104, 105]]
+
+    # Run 1: overflow forces splitting into leaf windows; interrupt once the
+    # window walk reaches timestamp 104, after leaves [100,101] and [102,103].
+    run_indexer(
+        FakeClient({"0xa": trades}, overflow_threshold=3, interrupt_at_window=104),
+        start=100,
+        end=199,
+    )
+
+    idx, ts = cursor_file.read_text().strip().split(",")
+    assert (idx, int(ts)) == ("0", 104), "Cursor should point inside the interrupted market"
+    assert sorted(read_all(data_dir)["timestamp"]) == [100, 101, 102, 103]
+
+    # Run 2: resume mid-market without refetching completed windows
+    client2 = FakeClient({"0xa": trades})
+    run_indexer(client2, start=100, end=199)
+
+    assert client2.requested == [("0xa", 104, 199)]
+    df = read_all(data_dir)
+    assert sorted(df["timestamp"]) == [100, 101, 102, 103, 104, 105]
+    assert not df.duplicated(subset=["transaction_hash", "timestamp"]).any()
+
+
 def test_duplicate_rows_within_and_across_windows_are_deduped(isolated_dirs):
-    data_dir, _ = isolated_dirs
+    data_dir, markets_dir, _ = isolated_dirs
+    write_markets(markets_dir, ["0xa"])
     boundary = make_trade(199, tx="0xdup")
 
     class SloppyClient(FakeClient):
-        """Returns a duplicated row in-window and a boundary row in both windows."""
+        """Splits once, returns a duplicated row in-window and a boundary row in both leaves."""
 
-        def get_data_trades_window(self, start, end, limit=1000, taker_only=True):
-            self.requested_windows.append((start, end))
-            if start == 100:
+        def get_data_trades_window(self, start, end, limit=1000, taker_only=True, market=None):
+            self.requested.append((market, start, end))
+            if (start, end) == (100, 299):
+                return [], True
+            if end <= 199:
                 return [make_trade(150, tx="0x150"), make_trade(150, tx="0x150"), boundary], False
             return [boundary, make_trade(250, tx="0x250")], False
 
-    client = SloppyClient([])
-    run_indexer(client, start=100, end=299, window_size=100)
+    client = SloppyClient({})
+    run_indexer(client, start=100, end=299)
 
     df = read_all(data_dir)
     assert sorted(df["timestamp"]) == [150, 199, 250]

--- a/tests/test_events_indexer.py
+++ b/tests/test_events_indexer.py
@@ -1,0 +1,211 @@
+"""Tests for the Polymarket events indexer: pagination, resume, interrupt, schema (no network)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.models import Event
+
+EVENT_FIELDS = [
+    "id",
+    "slug",
+    "title",
+    "category",
+    "tags",
+    "market_ids",
+    "volume",
+    "liquidity",
+    "active",
+    "closed",
+    "start_date",
+    "end_date",
+    "created_at",
+]
+
+
+def make_event(i: int, closed: bool = False) -> Event:
+    return Event.from_dict(
+        {
+            "id": str(i),
+            "slug": f"event-{i}",
+            "title": f"Event {i}",
+            "category": "Sports",
+            "tags": [{"slug": "sports"}],
+            "markets": [{"id": str(i * 10)}],
+            "volume": 10.0,
+            "liquidity": 5.0,
+            "active": not closed,
+            "closed": closed,
+            "startDate": "2026-06-01T00:00:00Z",
+            "endDate": "2026-06-30T00:00:00Z",
+            "createdAt": "2026-05-01T00:00:00Z",
+        }
+    )
+
+
+class FakeClient:
+    """Stub for PolymarketClient serving canned keyset pages.
+
+    `responses` maps (closed, after_cursor) -> (events, next_cursor);
+    `interrupt_at` raises KeyboardInterrupt before serving that key.
+    """
+
+    def __init__(self, responses: dict, interrupt_at: tuple | None = None):
+        self.responses = responses
+        self.calls: list[dict] = []
+        self._interrupt_at = interrupt_at
+        self.was_closed = False
+
+    def iter_events_keyset(self, limit: int = 500, after_cursor: str | None = None, **kwargs):
+        closed = kwargs.get("closed")
+        cursor = after_cursor
+        while True:
+            if self._interrupt_at is not None and (closed, cursor) == self._interrupt_at:
+                raise KeyboardInterrupt
+            self.calls.append({"limit": limit, "after_cursor": cursor, "closed": closed})
+            events, cursor = self.responses[(closed, cursor)]
+            yield events, cursor
+            if not cursor:
+                break
+
+    def close(self):
+        self.was_closed = True
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "events"
+    cursor_file = tmp_path / ".events_backfill_cursor"
+    import src.indexers.polymarket.events as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def run_indexer(client: FakeClient) -> None:
+    from src.indexers.polymarket.events import PolymarketEventsIndexer
+
+    with patch("src.indexers.polymarket.events.PolymarketClient", return_value=client):
+        PolymarketEventsIndexer().run()
+
+
+def read_all(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("events_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def test_full_backfill_paginates_both_phases(isolated_dirs, monkeypatch: pytest.MonkeyPatch):
+    """Both closed=False and closed=True passes run, following keyset cursors."""
+    import src.indexers.polymarket.events as mod
+
+    monkeypatch.setattr(mod, "CHUNK_SIZE", 4)
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(
+        {
+            (False, None): ([make_event(1), make_event(2)], "o2"),
+            (False, "o2"): ([make_event(3)], None),
+            (True, None): ([make_event(4, closed=True), make_event(5, closed=True)], None),
+        }
+    )
+    run_indexer(client)
+
+    assert client.calls == [
+        {"limit": 500, "after_cursor": None, "closed": False},
+        {"limit": 500, "after_cursor": "o2", "closed": False},
+        {"limit": 500, "after_cursor": None, "closed": True},
+    ]
+
+    files = sorted(data_dir.glob("events_*.parquet"), key=lambda p: int(p.stem.split("_")[1]))
+    assert [len(pd.read_parquet(f)) for f in files] == [4, 1], "Full chunk saved mid-run, remainder flushed at end"
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4", "5"]
+
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+    assert client.was_closed
+
+
+def test_parquet_schema_matches_event_model(isolated_dirs):
+    """Chunk columns are exactly the Event fields plus _fetched_at."""
+    data_dir, _ = isolated_dirs
+
+    client = FakeClient(
+        {
+            (False, None): ([make_event(1)], None),
+            (True, None): ([], None),
+        }
+    )
+    run_indexer(client)
+
+    df = read_all(data_dir)
+    assert list(df.columns) == EVENT_FIELDS + ["_fetched_at"]
+    assert json.loads(df.iloc[0]["tags"]) == ["sports"]
+    assert json.loads(df.iloc[0]["market_ids"]) == ["10"]
+    assert df.iloc[0]["_fetched_at"] is not None
+
+
+def test_resume_starts_from_saved_phase_and_cursor(isolated_dirs):
+    """A saved cursor skips completed phases and resumes mid-phase."""
+    _, cursor_file = isolated_dirs
+    cursor_file.write_text(json.dumps({"phase": "closed", "cursor": "c2"}))
+
+    client = FakeClient({(True, "c2"): ([make_event(6, closed=True)], None)})
+    run_indexer(client)
+
+    assert client.calls == [{"limit": 500, "after_cursor": "c2", "closed": True}]
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_interrupt_then_resume_completes(isolated_dirs):
+    """Interrupt a backfill with Ctrl+C, then resume and finish the job."""
+    data_dir, cursor_file = isolated_dirs
+
+    # Run 1: interrupt when the open phase requests the page at cursor "o2"
+    client1 = FakeClient(
+        {(False, None): ([make_event(1), make_event(2)], "o2")},
+        interrupt_at=(False, "o2"),
+    )
+    run_indexer(client1)
+
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    assert json.loads(cursor_file.read_text()) == {"phase": "open", "cursor": "o2"}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"], "Buffered events flushed on interrupt"
+
+    # Run 2: resume from the saved cursor, no interrupt
+    client2 = FakeClient(
+        {
+            (False, "o2"): ([make_event(3)], None),
+            (True, None): ([make_event(4, closed=True)], None),
+        }
+    )
+    run_indexer(client2)
+
+    assert client2.calls[0] == {"limit": 500, "after_cursor": "o2", "closed": False}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4"], "Resume fetches only the remaining pages"
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_interrupt_between_phases_resumes_at_closed_phase(isolated_dirs):
+    """After the open phase completes, resume skips straight to the closed phase."""
+    data_dir, cursor_file = isolated_dirs
+
+    client1 = FakeClient(
+        {(False, None): ([make_event(1)], None)},
+        interrupt_at=(True, None),
+    )
+    run_indexer(client1)
+
+    assert json.loads(cursor_file.read_text()) == {"phase": "closed", "cursor": None}
+
+    client2 = FakeClient({(True, None): ([make_event(2, closed=True)], None)})
+    run_indexer(client2)
+
+    assert all(call["closed"] is True for call in client2.calls), "Open phase should not be re-crawled"
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"]
+    assert not cursor_file.exists()

--- a/tests/test_events_indexer.py
+++ b/tests/test_events_indexer.py
@@ -52,13 +52,19 @@ class FakeClient:
     """Stub for PolymarketClient serving canned keyset pages.
 
     `responses` maps (closed, after_cursor) -> (events, next_cursor);
-    `interrupt_at` raises KeyboardInterrupt before serving that key.
+    `interrupt_at` raises `exc` (KeyboardInterrupt by default) before serving that key.
     """
 
-    def __init__(self, responses: dict, interrupt_at: tuple | None = None):
+    def __init__(
+        self,
+        responses: dict,
+        interrupt_at: tuple | None = None,
+        exc: type[BaseException] = KeyboardInterrupt,
+    ):
         self.responses = responses
         self.calls: list[dict] = []
         self._interrupt_at = interrupt_at
+        self._exc = exc
         self.was_closed = False
 
     def iter_events_keyset(self, limit: int = 500, after_cursor: str | None = None, **kwargs):
@@ -66,7 +72,7 @@ class FakeClient:
         cursor = after_cursor
         while True:
             if self._interrupt_at is not None and (closed, cursor) == self._interrupt_at:
-                raise KeyboardInterrupt
+                raise self._exc
             self.calls.append({"limit": limit, "after_cursor": cursor, "closed": closed})
             events, cursor = self.responses[(closed, cursor)]
             yield events, cursor
@@ -189,6 +195,22 @@ def test_interrupt_then_resume_completes(isolated_dirs):
     assert client2.calls[0] == {"limit": 500, "after_cursor": "o2", "closed": False}
     assert sorted(read_all(data_dir)["id"]) == ["1", "2", "3", "4"], "Resume fetches only the remaining pages"
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_crash_flushes_buffer_and_preserves_cursor(isolated_dirs):
+    """A non-interrupt crash still flushes buffered events, so the saved cursor never points past unsaved data."""
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(
+        {(False, None): ([make_event(1), make_event(2)], "o2")},
+        interrupt_at=(False, "o2"),
+        exc=RuntimeError,
+    )
+    with pytest.raises(RuntimeError):
+        run_indexer(client)
+
+    assert json.loads(cursor_file.read_text()) == {"phase": "open", "cursor": "o2"}
+    assert sorted(read_all(data_dir)["id"]) == ["1", "2"], "Buffered events flushed on crash"
 
 
 def test_interrupt_between_phases_resumes_at_closed_phase(isolated_dirs):

--- a/tests/test_orderbook_recorder.py
+++ b/tests/test_orderbook_recorder.py
@@ -1,0 +1,261 @@
+"""Tests for the live orderbook recorder against a mocked market WebSocket."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from src.indexers.polymarket.models import OrderBookDelta
+from src.indexers.polymarket.orderbook import OrderBookRecorder, OrderBookWriter
+
+CONDITION_ID = "0x" + "ab" * 32
+
+BOOK_MSG = {
+    "event_type": "book",
+    "asset_id": "111",
+    "market": CONDITION_ID,
+    "bids": [{"price": "0.48", "size": "30"}, {"price": "0.49", "size": "20"}],
+    "asks": [{"price": "0.52", "size": "25"}],
+    "timestamp": "1784254990511",
+    "hash": "0x1234",
+}
+
+PRICE_CHANGE_MSG = {
+    "event_type": "price_change",
+    "market": CONDITION_ID,
+    "price_changes": [
+        {
+            "asset_id": "111",
+            "price": "0.5",
+            "size": "200",
+            "side": "BUY",
+            "hash": "56621a121a47ed93",
+            "best_bid": "0.5",
+            "best_ask": "0.52",
+        },
+        {
+            "asset_id": "111",
+            "price": "0.52",
+            "size": "0",
+            "side": "SELL",
+            "hash": "77731b232b58fe04",
+            "best_bid": "0.5",
+            "best_ask": "0.53",
+        },
+    ],
+    "timestamp": "1784254991000",
+}
+
+
+class FakeSocket:
+    """Mocked market-channel socket: yields scripted frames and records sends."""
+
+    def __init__(self, frames: list[str] = (), error: Exception | None = None, on_drained=None):
+        self.frames = list(frames)
+        self.error = error
+        self.on_drained = on_drained
+        self.sent: list[str] = []
+        self._hold = asyncio.Event()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.frames:
+            return self.frames.pop(0)
+        if self.error is not None:
+            raise self.error
+        if self.on_drained is not None:
+            self.on_drained()
+            raise StopAsyncIteration
+        await self._hold.wait()
+        raise StopAsyncIteration
+
+    async def send(self, data: str):
+        self.sent.append(data)
+
+    def release(self):
+        self._hold.set()
+
+
+def read_table(data_dir: Path, table: str) -> pd.DataFrame:
+    files = sorted((data_dir / table).glob("*.parquet"))
+    assert files, f"no parquet chunks written for {table}"
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+# -- Model parsing -------------------------------------------------------------
+
+
+def test_delta_list_from_message_preserves_raw_strings():
+    deltas = OrderBookDelta.list_from_message(PRICE_CHANGE_MSG)
+
+    assert len(deltas) == 2
+    assert deltas[0].condition_id == CONDITION_ID
+    assert deltas[0].token_id == "111"
+    assert deltas[0].timestamp == 1784254991000
+    assert deltas[0].hash == "56621a121a47ed93"
+    assert (deltas[0].side, deltas[0].price, deltas[0].size) == ("BUY", "0.5", "200")
+    assert (deltas[0].best_bid, deltas[0].best_ask) == ("0.5", "0.52")
+    assert (deltas[1].side, deltas[1].price, deltas[1].size) == ("SELL", "0.52", "0")
+
+
+def test_delta_list_from_legacy_changes_shape():
+    message = {
+        "event_type": "price_change",
+        "market": CONDITION_ID,
+        "asset_id": "222",
+        "hash": "abcd",
+        "changes": [{"price": "0.4", "side": "SELL", "size": "3300"}],
+        "timestamp": "1729084877448",
+    }
+
+    deltas = OrderBookDelta.list_from_message(message)
+
+    assert len(deltas) == 1
+    assert deltas[0].token_id == "222"
+    assert deltas[0].hash == "abcd"
+    assert (deltas[0].side, deltas[0].price, deltas[0].size) == ("SELL", "0.4", "3300")
+    assert deltas[0].best_bid == ""
+
+
+# -- Message handling & persistence ---------------------------------------------
+
+
+def test_book_snapshot_persists_raw_levels_and_hash(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(BOOK_MSG))
+    writer.flush()
+
+    books = read_table(tmp_path, "books")
+    assert len(books) == 1
+    row = books.iloc[0]
+    assert row["token_id"] == "111"
+    assert row["condition_id"] == CONDITION_ID
+    assert row["timestamp"] == 1784254990511  # exchange milliseconds
+    assert row["hash"] == "0x1234"
+    assert json.loads(row["bids"]) == BOOK_MSG["bids"]  # raw levels, string prices intact
+    assert json.loads(row["asks"]) == BOOK_MSG["asks"]
+    assert row["_recorded_at"] is not None
+
+
+def test_price_change_deltas_persist_including_size_zero_removal(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(PRICE_CHANGE_MSG))
+    writer.flush()
+
+    changes = read_table(tmp_path, "price_changes")
+    assert len(changes) == 2
+    assert list(changes["side"]) == ["BUY", "SELL"]
+    assert list(changes["size"]) == ["200", "0"]  # "0" = level removed
+    assert list(changes["price"]) == ["0.5", "0.52"]
+    assert list(changes["best_bid"]) == ["0.5", "0.5"]
+    assert list(changes["best_ask"]) == ["0.52", "0.53"]
+    assert set(changes["timestamp"]) == {1784254991000}
+
+
+def test_non_json_and_unknown_events_are_ignored(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message("PONG")
+    recorder.handle_message(json.dumps({"event_type": "tick_size_change", "asset_id": "111"}))
+    writer.flush()
+
+    assert not (tmp_path / "books").exists()
+    assert not (tmp_path / "price_changes").exists()
+
+
+def test_writer_auto_flushes_at_chunk_size(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path, chunk_size=2)
+    recorder = OrderBookRecorder(["111"], writer)
+
+    recorder.handle_message(json.dumps(BOOK_MSG))
+    assert not (tmp_path / "books").exists()
+    recorder.handle_message(json.dumps(BOOK_MSG))
+
+    files = list((tmp_path / "books").glob("*.parquet"))
+    assert len(files) == 1
+    assert files[0].name == "books_1784254990511_1784254990511.parquet"
+    assert len(pd.read_parquet(files[0])) == 2
+
+
+# -- Live recording over a mocked socket ------------------------------------------
+
+
+def test_record_subscribes_and_persists_stream(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> FakeSocket:
+        # a real feed wraps some frames in a JSON array; both shapes must record
+        socket = FakeSocket(
+            frames=[json.dumps([BOOK_MSG]), json.dumps(PRICE_CHANGE_MSG)],
+            on_drained=lambda: recorder.stop(),
+        )
+        recorder = OrderBookRecorder(["111", "222"], writer, connect=lambda: socket)
+        await recorder.record()
+        return socket
+
+    socket = asyncio.run(main())
+
+    assert json.loads(socket.sent[0]) == {"assets_ids": ["111", "222"], "type": "market"}
+    assert len(read_table(tmp_path, "books")) == 1
+    assert len(read_table(tmp_path, "price_changes")) == 2
+
+
+def test_record_sends_ping_heartbeats(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> FakeSocket:
+        socket = FakeSocket()
+        recorder = OrderBookRecorder(["111"], writer, ping_interval=0.01, connect=lambda: socket)
+        task = asyncio.create_task(recorder.record())
+        await asyncio.sleep(0.06)
+        recorder.stop()
+        socket.release()
+        await task
+        return socket
+
+    socket = asyncio.run(main())
+
+    assert json.loads(socket.sent[0])["type"] == "market"
+    assert socket.sent.count("PING") >= 2
+
+
+def test_record_reconnects_and_resubscribes_after_drop(tmp_path: Path):
+    writer = OrderBookWriter(data_dir=tmp_path)
+
+    async def main() -> list[FakeSocket]:
+        sockets: list[FakeSocket] = []
+        recorder = OrderBookRecorder(
+            ["111"],
+            writer,
+            initial_reconnect_delay=0,
+            connect=lambda: sockets.pop(0),
+        )
+        sockets.append(FakeSocket(frames=[json.dumps(BOOK_MSG)], error=RuntimeError("connection dropped")))
+        second = FakeSocket(frames=[json.dumps(BOOK_MSG)], on_drained=lambda: recorder.stop())
+        sockets.append(second)
+        first = sockets[0]
+        await recorder.record()
+        return [first, second]
+
+    first, second = asyncio.run(main())
+
+    # both connections must (re)subscribe; the server answers each with a fresh snapshot
+    assert json.loads(first.sent[0]) == {"assets_ids": ["111"], "type": "market"}
+    assert json.loads(second.sent[0]) == {"assets_ids": ["111"], "type": "market"}
+    assert len(read_table(tmp_path, "books")) == 2

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -375,6 +375,19 @@ def test_get_data_trades_window_truncates_at_offset_cap(monkeypatch):
     assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
 
 
+def test_get_data_trades_window_scopes_by_market():
+    client = make_client([[DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, market="0xaa,0xbb")
+
+    assert len(trades) == 1
+    assert truncated is False
+    params = client.http.calls[0][1]
+    assert params["market"] == "0xaa,0xbb"
+    assert params["start"] == 1
+    assert params["end"] == 100
+
+
 def test_get_data_trades_window_counts_raw_rows_for_pagination():
     malformed = dict(DATA_API_TRADE, size="not-a-number")
     client = make_client([[DATA_API_TRADE, malformed], [DATA_API_TRADE]])

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
-from src.indexers.polymarket.client import PolymarketClient
-from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+import src.indexers.polymarket.client as client_module
+from src.indexers.polymarket.client import FULL_HISTORY_START, PolymarketClient
+from src.indexers.polymarket.models import DataApiTrade, Event, Market, OrderBookSnapshot, PricePoint
 
 GAMMA_MARKET = {
     "id": "500000",
@@ -39,6 +40,24 @@ GAMMA_EVENT = {
     "startDate": "2026-06-04T00:00:00Z",
     "endDate": "2026-06-22T00:00:00Z",
     "createdAt": "2026-05-27T14:40:02.074Z",
+}
+
+DATA_API_TRADE = {
+    "proxyWallet": "0x" + "ef" * 20,
+    "side": "BUY",
+    "asset": "111",
+    "conditionId": "0x" + "ab" * 32,
+    "size": "10.5",
+    "price": "0.65",
+    "timestamp": 1752700000,
+    "transactionHash": "0x" + "12" * 32,
+    "title": "Will it rain tomorrow?",
+    "slug": "will-it-rain-tomorrow",
+    "eventSlug": "weather-week",
+    "outcome": "Yes",
+    "outcomeIndex": 0,
+    "name": "trader",
+    "pseudonym": "Quiet-Fox",
 }
 
 ORDER_BOOK = {
@@ -259,6 +278,114 @@ def test_iter_events_keyset_resumes_from_cursor():
     url, params = client.http.calls[0]
     assert url == "https://gamma-api.polymarket.com/events/keyset"
     assert params["after_cursor"] == "resume-here"
+
+
+# -- Data API trades --------------------------------------------------------------
+
+
+def test_data_api_trade_from_dict():
+    trade = DataApiTrade.from_dict(DATA_API_TRADE)
+
+    assert trade.proxy_wallet == "0x" + "ef" * 20
+    assert trade.side == "BUY"
+    assert trade.asset == "111"
+    assert trade.condition_id == "0x" + "ab" * 32
+    assert trade.size == 10.5
+    assert trade.price == 0.65
+    assert trade.timestamp == 1752700000
+    assert trade.transaction_hash == "0x" + "12" * 32
+    assert trade.title == "Will it rain tomorrow?"
+    assert trade.event_slug == "weather-week"
+    assert trade.outcome == "Yes"
+    assert trade.outcome_index == 0
+    assert trade.pseudonym == "Quiet-Fox"
+
+
+def test_data_api_trade_from_dict_defaults():
+    trade = DataApiTrade.from_dict({})
+
+    assert trade.proxy_wallet == ""
+    assert trade.asset == ""
+    assert trade.size == 0.0
+    assert trade.price == 0.0
+    assert trade.timestamp == 0
+    assert trade.outcome_index == -1
+    assert trade.pseudonym == ""
+
+
+def test_get_data_trades_default_window_omits_start_and_sends_taker_only():
+    client = make_client([[DATA_API_TRADE]])
+
+    trades = client.get_data_trades()
+
+    assert len(trades) == 1
+    url, params = client.http.calls[0]
+    assert url == "https://data-api.polymarket.com/trades"
+    assert params == {"limit": 1000, "offset": 0, "takerOnly": True}
+    assert "start" not in params  # API defaults to its ~3-year window
+    assert "end" not in params
+
+
+def test_get_data_trades_full_history_sends_start_1():
+    client = make_client([[DATA_API_TRADE]])
+
+    client.get_data_trades(start=FULL_HISTORY_START, end=1752700000, taker_only=False)
+
+    assert client.http.calls[0][1] == {
+        "limit": 1000,
+        "offset": 0,
+        "takerOnly": False,
+        "start": 1,
+        "end": 1752700000,
+    }
+
+
+def test_get_data_trades_skips_malformed_rows():
+    malformed = dict(DATA_API_TRADE, size="not-a-number")
+    client = make_client([[DATA_API_TRADE, malformed, "not-a-dict", None]])
+
+    trades = client.get_data_trades()
+
+    assert len(trades) == 1
+    assert trades[0].size == 10.5
+
+
+def test_get_data_trades_window_paginates_offsets_until_short_page():
+    client = make_client([[DATA_API_TRADE] * 2, [DATA_API_TRADE] * 2, [DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    assert len(trades) == 5
+    assert truncated is False
+    assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
+    for _, params in client.http.calls:
+        assert params["start"] == 1
+        assert params["end"] == 100
+        assert params["takerOnly"] is True
+
+
+def test_get_data_trades_window_truncates_at_offset_cap(monkeypatch):
+    monkeypatch.setattr(client_module, "MAX_DATA_API_OFFSET", 4)
+    client = make_client([[DATA_API_TRADE] * 2] * 3)
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    assert len(trades) == 6
+    assert truncated is True
+    assert [call[1]["offset"] for call in client.http.calls] == [0, 2, 4]
+
+
+def test_get_data_trades_window_counts_raw_rows_for_pagination():
+    malformed = dict(DATA_API_TRADE, size="not-a-number")
+    client = make_client([[DATA_API_TRADE, malformed], [DATA_API_TRADE]])
+
+    trades, truncated = client.get_data_trades_window(1, 100, limit=2)
+
+    # First page is full in raw rows despite the skipped malformed row,
+    # so pagination must continue to the second (short) page.
+    assert len(trades) == 2
+    assert truncated is False
+    assert len(client.http.calls) == 2
 
 
 # -- CLOB endpoints --------------------------------------------------------------

--- a/tests/test_polymarket_client.py
+++ b/tests/test_polymarket_client.py
@@ -1,0 +1,311 @@
+"""Unit tests for PolymarketClient and its Gamma/CLOB models (no network)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from src.indexers.polymarket.client import PolymarketClient
+from src.indexers.polymarket.models import Event, Market, OrderBookSnapshot, PricePoint
+
+GAMMA_MARKET = {
+    "id": "500000",
+    "conditionId": "0x" + "ab" * 32,
+    "question": "Will it rain tomorrow?",
+    "slug": "will-it-rain-tomorrow",
+    "outcomes": '["Yes", "No"]',
+    "outcomePrices": '["0.65", "0.35"]',
+    "clobTokenIds": '["111", "222"]',
+    "volume": "1234.5",
+    "liquidity": "678.9",
+    "active": True,
+    "closed": False,
+    "endDate": "2026-08-01T00:00:00Z",
+    "createdAt": "2026-07-01T12:30:00Z",
+    "marketMakerAddress": "0x" + "cd" * 20,
+}
+
+GAMMA_EVENT = {
+    "id": "2891",
+    "slug": "nba-finals-2026",
+    "title": "NBA Finals 2026",
+    "category": "Sports",
+    "tags": [{"id": "1", "label": "Sports", "slug": "sports"}, {"id": "2", "label": "NBA", "slug": "nba"}],
+    "markets": [{"id": "500000"}, {"id": "500001"}],
+    "volume": 1335.05,
+    "liquidity": 42.0,
+    "active": True,
+    "closed": True,
+    "startDate": "2026-06-04T00:00:00Z",
+    "endDate": "2026-06-22T00:00:00Z",
+    "createdAt": "2026-05-27T14:40:02.074Z",
+}
+
+ORDER_BOOK = {
+    "market": "0x" + "ab" * 32,
+    "asset_id": "111",
+    "timestamp": "1784254990511",
+    "hash": "720dff71476f22d3",
+    "bids": [{"price": "0.45", "size": "100"}, {"price": "0.44", "size": "50.5"}],
+    "asks": [{"price": "0.46", "size": "150"}],
+    "min_order_size": "5",
+    "tick_size": "0.001",
+    "neg_risk": True,
+    "last_trade_price": "0.45",
+}
+
+
+class FakeHttp:
+    """Stub for HttpClient that returns canned responses and records calls."""
+
+    def __init__(self, responses: list):
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, *, params: dict | None = None):
+        self.calls.append((url, params or {}))
+        return self.responses.pop(0)
+
+    def close(self):
+        pass
+
+
+def make_client(responses: list) -> PolymarketClient:
+    client = PolymarketClient()
+    client.http.close()
+    client.http = FakeHttp(responses)
+    return client
+
+
+# -- Model parsing -------------------------------------------------------------
+
+
+def test_market_from_dict():
+    market = Market.from_dict(GAMMA_MARKET)
+
+    assert market.id == "500000"
+    assert market.condition_id == "0x" + "ab" * 32
+    assert market.clob_token_ids == '["111", "222"]'
+    assert market.volume == 1234.5
+    assert market.liquidity == 678.9
+    assert market.active is True
+    assert market.closed is False
+    assert market.end_date == datetime(2026, 8, 1, tzinfo=timezone.utc)
+    assert market.created_at == datetime(2026, 7, 1, 12, 30, tzinfo=timezone.utc)
+    assert market.market_maker_address == "0x" + "cd" * 20
+
+
+def test_market_from_dict_defaults():
+    market = Market.from_dict({})
+
+    assert market.id == ""
+    assert market.outcomes == "[]"
+    assert market.volume == 0.0
+    assert market.active is False
+    assert market.end_date is None
+    assert market.market_maker_address is None
+
+
+def test_event_from_dict():
+    event = Event.from_dict(GAMMA_EVENT)
+
+    assert event.id == "2891"
+    assert event.slug == "nba-finals-2026"
+    assert event.title == "NBA Finals 2026"
+    assert event.category == "Sports"
+    assert json.loads(event.tags) == ["sports", "nba"]
+    assert json.loads(event.market_ids) == ["500000", "500001"]
+    assert event.volume == 1335.05
+    assert event.liquidity == 42.0
+    assert event.active is True
+    assert event.closed is True
+    assert event.start_date == datetime(2026, 6, 4, tzinfo=timezone.utc)
+    assert event.end_date == datetime(2026, 6, 22, tzinfo=timezone.utc)
+    assert event.created_at is not None
+
+
+def test_event_from_dict_defaults():
+    event = Event.from_dict({})
+
+    assert event.id == ""
+    assert event.category is None
+    assert json.loads(event.tags) == []
+    assert json.loads(event.market_ids) == []
+    assert event.volume == 0.0
+    assert event.start_date is None
+
+
+def test_price_point_from_dict():
+    point = PricePoint.from_dict("111", {"t": 1784251816, "p": 0.0125})
+
+    assert point.token_id == "111"
+    assert point.timestamp == 1784251816
+    assert point.price == 0.0125
+
+
+def test_order_book_snapshot_from_dict():
+    book = OrderBookSnapshot.from_dict(ORDER_BOOK)
+
+    assert book.condition_id == "0x" + "ab" * 32
+    assert book.token_id == "111"
+    assert book.timestamp == 1784254990511
+    assert book.hash == "720dff71476f22d3"
+    assert [(level.price, level.size) for level in book.bids] == [(0.45, 100.0), (0.44, 50.5)]
+    assert [(level.price, level.size) for level in book.asks] == [(0.46, 150.0)]
+    assert book.min_order_size == 5.0
+    assert book.tick_size == 0.001
+    assert book.neg_risk is True
+    assert book.last_trade_price == 0.45
+
+
+def test_order_book_snapshot_from_dict_empty():
+    book = OrderBookSnapshot.from_dict({})
+
+    assert book.condition_id == ""
+    assert book.bids == []
+    assert book.asks == []
+    assert book.neg_risk is False
+
+
+# -- Gamma offset pagination ----------------------------------------------------
+
+
+def test_iter_markets_stops_on_short_page():
+    client = make_client([[GAMMA_MARKET] * 2, [GAMMA_MARKET]])
+
+    pages = list(client.iter_markets(limit=2))
+
+    assert [(len(markets), offset) for markets, offset in pages] == [(2, 2), (1, 3)]
+    assert all(isinstance(m, Market) for m in pages[0][0])
+    assert client.http.calls[0] == ("https://gamma-api.polymarket.com/markets", {"limit": 2, "offset": 0})
+    assert client.http.calls[1][1] == {"limit": 2, "offset": 2}
+
+
+def test_iter_markets_empty_first_page_yields_sentinel():
+    client = make_client([[]])
+
+    assert list(client.iter_markets(limit=2)) == [([], -1)]
+
+
+def test_iter_events_matches_iter_markets_semantics():
+    client = make_client([[GAMMA_EVENT] * 2, []])
+
+    pages = list(client.iter_events(limit=2))
+
+    assert [(len(events), offset) for events, offset in pages] == [(2, 2), (0, -1)]
+    assert all(isinstance(e, Event) for e in pages[0][0])
+    assert client.http.calls[0] == ("https://gamma-api.polymarket.com/events", {"limit": 2, "offset": 0})
+
+
+def test_get_events_passes_filters():
+    client = make_client([[GAMMA_EVENT]])
+
+    events = client.get_events(limit=10, offset=5, closed=True)
+
+    assert len(events) == 1
+    assert client.http.calls == [
+        ("https://gamma-api.polymarket.com/events", {"limit": 10, "offset": 5, "closed": True})
+    ]
+
+
+# -- Gamma keyset pagination ----------------------------------------------------
+
+
+def test_get_markets_keyset_first_page_omits_cursor():
+    client = make_client([{"markets": [GAMMA_MARKET], "next_cursor": "abc123"}])
+
+    markets, cursor = client.get_markets_keyset(limit=100, closed=True)
+
+    assert len(markets) == 1
+    assert isinstance(markets[0], Market)
+    assert cursor == "abc123"
+    url, params = client.http.calls[0]
+    assert url == "https://gamma-api.polymarket.com/markets/keyset"
+    assert params == {"limit": 100, "closed": True}
+    assert "after_cursor" not in params
+
+
+def test_get_markets_keyset_final_page_returns_none_cursor():
+    client = make_client([{"markets": [GAMMA_MARKET]}])
+
+    markets, cursor = client.get_markets_keyset(after_cursor="abc123")
+
+    assert len(markets) == 1
+    assert cursor is None
+    assert client.http.calls[0][1]["after_cursor"] == "abc123"
+
+
+def test_iter_markets_keyset_follows_cursor_until_exhausted():
+    client = make_client(
+        [
+            {"markets": [GAMMA_MARKET] * 2, "next_cursor": "page2"},
+            {"markets": [GAMMA_MARKET]},
+        ]
+    )
+
+    pages = list(client.iter_markets_keyset(limit=2))
+
+    assert [(len(markets), cursor) for markets, cursor in pages] == [(2, "page2"), (1, None)]
+    assert "after_cursor" not in client.http.calls[0][1]
+    assert client.http.calls[1][1]["after_cursor"] == "page2"
+
+
+def test_iter_events_keyset_resumes_from_cursor():
+    client = make_client([{"events": [GAMMA_EVENT]}])
+
+    pages = list(client.iter_events_keyset(after_cursor="resume-here"))
+
+    assert [(len(events), cursor) for events, cursor in pages] == [(1, None)]
+    url, params = client.http.calls[0]
+    assert url == "https://gamma-api.polymarket.com/events/keyset"
+    assert params["after_cursor"] == "resume-here"
+
+
+# -- CLOB endpoints --------------------------------------------------------------
+
+
+def test_get_price_history_parses_points_in_order():
+    client = make_client([{"history": [{"t": 100, "p": 0.5}, {"t": 160, "p": 0.55}]}])
+
+    points = client.get_price_history("111")
+
+    assert [(p.token_id, p.timestamp, p.price) for p in points] == [("111", 100, 0.5), ("111", 160, 0.55)]
+    assert client.http.calls == [("https://clob.polymarket.com/prices-history", {"market": "111", "interval": "max"})]
+
+
+def test_get_price_history_passes_bounds_without_interval():
+    client = make_client([{"history": []}])
+
+    points = client.get_price_history("111", interval=None, fidelity=10, start_ts=100, end_ts=200)
+
+    assert points == []
+    assert client.http.calls[0][1] == {"market": "111", "fidelity": 10, "startTs": 100, "endTs": 200}
+
+
+def test_get_price_history_tolerates_missing_history():
+    client = make_client([{}])
+
+    assert client.get_price_history("111") == []
+
+
+def test_get_order_book():
+    client = make_client([ORDER_BOOK])
+
+    book = client.get_order_book("111")
+
+    assert isinstance(book, OrderBookSnapshot)
+    assert book.token_id == "111"
+    assert client.http.calls == [("https://clob.polymarket.com/book", {"token_id": "111"})]
+
+
+def test_get_midpoint_spread_and_price():
+    client = make_client([{"mid": "0.012"}, {"spread": "0.014"}, {"price": "0.005"}])
+
+    assert client.get_midpoint("111") == 0.012
+    assert client.get_spread("111") == 0.014
+    assert client.get_price("111", "BUY") == 0.005
+    assert client.http.calls == [
+        ("https://clob.polymarket.com/midpoint", {"token_id": "111"}),
+        ("https://clob.polymarket.com/spread", {"token_id": "111"}),
+        ("https://clob.polymarket.com/price", {"token_id": "111", "side": "BUY"}),
+    ]

--- a/tests/test_price_history_indexer.py
+++ b/tests/test_price_history_indexer.py
@@ -198,7 +198,7 @@ def test_parquet_schema_and_values(isolated_dirs):
 
 def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
     data_dir, markets_dir = isolated_dirs
-    end_date = CREATED_AT + timedelta(days=40)  # spans two request windows
+    end_date = CREATED_AT + timedelta(days=40)  # spans multiple request windows
     write_markets(markets_dir, [{"clob_token_ids": '["111"]', "created_at": CREATED_AT, "end_date": end_date}])
     boundary_ts = BASE_TS + mod.WINDOW_SECONDS
     fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.5), (boundary_ts, 0.6), (boundary_ts + 60, 0.7)]})
@@ -208,8 +208,13 @@ def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
     expected_end = int(end_date.timestamp()) + mod.END_PADDING_SECONDS
     assert fake.calls == [
         ("111", None, mod.FIDELITY_MINUTES, BASE_TS, boundary_ts),
-        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, expected_end),
+        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, BASE_TS + 2 * mod.WINDOW_SECONDS),
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS + 2 * mod.WINDOW_SECONDS, BASE_TS + 3 * mod.WINDOW_SECONDS),
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS + 3 * mod.WINDOW_SECONDS, expected_end),
     ]
+    assert all(call[4] - call[3] <= 15 * 24 * 60 * 60 for call in fake.calls), (
+        "/prices-history rejects startTs/endTs spans longer than 15 days"
+    )
     df = load_prices(data_dir)
     assert len(df) == 3, "boundary point returned by both windows should be stored once"
     assert sorted(df["timestamp"].tolist()) == [BASE_TS + 60, boundary_ts, boundary_ts + 60]

--- a/tests/test_price_history_indexer.py
+++ b/tests/test_price_history_indexer.py
@@ -1,0 +1,215 @@
+"""Tests for the Polymarket price history indexer (no network)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import src.indexers.polymarket.price_history as mod
+from src.indexers.polymarket.models import PricePoint
+from src.indexers.polymarket.price_history import PolymarketPriceHistoryIndexer
+
+CREATED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+END_DATE = datetime(2026, 1, 15, tzinfo=timezone.utc)
+BASE_TS = int(CREATED_AT.timestamp())
+
+
+class FakeClient:
+    """Stub for PolymarketClient that returns canned histories and records calls."""
+
+    def __init__(self, histories: dict[str, list[tuple[int, float]]] | None = None, errors: set[str] | None = None):
+        self.histories = histories or {}
+        self.errors = errors or set()
+        self.calls: list[tuple[str, str | None, int | None, int | None, int | None]] = []
+
+    def get_price_history(self, token_id, interval="max", fidelity=None, start_ts=None, end_ts=None):
+        self.calls.append((token_id, interval, fidelity, start_ts, end_ts))
+        if token_id in self.errors:
+            raise RuntimeError("API unavailable")
+        return [
+            PricePoint(token_id=token_id, timestamp=t, price=p)
+            for t, p in self.histories.get(token_id, [])
+            if start_ts <= t <= end_ts
+        ]
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and MARKETS_DIR at temp directories."""
+    data_dir = tmp_path / "price_history"
+    markets_dir = tmp_path / "markets"
+    markets_dir.mkdir()
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "MARKETS_DIR", markets_dir)
+    return data_dir, markets_dir
+
+
+def write_markets(markets_dir: Path, rows: list[dict]) -> None:
+    records = [
+        {
+            "id": str(i),
+            "clob_token_ids": row.get("clob_token_ids", "[]"),
+            "volume": row.get("volume", 0.0),
+            "created_at": row.get("created_at", CREATED_AT),
+            "end_date": row.get("end_date", END_DATE),
+        }
+        for i, row in enumerate(rows)
+    ]
+    pd.DataFrame(records).to_parquet(markets_dir / f"markets_0_{len(records)}.parquet")
+
+
+def run_indexer(fake: FakeClient, max_workers: int = 2) -> None:
+    with patch.object(mod, "PolymarketClient", return_value=fake):
+        PolymarketPriceHistoryIndexer(max_workers=max_workers).run()
+
+
+def load_prices(data_dir: Path) -> pd.DataFrame:
+    files = sorted(data_dir.glob("prices_*.parquet"))
+    assert files, "expected at least one prices parquet chunk"
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def test_fetches_both_outcome_tokens(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"111", "222"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222"]
+
+
+def test_covers_all_markets_regardless_of_volume(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(
+        markets_dir,
+        [
+            {"clob_token_ids": '["111", "222"]', "volume": 0.0},
+            {"clob_token_ids": '["333", "444"]', "volume": 250000.0},
+        ],
+    )
+    histories = {t: [(BASE_TS + 60, 0.5)] for t in ["111", "222", "333", "444"]}
+    fake = FakeClient(histories=histories)
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"111", "222", "333", "444"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222", "333", "444"]
+
+
+def test_malformed_token_arrays_are_skipped(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(
+        markets_dir,
+        [
+            {"clob_token_ids": "not json"},
+            {"clob_token_ids": '"111"'},  # valid JSON but not a list
+            {"clob_token_ids": '[123, null, ""]'},  # non-string and empty entries
+            {"clob_token_ids": None},
+            {"clob_token_ids": '["555"]'},
+        ],
+    )
+    fake = FakeClient(histories={"555": [(BASE_TS + 60, 0.9)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"555"}
+    df = load_prices(data_dir)
+    assert df["token_id"].unique().tolist() == ["555"]
+
+
+def test_resume_skips_already_stored_tokens(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    data_dir.mkdir(parents=True)
+    existing = pd.DataFrame([{"token_id": "111", "timestamp": BASE_TS, "price": 0.5, "_fetched_at": datetime.utcnow()}])
+    existing.to_parquet(data_dir / "prices_0_10000.parquet")
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    fake = FakeClient(histories={"222": [(BASE_TS + 60, 0.7)]})
+
+    run_indexer(fake)
+
+    assert {call[0] for call in fake.calls} == {"222"}
+    files = sorted(f.name for f in data_dir.glob("prices_*.parquet"))
+    assert files == ["prices_0_10000.parquet", "prices_10000_20000.parquet"]
+    new_chunk = pd.read_parquet(data_dir / "prices_10000_20000.parquet")
+    assert new_chunk["token_id"].unique().tolist() == ["222"]
+
+
+def test_rerun_after_completion_is_noop(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    histories = {"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]}
+
+    run_indexer(FakeClient(histories=histories))
+    rerun = FakeClient(histories=histories)
+    run_indexer(rerun)
+
+    assert rerun.calls == []
+    assert len(list(data_dir.glob("prices_*.parquet"))) == 1
+
+
+def test_api_failure_skips_token_and_retries_next_run(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111", "222"]'}])
+    histories = {"111": [(BASE_TS + 60, 0.65)], "222": [(BASE_TS + 60, 0.35)]}
+    failing = FakeClient(histories=histories, errors={"111"})
+
+    run_indexer(failing)
+
+    df = load_prices(data_dir)
+    assert df["token_id"].unique().tolist() == ["222"]
+
+    recovered = FakeClient(histories=histories)
+    run_indexer(recovered)
+
+    assert {call[0] for call in recovered.calls} == {"111"}
+    df = load_prices(data_dir)
+    assert sorted(df["token_id"].unique()) == ["111", "222"]
+
+
+def test_parquet_schema_and_values(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    write_markets(markets_dir, [{"clob_token_ids": '["111"]'}])
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.65), (BASE_TS + 120, 0.66)]})
+
+    run_indexer(fake, max_workers=1)
+
+    df = load_prices(data_dir)
+    assert list(df.columns) == ["token_id", "timestamp", "price", "_fetched_at"]
+    assert df["token_id"].dtype == object
+    assert df["timestamp"].dtype == "int64"
+    assert df["price"].dtype == "float64"
+    assert pd.api.types.is_datetime64_any_dtype(df["_fetched_at"])
+    assert df.sort_values("timestamp")[["timestamp", "price"]].values.tolist() == [
+        [BASE_TS + 60, 0.65],
+        [BASE_TS + 120, 0.66],
+    ]
+
+
+def test_long_histories_are_windowed_and_deduplicated(isolated_dirs):
+    data_dir, markets_dir = isolated_dirs
+    end_date = CREATED_AT + timedelta(days=40)  # spans two request windows
+    write_markets(markets_dir, [{"clob_token_ids": '["111"]', "created_at": CREATED_AT, "end_date": end_date}])
+    boundary_ts = BASE_TS + mod.WINDOW_SECONDS
+    fake = FakeClient(histories={"111": [(BASE_TS + 60, 0.5), (boundary_ts, 0.6), (boundary_ts + 60, 0.7)]})
+
+    run_indexer(fake, max_workers=1)
+
+    expected_end = int(end_date.timestamp()) + mod.END_PADDING_SECONDS
+    assert fake.calls == [
+        ("111", None, mod.FIDELITY_MINUTES, BASE_TS, boundary_ts),
+        ("111", None, mod.FIDELITY_MINUTES, boundary_ts, expected_end),
+    ]
+    df = load_prices(data_dir)
+    assert len(df) == 3, "boundary point returned by both windows should be stored once"
+    assert sorted(df["timestamp"].tolist()) == [BASE_TS + 60, boundary_ts, boundary_ts + 60]

--- a/tests/test_resolutions_indexer.py
+++ b/tests/test_resolutions_indexer.py
@@ -84,9 +84,12 @@ def test_interrupt_then_resume_completes(isolated_dirs):
         indexer = PolymarketResolutionsIndexer(to_block=5000, chunk_size=1000)
         indexer.run()
 
-    # Should have resumed from the saved cursor, not from the beginning
+    # Should have resumed from the block after the cursor: the cursor block's
+    # rows were already flushed, so re-fetching it would duplicate them
     first_requested = min(start for start, _ in client2.requested_ranges)
-    assert first_requested == saved_block, f"Resume should start from cursor ({saved_block}), not {first_requested}"
+    assert first_requested == saved_block + 1, (
+        f"Resume should start after cursor ({saved_block + 1}), not {first_requested}"
+    )
 
     # Cursor should be cleaned up after successful completion
     assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"

--- a/tests/test_resolutions_indexer.py
+++ b/tests/test_resolutions_indexer.py
@@ -1,0 +1,149 @@
+"""Test that the resolutions backfill can be interrupted and resumed without losing data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.indexers.polymarket.blockchain import ConditionResolution
+
+
+def make_resolution(block_number: int, payout_numerators: list[int] | None = None) -> ConditionResolution:
+    return ConditionResolution(
+        block_number=block_number,
+        transaction_hash="0xabc",
+        log_index=0,
+        condition_id="0x" + "11" * 32,
+        oracle="0x" + "22" * 20,
+        question_id="0x" + "33" * 32,
+        outcome_slot_count=2,
+        payout_numerators=payout_numerators if payout_numerators is not None else [1, 0],
+    )
+
+
+class FakeClient:
+    """Stub for PolygonClient that tracks which blocks were requested."""
+
+    def __init__(self, *, interrupt_at_block: int | None = None, error_at_block: int | None = None):
+        self._interrupt_at = interrupt_at_block
+        self._error_at = error_at_block
+        self.requested_ranges: list[tuple[int, int]] = []
+
+    def get_block_number(self) -> int:
+        return 5000
+
+    def get_condition_resolutions(self, from_block: int, to_block: int) -> list[ConditionResolution]:
+        if self._interrupt_at is not None and from_block >= self._interrupt_at:
+            raise KeyboardInterrupt
+        if self._error_at is not None and from_block >= self._error_at:
+            raise RuntimeError("rpc exploded")
+        self.requested_ranges.append((from_block, to_block))
+        return [make_resolution(block_number=from_block)]
+
+
+@pytest.fixture()
+def isolated_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point DATA_DIR and CURSOR_FILE at temp directories."""
+    data_dir = tmp_path / "resolutions"
+    cursor_file = tmp_path / ".resolutions_block_cursor"
+    import src.indexers.polymarket.resolutions as mod
+
+    monkeypatch.setattr(mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(mod, "CURSOR_FILE", cursor_file)
+    return data_dir, cursor_file
+
+
+def test_interrupt_then_resume_completes(isolated_dirs):
+    """Interrupt a backfill with Ctrl+C, then resume and finish the job."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    # Run 1: interrupt at block 3000
+    client1 = FakeClient(interrupt_at_block=3000)
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client1):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=5000, chunk_size=1000)
+        indexer.run()
+
+    # Cursor should exist and point to the last completed block
+    assert cursor_file.exists(), "Cursor file should survive Ctrl+C"
+    saved_block = int(cursor_file.read_text().strip())
+    assert saved_block == 2999, f"Cursor should be at last completed chunk end, got {saved_block}"
+
+    # Buffered rows fetched before the interrupt should have been flushed
+    flushed = pd.concat([pd.read_parquet(f) for f in data_dir.glob("resolutions_*.parquet")])
+    assert len(flushed) == 2, "Resolutions fetched before the interrupt should be flushed to parquet"
+
+    # Run 2: resume with no from_block (reads cursor), no interrupt
+    client2 = FakeClient()
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client2):
+        indexer = PolymarketResolutionsIndexer(to_block=5000, chunk_size=1000)
+        indexer.run()
+
+    # Should have resumed from the saved cursor, not from the beginning
+    first_requested = min(start for start, _ in client2.requested_ranges)
+    assert first_requested == saved_block, f"Resume should start from cursor ({saved_block}), not {first_requested}"
+
+    # Cursor should be cleaned up after successful completion
+    assert not cursor_file.exists(), "Cursor file should be deleted after successful completion"
+
+
+def test_exception_preserves_cursor_and_flushes_buffer(isolated_dirs):
+    """Any exception (not just Ctrl+C) preserves the cursor and flushes buffered rows."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient(error_at_block=3000)
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=5000, chunk_size=1000)
+        with pytest.raises(RuntimeError):
+            indexer.run()
+
+    assert cursor_file.exists(), "Cursor file should survive an unexpected exception"
+    assert int(cursor_file.read_text().strip()) == 2999
+
+    flushed = pd.concat([pd.read_parquet(f) for f in data_dir.glob("resolutions_*.parquet")])
+    assert len(flushed) == 2, "Resolutions fetched before the error should be flushed to parquet"
+
+
+def test_parquet_schema_and_winning_outcome_derivable(isolated_dirs):
+    """Saved rows serialize payout_numerators as a JSON string and keep the winning outcome derivable."""
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    data_dir, cursor_file = isolated_dirs
+
+    client = FakeClient()
+    with patch("src.indexers.polymarket.resolutions.PolygonClient", return_value=client):
+        indexer = PolymarketResolutionsIndexer(from_block=1000, to_block=1999, chunk_size=1000)
+        indexer.run()
+
+    files = list(data_dir.glob("resolutions_*.parquet"))
+    assert len(files) == 1
+    df = pd.read_parquet(files[0])
+    assert list(df.columns) == [
+        "block_number",
+        "transaction_hash",
+        "log_index",
+        "condition_id",
+        "oracle",
+        "question_id",
+        "outcome_slot_count",
+        "payout_numerators",
+        "_fetched_at",
+    ]
+
+    row = df.iloc[0]
+    assert row["block_number"] == 1000
+    assert row["condition_id"] == "0x" + "11" * 32
+    assert row["outcome_slot_count"] == 2
+
+    # payout_numerators is a JSON string from which the winning outcome is derivable
+    numerators = json.loads(row["payout_numerators"])
+    assert numerators == [1, 0]
+    nonzero = [i for i, numerator in enumerate(numerators) if numerator != 0]
+    assert nonzero == [0]

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -728,7 +728,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -799,7 +799,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1301,7 +1301,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1586,7 +1586,7 @@ name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -1868,16 +1868,16 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "cycler", marker = "python_full_version < '3.10'" },
-    { name = "fonttools", marker = "python_full_version < '3.10'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyparsing", marker = "python_full_version < '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "importlib-resources" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -1933,17 +1933,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.10'" },
-    { name = "fonttools", marker = "python_full_version >= '3.10'" },
-    { name = "kiwisolver", version = "1.4.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver", version = "1.4.9", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "packaging" },
+    { name = "pillow", version = "12.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/e2/d2d5295be2f44c678ebaf3544ba32d20c1f9ef08c49fe47f496180e1db15/matplotlib-3.10.7.tar.gz", hash = "sha256:a06ba7e2a2ef9131c79c49e63dad355d2d878413a0376c1727c8b9335ff731c7", size = 34804865, upload-time = "2025-10-09T00:28:00.669Z" }
 wheels = [
@@ -2724,6 +2724,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
     { name = "web3" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -2753,6 +2754,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "web3", specifier = ">=6.0.0" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -3226,13 +3228,13 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -3249,13 +3251,13 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -3525,7 +3527,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -3563,7 +3565,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3623,7 +3625,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [


### PR DESCRIPTION
## What changed? Why?

Integration branch assembling the complete open Polymarket data stack into a single branch, merging the following PRs in dependency order:

- #52 — storage correctness (preserve backfill progress on interrupt)
- #51 — resolution foundation (decode `ConditionResolution` events in `PolygonClient`)
- #53 — API foundation (events, keyset pagination, CLOB market-data support in the client)
- #54 — events indexer
- #55 — price history indexer
- #56 — live CLOB orderbook websocket recorder
- #57 — condition resolutions indexer
- #58 — FPMM collateral lookup indexer
- #59 — Data API market-wide trades indexer

No feature behavior was changed beyond resolving merge conflicts, all of which were mechanical (adjacent additions to the `docs/SCHEMAS.md` section list and the `README.md` data-directory tree).

This branch exists to serve as the base for the upcoming Docker Compose E2E harness, which will be a separate PR stacked on this one.

## Notes to reviewers

All code here has already been reviewed (or is under review) in the individual PRs listed above; this PR only adds merge commits. Key merged files:

- `src/indexers/polymarket/client.py`, `models.py` — API foundation
- `src/indexers/polymarket/events.py`, `price_history.py`, `orderbook.py`, `resolutions.py`, `collateral.py`, `data_api_trades.py` — new indexers
- `src/indexers/polymarket/blockchain.py` — `ConditionResolution` decoding
- `src/indexers/polymarket/markets.py`, `fpmm_trades.py` — backfill progress preservation
- `docs/SCHEMAS.md`, `README.md` — merged docs (only files with conflicts)

## How has it been tested?

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (75 files already formatted)
- `uv run pytest tests/ -v` — 204 passed, 4 warnings
