### PR TITLE
test: add docker compose e2e harness for the polymarket stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.venv
+.env
+__pycache__
+*.py[oc]
+data
+data.zip
+*.tar.zst
+output
+fig
+scratchpad
+.tmp
+research
+docs

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 POLYGON_RPC=
 POLYMARKET_START_BLOCK=33605403
+# Optional API base URL overrides (default to production endpoints when unset)
+# POLYMARKET_GAMMA_URL=https://gamma-api.polymarket.com
+# POLYMARKET_CLOB_URL=https://clob.polymarket.com
+# POLYMARKET_DATA_API_URL=https://data-api.polymarket.com
+# POLYMARKET_WS_URL=wss://ws-subscriptions-clob.polymarket.com/ws/market

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: analyze run index record package lint format test setup
+.PHONY: analyze run index record package lint format test e2e setup
 
 RUN = uv run main.py
 
@@ -27,6 +27,10 @@ format:
 
 test:
 	uv run pytest tests/ -v
+
+e2e:
+	docker compose -f compose.e2e.yaml up --build --abort-on-container-exit --exit-code-from runner; \
+	status=$$?; docker compose -f compose.e2e.yaml down -v --remove-orphans; exit $$status
 
 setup:
 	bash scripts/install-tools.sh

--- a/compose.e2e.yaml
+++ b/compose.e2e.yaml
@@ -1,0 +1,34 @@
+services:
+  mock:
+    build:
+      context: tests/e2e/mock
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health', timeout=2)"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+
+  runner:
+    build:
+      context: .
+      dockerfile: tests/e2e/runner.Dockerfile
+    depends_on:
+      mock:
+        condition: service_healthy
+    environment:
+      POLYMARKET_GAMMA_URL: http://mock:8080/gamma
+      POLYMARKET_CLOB_URL: http://mock:8080/clob
+      POLYMARKET_DATA_API_URL: http://mock:8080/data-api
+      POLYMARKET_WS_URL: ws://mock:8080/ws/market
+      POLYGON_RPC: http://mock:8080/rpc
+      POLYMARKET_START_BLOCK: "1100000"
+      CONDITIONAL_TOKENS_START_BLOCK: "1100000"
+      E2E_MOCK_ADMIN_URL: http://mock:8080
+      E2E_EXPECT_NO_EGRESS: "1"
+    tmpfs:
+      - /app/data
+
+networks:
+  default:
+    # No external egress: tests cannot silently reach production endpoints.
+    internal: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+addopts = ["-m", "not e2e"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "e2e: end-to-end tests that require the Docker Compose mock harness (run with 'make e2e')",
+]
 
 [tool.ruff]
 target-version = "py39"

--- a/src/indexers/polymarket/client.py
+++ b/src/indexers/polymarket/client.py
@@ -1,12 +1,17 @@
+import os
 from collections.abc import Generator
 from typing import Optional, Union
+
+from dotenv import load_dotenv
 
 from src.common.client import HttpClient
 from src.indexers.polymarket.models import DataApiTrade, Event, Market, OrderBookSnapshot, PricePoint
 
-GAMMA_API_URL = "https://gamma-api.polymarket.com"
-CLOB_API_URL = "https://clob.polymarket.com"
-DATA_API_URL = "https://data-api.polymarket.com"
+load_dotenv()
+
+GAMMA_API_URL = os.getenv("POLYMARKET_GAMMA_URL", "https://gamma-api.polymarket.com")
+CLOB_API_URL = os.getenv("POLYMARKET_CLOB_URL", "https://clob.polymarket.com")
+DATA_API_URL = os.getenv("POLYMARKET_DATA_API_URL", "https://data-api.polymarket.com")
 
 # The Data API `/trades` and `/activity` endpoints only honor `start`/`end`
 # when the query is scoped by `market` or `user`; the unscoped market-wide

--- a/src/indexers/polymarket/orderbook.py
+++ b/src/indexers/polymarket/orderbook.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,7 +29,7 @@ from src.common.indexer import Indexer
 from src.indexers.polymarket.client import PolymarketClient
 from src.indexers.polymarket.models import OrderBookDelta
 
-WS_MARKET_URL = "wss://ws-subscriptions-clob.polymarket.com/ws/market"
+WS_MARKET_URL = os.getenv("POLYMARKET_WS_URL", "wss://ws-subscriptions-clob.polymarket.com/ws/market")
 DATA_DIR = Path("data/polymarket/orderbook")
 CHUNK_SIZE = 10000
 PING_INTERVAL_SECONDS = 10.0

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,166 @@
+"""Fixtures for the Compose end-to-end suite.
+
+These tests drive the real production classes (real httpx, web3, and
+websockets clients) against the mock service container; the only test-side
+injection is environment-based URL configuration, done by compose.e2e.yaml.
+"""
+
+import importlib.util
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+E2E_DIR = Path(__file__).resolve().parent
+REPO_ROOT = E2E_DIR.parents[1]
+
+REQUIRED_ENV = [
+    "E2E_MOCK_ADMIN_URL",
+    "POLYMARKET_GAMMA_URL",
+    "POLYMARKET_CLOB_URL",
+    "POLYMARKET_DATA_API_URL",
+    "POLYMARKET_WS_URL",
+    "POLYGON_RPC",
+]
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if E2E_DIR in Path(str(item.fspath)).parents:
+            item.add_marker(pytest.mark.e2e)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_harness():
+    missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
+    if missing:
+        pytest.skip(f"e2e harness not configured; missing env vars: {', '.join(missing)}")
+
+
+@pytest.fixture(scope="session")
+def fx():
+    """The mock's fixture corpus, loaded from the exact module the mock serves."""
+    spec = importlib.util.spec_from_file_location("e2e_mock_fixtures", E2E_DIR / "mock" / "fixtures.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class MockAdmin:
+    """Client for the mock's admin endpoints (request accounting, fault injection)."""
+
+    def __init__(self, base_url: str):
+        self.http = httpx.Client(base_url=base_url, timeout=10.0)
+
+    def close(self):
+        self.http.close()
+
+    def reset(self):
+        self.http.post("/admin/reset").raise_for_status()
+
+    def counts(self) -> dict:
+        return self.http.get("/admin/requests").json()["counts"]
+
+    def count(self, key: str) -> int:
+        return self.counts().get(key, 0)
+
+    def events(self, key: str) -> list:
+        events = self.http.get("/admin/requests").json()["events"]
+        return [e for e in events if e["key"] == key]
+
+    def fail_next(self, key: str, status: int = 500, times: int = 1):
+        self.http.post("/admin/fail-next", json={"key": key, "status": status, "times": times}).raise_for_status()
+
+    def set_latency(self, key: str, seconds: float):
+        self.http.post("/admin/latency", json={"key": key, "seconds": seconds}).raise_for_status()
+
+    def ws_state(self) -> dict:
+        return self.http.get("/admin/ws").json()
+
+
+@pytest.fixture(scope="session")
+def admin(_require_harness):
+    client = MockAdmin(os.environ["E2E_MOCK_ADMIN_URL"])
+    yield client
+    client.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock(_require_harness, admin):
+    admin.reset()
+
+
+@pytest.fixture()
+def workdir(tmp_path, monkeypatch):
+    """Fresh working directory; the indexers' data/cursor paths are CWD-relative."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(scope="session")
+def seeded_markets_dir(tmp_path_factory, _require_harness):
+    """A workspace where a real markets-indexer run has already completed,
+    for scenarios that consume the markets dataset (price history, Data API)."""
+    from src.indexers.polymarket.markets import PolymarketMarketsIndexer
+
+    path = tmp_path_factory.mktemp("seeded-markets")
+    cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        PolymarketMarketsIndexer().run()
+    finally:
+        os.chdir(cwd)
+    return path
+
+
+@pytest.fixture()
+def seeded_workdir(seeded_markets_dir, monkeypatch):
+    monkeypatch.chdir(seeded_markets_dir)
+    return seeded_markets_dir
+
+
+@pytest.fixture(scope="session")
+def wait_until():
+    def _wait(predicate, timeout: float = 60.0, interval: float = 0.01, message: str = "condition"):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = predicate()
+            if result:
+                return result
+            time.sleep(interval)
+        raise AssertionError(f"timed out after {timeout}s waiting for {message}")
+
+    return _wait
+
+
+@pytest.fixture(scope="session")
+def run_indexer():
+    """Launch an indexer in a real subprocess so interrupts are delivered as
+    actual SIGINT signals, not exceptions raised from inside a fake."""
+
+    def _run(code: str, cwd: Path) -> subprocess.Popen:
+        return subprocess.Popen(
+            [sys.executable, "-c", code],
+            cwd=str(cwd),
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def interrupt_and_wait():
+    def _interrupt(proc: subprocess.Popen, timeout: float = 120.0) -> str:
+        proc.send_signal(signal.SIGINT)
+        output, _ = proc.communicate(timeout=timeout)
+        return output
+
+    return _interrupt

--- a/tests/e2e/mock/Dockerfile
+++ b/tests/e2e/mock/Dockerfile
@@ -1,0 +1,13 @@
+# Mock service image: intentionally independent of the repository's
+# dependency lock so production dependencies never leak into the mock.
+FROM python:3.9-slim
+
+WORKDIR /srv
+
+RUN pip install --no-cache-dir "fastapi>=0.110,<1" "uvicorn>=0.30,<1" "websockets>=12,<16"
+
+COPY app.py fixtures.py ./
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080", "--log-level", "warning"]

--- a/tests/e2e/mock/app.py
+++ b/tests/e2e/mock/app.py
@@ -1,0 +1,441 @@
+"""Deterministic mock of every external surface the Polymarket stack talks to.
+
+One FastAPI app serves five surfaces on path prefixes:
+
+    /gamma/*     Gamma REST (offset + keyset pagination, closed filtering)
+    /clob/*      CLOB REST (prices-history with the 15-day cap, book, prices)
+    /data-api/*  Data API REST (market/start/end scoping, 10,000 offset cap)
+    /rpc         Polygon JSON-RPC (block/log filtering, ABI-encoded logs,
+                 "too large" errors, eth_call selector dispatch)
+    /ws/market   CLOB market WebSocket (subscribe, book, price_change,
+                 PING/PONG, scripted disconnect/reconnect)
+
+plus /admin/* endpoints for request inspection and fault injection. All data
+comes from the deterministic corpus in ``fixtures.py``.
+"""
+
+import asyncio
+import json
+
+import fixtures as fx
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+MARKETS = fx.build_markets()
+EVENTS = fx.build_events()
+DATA_TRADES = sorted(fx.build_data_trades(), key=lambda t: -t["timestamp"])
+LOGS = fx.build_logs()
+COLLATERAL = fx.build_collateral_map()
+FEATURED_TOKENS = set(fx.all_featured_token_ids())
+
+KEYSET_LIMIT_CAPS = {"markets": 100, "events": 500}
+MAX_EVENT_LOG = 20000
+
+
+def _initial_state():
+    return {
+        "counts": {},
+        "events": [],
+        "fail_next": {},
+        "latency": {},
+        "ws": {"connections": 0, "subscriptions": [], "pings": 0, "invalid_subscribes": 0},
+    }
+
+
+STATE = _initial_state()
+
+
+async def pre(key, **meta):
+    """Latency, request accounting, and one-shot fault injection for one call."""
+    await asyncio.sleep(STATE["latency"].get(key, 0))
+    STATE["counts"][key] = STATE["counts"].get(key, 0) + 1
+    if len(STATE["events"]) < MAX_EVENT_LOG:
+        STATE["events"].append({"key": key, "meta": meta})
+    entry = STATE["fail_next"].get(key)
+    if entry and entry["times"] > 0:
+        entry["times"] -= 1
+        raise HTTPException(status_code=entry["status"], detail="injected failure")
+
+
+def _qbool(params, name):
+    value = params.get(name)
+    return None if value is None else value.lower() == "true"
+
+
+def _filter_flags(rows, params):
+    for flag in ("active", "closed"):
+        wanted = _qbool(params, flag)
+        if wanted is not None:
+            rows = [r for r in rows if r[flag] == wanted]
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Gamma REST
+# ---------------------------------------------------------------------------
+
+
+async def _gamma_offset(kind, rows, request):
+    params = request.query_params
+    offset = int(params.get("offset", 0))
+    limit = int(params.get("limit", 100))
+    await pre("/gamma/" + kind, offset=offset, limit=limit)
+    rows = _filter_flags(rows, params)
+    if params.get("order") == "volume":
+        ascending = _qbool(params, "ascending")
+        rows = sorted(rows, key=lambda r: r["volume"], reverse=not ascending)
+    return rows[offset : offset + limit]
+
+
+@app.get("/gamma/markets")
+async def gamma_markets(request: Request):
+    return await _gamma_offset("markets", MARKETS, request)
+
+
+@app.get("/gamma/events")
+async def gamma_events(request: Request):
+    return await _gamma_offset("events", EVENTS, request)
+
+
+async def _gamma_keyset(kind, rows, request):
+    params = request.query_params
+    cursor = int(params.get("after_cursor") or 0)
+    limit = min(int(params.get("limit", 100)), KEYSET_LIMIT_CAPS[kind])
+    await pre(f"/gamma/{kind}/keyset", cursor=cursor, limit=limit, closed=params.get("closed"))
+    rows = _filter_flags(rows, params)
+    page = rows[cursor : cursor + limit]
+    next_cursor = str(cursor + limit) if cursor + limit < len(rows) else None
+    return {kind: page, "next_cursor": next_cursor}
+
+
+@app.get("/gamma/markets/keyset")
+async def gamma_markets_keyset(request: Request):
+    return await _gamma_keyset("markets", MARKETS, request)
+
+
+@app.get("/gamma/events/keyset")
+async def gamma_events_keyset(request: Request):
+    return await _gamma_keyset("events", EVENTS, request)
+
+
+# ---------------------------------------------------------------------------
+# CLOB REST
+# ---------------------------------------------------------------------------
+
+
+@app.get("/clob/prices-history")
+async def clob_prices_history(request: Request):
+    params = request.query_params
+    token_id = params.get("market", "")
+    start_ts = params.get("startTs")
+    end_ts = params.get("endTs")
+    span = int(end_ts) - int(start_ts) if start_ts and end_ts else None
+    await pre("/clob/prices-history", market=token_id, span=span)
+    if start_ts is None or end_ts is None:
+        raise HTTPException(status_code=400, detail="startTs and endTs are required by this mock")
+    if span > fx.PRICE_WINDOW_DAYS * fx.DAY:
+        # Undocumented production behavior: ranges longer than 15 days 400.
+        raise HTTPException(status_code=400, detail="invalid request: startTs/endTs range too long")
+    if token_id not in FEATURED_TOKENS:
+        return {"history": []}
+    points = fx.price_points(int(start_ts), int(end_ts))
+    return {"history": [{"t": ts, "p": fx.price_at(token_id, ts)} for ts in points]}
+
+
+@app.get("/clob/book")
+async def clob_book(request: Request):
+    token_id = request.query_params.get("token_id", "")
+    await pre("/clob/book", token_id=token_id)
+    book = fx.ws_book_message(token_id)
+    return {
+        "market": book["market"],
+        "asset_id": token_id,
+        "timestamp": fx.WS_BOOK_TS_MS,
+        "hash": book["hash"],
+        "bids": fx.WS_BOOK_BIDS,
+        "asks": fx.WS_BOOK_ASKS,
+        "min_order_size": "5",
+        "tick_size": "0.01",
+        "neg_risk": False,
+        "last_trade_price": "0.44",
+    }
+
+
+@app.get("/clob/midpoint")
+async def clob_midpoint(request: Request):
+    await pre("/clob/midpoint")
+    return {"mid": "0.5"}
+
+
+@app.get("/clob/spread")
+async def clob_spread(request: Request):
+    await pre("/clob/spread")
+    return {"spread": "0.1"}
+
+
+@app.get("/clob/price")
+async def clob_price(request: Request):
+    side = request.query_params.get("side", "")
+    await pre("/clob/price", side=side)
+    return {"price": "0.45" if side == "BUY" else "0.55"}
+
+
+# ---------------------------------------------------------------------------
+# Data API REST
+# ---------------------------------------------------------------------------
+
+
+@app.get("/data-api/trades")
+async def data_api_trades(request: Request):
+    params = request.query_params
+    start = int(params.get("start", 0) or 0)
+    end = int(params.get("end", 2**62) or 2**62)
+    limit = int(params.get("limit", 100))
+    offset = int(params.get("offset", 0))
+    market = params.get("market")
+    await pre("/data-api/trades", market=market, start=start, end=end, limit=limit, offset=offset)
+    rows = DATA_TRADES
+    if market:
+        # start/end are only honored on market-scoped queries, as in production.
+        wanted = set(market.split(","))
+        rows = [t for t in rows if t["conditionId"] in wanted and start <= t["timestamp"] <= end]
+    offset = min(offset, fx.MAX_DATA_API_OFFSET)
+    return rows[offset : offset + limit]
+
+
+# ---------------------------------------------------------------------------
+# Polygon JSON-RPC
+# ---------------------------------------------------------------------------
+
+ZERO_HASH = "0x" + "00" * 32
+
+
+def _rpc_block(number):
+    return {
+        "number": hex(number),
+        "hash": "0x" + format(0xB10C000000 + number, "064x"),
+        "parentHash": "0x" + format(0xB10C000000 + number - 1, "064x"),
+        "nonce": "0x0000000000000000",
+        "sha3Uncles": ZERO_HASH,
+        "logsBloom": "0x" + "00" * 256,
+        "transactionsRoot": ZERO_HASH,
+        "stateRoot": ZERO_HASH,
+        "receiptsRoot": ZERO_HASH,
+        "miner": "0x" + "00" * 20,
+        "mixHash": ZERO_HASH,
+        "difficulty": "0x1",
+        "totalDifficulty": "0x1",
+        # 97-byte POA extraData: requires ExtraDataToPOAMiddleware to parse.
+        "extraData": "0x" + "22" * 97,
+        "size": "0x220",
+        "gasLimit": "0x1c9c380",
+        "gasUsed": "0x0",
+        "timestamp": hex(fx.block_timestamp(number)),
+        "baseFeePerGas": "0x8",
+        "transactions": [],
+        "uncles": [],
+    }
+
+
+def _to_block_number(value):
+    if value in (None, "latest", "pending", "safe", "finalized"):
+        return fx.HEAD_BLOCK
+    if isinstance(value, str):
+        return int(value, 16) if value.startswith("0x") else int(value)
+    return int(value)
+
+
+def _topic_matches(log_topics, wanted):
+    for i, entry in enumerate(wanted or []):
+        if entry is None:
+            continue
+        options = entry if isinstance(entry, list) else [entry]
+        if i >= len(log_topics) or log_topics[i].lower() not in {o.lower() for o in options}:
+            return False
+    return True
+
+
+def _format_log(log):
+    return {
+        "address": log["address"],
+        "topics": log["topics"],
+        "data": log["data"],
+        "blockNumber": hex(log["blockNumber"]),
+        "logIndex": hex(log["logIndex"]),
+        "transactionIndex": hex(log["transactionIndex"]),
+        "transactionHash": log["transactionHash"],
+        "blockHash": log["blockHash"],
+        "removed": False,
+    }
+
+
+def _eth_get_logs(flt):
+    from_block = _to_block_number(flt.get("fromBlock", 0))
+    to_block = _to_block_number(flt.get("toBlock", "latest"))
+    address = flt.get("address")
+    if address is not None and not isinstance(address, list):
+        address = [address]
+    addresses = {a.lower() for a in address} if address else None
+    if addresses is None and to_block - from_block + 1 > fx.TOPIC_ONLY_MAX_SPAN:
+        return None, {"code": -32005, "message": "query returned more than 10000 results, block range too large"}
+    matched = [
+        _format_log(log)
+        for log in LOGS
+        if from_block <= log["blockNumber"] <= to_block
+        and (addresses is None or log["address"].lower() in addresses)
+        and _topic_matches(log["topics"], flt.get("topics"))
+    ]
+    return matched, None
+
+
+def _eth_call(call):
+    to = (call.get("to") or "").lower()
+    data = call.get("data") or call.get("input") or ""
+    selector = data[:10].lower()
+    if selector == fx.SELECTOR_COLLATERAL_TOKEN and to in COLLATERAL:
+        return fx.encode_address(COLLATERAL[to]), None
+    if selector == fx.SELECTOR_SYMBOL and to == fx.TOKEN_USDC:
+        return fx.encode_string("USDC"), None
+    return None, {"code": 3, "message": "execution reverted"}
+
+
+@app.post("/rpc")
+async def rpc(request: Request):
+    body = await request.json()
+    method = body.get("method", "")
+    params = body.get("params") or []
+    key = "rpc:" + method
+    error = None
+    if method == "eth_chainId":
+        await pre(key)
+        result = "0x89"
+    elif method == "net_version":
+        await pre(key)
+        result = "137"
+    elif method == "eth_blockNumber":
+        await pre(key)
+        result = hex(fx.HEAD_BLOCK)
+    elif method == "eth_getBlockByNumber":
+        number = _to_block_number(params[0] if params else "latest")
+        await pre(key, number=number)
+        result = _rpc_block(number)
+    elif method == "eth_getLogs":
+        flt = params[0] if params else {}
+        from_block = _to_block_number(flt.get("fromBlock", 0))
+        to_block = _to_block_number(flt.get("toBlock", "latest"))
+        topics = flt.get("topics") or []
+        await pre(
+            key,
+            from_block=from_block,
+            to_block=to_block,
+            span=to_block - from_block + 1,
+            address=(flt.get("address") or "").lower() if isinstance(flt.get("address"), str) else flt.get("address"),
+            topic0=(topics[0] if topics and isinstance(topics[0], str) else None),
+        )
+        result, error = _eth_get_logs(flt)
+    elif method == "eth_call":
+        call = params[0] if params else {}
+        await pre(key, to=(call.get("to") or "").lower(), selector=(call.get("data") or "")[:10].lower())
+        result, error = _eth_call(call)
+    else:
+        await pre(key)
+        result, error = None, {"code": -32601, "message": f"method {method} not supported by mock"}
+    response = {"jsonrpc": "2.0", "id": body.get("id", 1)}
+    if error is not None:
+        response["error"] = error
+    else:
+        response["result"] = result
+    return JSONResponse(response)
+
+
+# ---------------------------------------------------------------------------
+# CLOB market WebSocket
+# ---------------------------------------------------------------------------
+
+
+@app.websocket("/ws/market")
+async def ws_market(ws: WebSocket):
+    await ws.accept()
+    try:
+        raw = await ws.receive_text()
+        payload = json.loads(raw)
+        assert isinstance(payload.get("assets_ids"), list) and payload.get("type") == "market"
+    except WebSocketDisconnect:
+        return
+    except (AssertionError, TypeError, ValueError):
+        STATE["ws"]["invalid_subscribes"] += 1
+        await ws.close()
+        return
+    STATE["ws"]["connections"] += 1
+    connection = STATE["ws"]["connections"]
+    STATE["ws"]["subscriptions"].append(payload)
+    tokens = [str(t) for t in payload["assets_ids"]]
+    # The server re-sends a full book snapshot per token on every subscribe.
+    await ws.send_text(json.dumps([fx.ws_book_message(t) for t in tokens]))
+    if connection == 1:
+        # Scripted mid-stream disconnect: the recorder must reconnect and
+        # re-subscribe to keep recording.
+        await ws.send_text(json.dumps(fx.ws_price_change_conn1(tokens[0])))
+        await ws.close()
+        return
+    await ws.send_text(json.dumps(fx.ws_price_change_conn2(tokens[0])))
+    await ws.send_text(json.dumps(fx.ws_legacy_change_conn2(tokens[0])))
+    while True:
+        try:
+            raw = await asyncio.wait_for(ws.receive_text(), timeout=0.1)
+        except asyncio.TimeoutError:
+            try:
+                # No-op heartbeat so the recorder's message loop stays
+                # responsive to stop() without arbitrary sleeps in tests.
+                await ws.send_text("{}")
+            except Exception:
+                return
+            continue
+        except WebSocketDisconnect:
+            return
+        if raw == "PING":
+            STATE["ws"]["pings"] += 1
+            await ws.send_text("PONG")
+
+
+# ---------------------------------------------------------------------------
+# Admin / health
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.post("/admin/reset")
+async def admin_reset():
+    global STATE
+    STATE = _initial_state()
+    return {"status": "reset"}
+
+
+@app.get("/admin/requests")
+async def admin_requests():
+    return {"counts": STATE["counts"], "events": STATE["events"]}
+
+
+@app.get("/admin/ws")
+async def admin_ws():
+    return STATE["ws"]
+
+
+@app.post("/admin/fail-next")
+async def admin_fail_next(request: Request):
+    body = await request.json()
+    STATE["fail_next"][body["key"]] = {"status": int(body.get("status", 500)), "times": int(body.get("times", 1))}
+    return {"status": "armed"}
+
+
+@app.post("/admin/latency")
+async def admin_latency(request: Request):
+    body = await request.json()
+    STATE["latency"][body["key"]] = float(body["seconds"])
+    return {"status": "set"}

--- a/tests/e2e/mock/fixtures.py
+++ b/tests/e2e/mock/fixtures.py
@@ -1,0 +1,547 @@
+"""Deterministic fixture corpus shared by the e2e mock service and the e2e tests.
+
+This module is stdlib-only: it is imported both inside the mock container
+(next to ``app.py``) and from the test runner (via ``importlib``) so the
+tests can derive expected values from the exact data the mock serves.
+
+All timestamps are fixed in the past so runs are reproducible.
+"""
+
+import json
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Time bases
+# ---------------------------------------------------------------------------
+
+MARKETS_BASE_TS = 1704067200  # 2024-01-01T00:00:00Z, a multiple of 3600
+DAY = 86400
+HOUR = 3600
+
+# ---------------------------------------------------------------------------
+# Gamma markets
+# ---------------------------------------------------------------------------
+
+TOTAL_MARKETS = 25000
+# Scheduled market lifetime in days for the six "featured" markets (the only
+# ones that carry CLOB token IDs and condition IDs). The price-history window
+# for each is its lifetime + the indexer's 7-day end padding, so these spans
+# force 1, 1, 2, 2, 4 and 4 fifteen-day request windows respectively.
+FEATURED_SPANS_DAYS = [5, 5, 20, 20, 40, 40]
+FEATURED_COUNT = len(FEATURED_SPANS_DAYS)
+END_PADDING_DAYS = 7
+PRICE_WINDOW_DAYS = 15
+
+
+def iso(ts):
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def featured_condition_id(i):
+    return "0x" + format(0xC0FFEE00 + i, "064x")
+
+
+def featured_token_ids(i):
+    base = 10**20
+    return [str(base + i * 2 + 1), str(base + i * 2 + 2)]
+
+
+def featured_created_ts(i):
+    return MARKETS_BASE_TS + i * DAY
+
+
+def featured_end_ts(i):
+    return featured_created_ts(i) + FEATURED_SPANS_DAYS[i] * DAY
+
+
+def all_featured_token_ids():
+    return [token for i in range(FEATURED_COUNT) for token in featured_token_ids(i)]
+
+
+def build_markets():
+    markets = []
+    for i in range(TOTAL_MARKETS):
+        featured = i < FEATURED_COUNT
+        if featured:
+            created = featured_created_ts(i)
+            market = {
+                "id": str(i),
+                "conditionId": featured_condition_id(i),
+                "question": f"Featured question {i}?",
+                "slug": f"featured-market-{i}",
+                "outcomes": json.dumps(["Yes", "No"]),
+                "outcomePrices": json.dumps(["0.4", "0.6"]),
+                "clobTokenIds": json.dumps(featured_token_ids(i)),
+                "volume": float(10**9 - i),
+                "liquidity": 50000.0,
+                "active": True,
+                "closed": False,
+                "createdAt": iso(created),
+                "endDate": iso(featured_end_ts(i)),
+                "marketMakerAddress": None,
+            }
+        else:
+            market = {
+                "id": str(i),
+                "conditionId": "",
+                "question": f"Question {i}?",
+                "slug": f"market-{i}",
+                "outcomes": json.dumps(["Yes", "No"]),
+                "outcomePrices": json.dumps(["0.5", "0.5"]),
+                "clobTokenIds": "[]",
+                "volume": float(i % 1000),
+                "liquidity": float(i % 500),
+                "active": i % 3 != 0,
+                "closed": i % 3 == 0,
+                "createdAt": iso(MARKETS_BASE_TS),
+                "endDate": iso(MARKETS_BASE_TS + 30 * DAY),
+                "marketMakerAddress": None,
+            }
+        markets.append(market)
+    return markets
+
+
+# ---------------------------------------------------------------------------
+# Gamma events (keyset pagination, two closed phases)
+# ---------------------------------------------------------------------------
+
+OPEN_EVENTS = 700
+CLOSED_EVENTS = 700
+TOTAL_EVENTS = OPEN_EVENTS + CLOSED_EVENTS
+
+
+def build_events():
+    events = []
+    for i in range(TOTAL_EVENTS):
+        closed = i >= OPEN_EVENTS
+        events.append(
+            {
+                "id": str(i),
+                "slug": f"event-{i}",
+                "title": f"Event {i}",
+                "category": f"Category {i % 4}",
+                "tags": [{"slug": f"tag-{i % 5}"}],
+                "markets": [{"id": str(i)}],
+                "volume": float(i * 10),
+                "liquidity": float(i * 5),
+                "active": not closed,
+                "closed": closed,
+                "startDate": iso(MARKETS_BASE_TS + i * HOUR),
+                "endDate": iso(MARKETS_BASE_TS + 30 * DAY),
+                "createdAt": iso(MARKETS_BASE_TS),
+            }
+        )
+    return events
+
+
+# ---------------------------------------------------------------------------
+# CLOB price history (hourly grid anchored at midnight UTC)
+# ---------------------------------------------------------------------------
+
+
+def price_at(token_id, ts):
+    return ((int(token_id) * 13 + ts // HOUR) % 99 + 1) / 100
+
+
+def price_points(start_ts, end_ts):
+    """All hourly grid points in [start_ts, end_ts], inclusive on both ends.
+
+    Both-end inclusivity means adjacent request windows share their boundary
+    point, which is exactly what the real API does and what the indexer's
+    seen-timestamp dedup exists for.
+    """
+    first = ((start_ts + HOUR - 1) // HOUR) * HOUR
+    return list(range(first, end_ts + 1, HOUR))
+
+
+def expected_price_rows(i):
+    """Number of distinct price points for one token of featured market i."""
+    span = (FEATURED_SPANS_DAYS[i] + END_PADDING_DAYS) * DAY
+    return span // HOUR + 1
+
+
+def expected_price_requests(i):
+    """Number of <=15-day windows needed to cover featured market i."""
+    span = (FEATURED_SPANS_DAYS[i] + END_PADDING_DAYS) * DAY
+    return -(-span // (PRICE_WINDOW_DAYS * DAY))
+
+
+# ---------------------------------------------------------------------------
+# Data API trade tape
+# ---------------------------------------------------------------------------
+
+DATA_TRADES_COUNT = 12000  # sized to overflow the 10,000 offset cap once
+DATA_START = MARKETS_BASE_TS
+DATA_END = DATA_START + DATA_TRADES_COUNT - 1
+MALFORMED_TRADE_TIMESTAMPS = [DATA_START + 100, DATA_START + 200]
+
+
+def build_data_trades():
+    """One trade per second across the six featured markets, plus two rows
+    that fail model parsing (non-numeric size) to exercise skip-at-parse."""
+    trades = []
+    for j in range(DATA_TRADES_COUNT):
+        market = j % FEATURED_COUNT
+        trades.append(
+            {
+                "proxyWallet": "0x" + format(j % 97, "040x"),
+                "side": "BUY" if j % 2 == 0 else "SELL",
+                "asset": featured_token_ids(market)[j % 2],
+                "conditionId": featured_condition_id(market),
+                "size": round(1 + (j % 50) / 10, 1),
+                "price": ((j % 99) + 1) / 100,
+                "timestamp": DATA_START + j,
+                "transactionHash": "0x" + format(j, "064x"),
+                "title": f"Featured question {market}?",
+                "slug": f"featured-market-{market}",
+                "eventSlug": f"event-{market}",
+                "outcome": "Yes" if j % 2 == 0 else "No",
+                "outcomeIndex": j % 2,
+                "name": f"trader-{j % 97}",
+                "pseudonym": f"Pseudonym-{j % 97}",
+            }
+        )
+    for ts in MALFORMED_TRADE_TIMESTAMPS:
+        trades.append(
+            {
+                "proxyWallet": "0xmalformed",
+                "side": "BUY",
+                "asset": featured_token_ids(0)[0],
+                "conditionId": featured_condition_id(0),
+                "size": "not-a-number",
+                "price": 0.5,
+                "timestamp": ts,
+                "transactionHash": "0xmalformed",
+            }
+        )
+    return trades
+
+
+MAX_DATA_API_OFFSET = 10000
+
+# ---------------------------------------------------------------------------
+# Polygon JSON-RPC: chain shape
+# ---------------------------------------------------------------------------
+
+HEAD_BLOCK = 1103100
+E2E_START_BLOCK = 1100000  # POLYMARKET_START_BLOCK / CONDITIONAL_TOKENS_START_BLOCK in compose
+GENESIS_TS = 1690000000
+BLOCK_TIME_SECONDS = 2
+# Topic-only getLogs filters (the FPMM indexer's) wider than this return the
+# "block range too large" error, forcing the indexer's bisection path.
+TOPIC_ONLY_MAX_SPAN = 600
+
+
+def block_timestamp(n):
+    return GENESIS_TS + n * BLOCK_TIME_SECONDS
+
+
+CTF_EXCHANGE = "0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e"
+NEGRISK_CTF_EXCHANGE = "0xc5d563a36ae78145c45a50134d48a1215220f80a"
+CONDITIONAL_TOKENS = "0x4d97dcd97ec945f40cf65f87097ace5ea0476045"
+
+ORDER_FILLED_TOPIC = "0xd0a08e8c493f9c94f29311604c9de1b4e8c8d4c06bd0c789af57f2d65bfec0f6"
+CONDITION_RESOLUTION_TOPIC = "0xb44d84d3289691f71497564b85d4233648d9dbae8cbdbb4329f301c3a0185894"
+FPMM_BUY_TOPIC = "0x4f62630f51608fc8a7603a9391a5101e58bd7c276139366fc107dc3b67c3dcf8"
+FPMM_SELL_TOPIC = "0xadcf2a240ed9300d681d9a3f5382b6c1beed1b7e46643e0c7b42cbe6e2d766b4"
+
+
+def _word(value):
+    return format(value, "064x")
+
+
+def _addr_topic(address):
+    return "0x" + "0" * 24 + address[2:].lower()
+
+
+def _data(*words):
+    return "0x" + "".join(_word(w) for w in words)
+
+
+def _log(address, topics, data, block, log_index, tx_seq):
+    return {
+        "address": address,
+        "topics": topics,
+        "data": data,
+        "blockNumber": block,
+        "logIndex": log_index,
+        "transactionIndex": 0,
+        "transactionHash": "0x" + format(0xABC0000000 + tx_seq, "064x"),
+        "blockHash": "0x" + format(0xB10C000000 + block, "064x"),
+        "removed": False,
+    }
+
+
+MAKER_ADDR = "0x" + "11" * 20
+TAKER_ADDR = "0x" + "22" * 20
+ORACLE_ADDR = "0x" + "33" * 20
+
+
+def _order_filled_log(
+    address, block, log_index, tx_seq, maker_asset_id, taker_asset_id, maker_amount, taker_amount, fee
+):
+    return _log(
+        address,
+        [
+            ORDER_FILLED_TOPIC,
+            "0x" + format(0x0DE40000 + tx_seq, "064x"),  # orderHash
+            _addr_topic(MAKER_ADDR),
+            _addr_topic(TAKER_ADDR),
+        ],
+        _data(maker_asset_id, taker_asset_id, maker_amount, taker_amount, fee),
+        block,
+        log_index,
+        tx_seq,
+    )
+
+
+def build_ctf_trade_params():
+    """(contract, block, log_index, maker_asset_id, taker_asset_id, maker_amount, taker_amount, fee).
+
+    CTF Exchange fills live only in blocks [E2E_START_BLOCK, E2E_START_BLOCK+23]
+    (before the first cursor write of any chunked run) and NegRisk fills avoid
+    blocks that are chunk-boundary re-fetch candidates for a chunk size of 25
+    ((block - E2E_START_BLOCK) % 25 == 24). Together these make process-kill
+    resume deterministic and duplicate-free by construction.
+    """
+    params = []
+    for k in range(30):
+        block = E2E_START_BLOCK + (k % 24)
+        params.append((CTF_EXCHANGE, block, k // 24, 0, 10**20 + k, (k + 1) * 10**6, 2 * 10**6, 1000 + k))
+    for k in range(60):
+        block = E2E_START_BLOCK + 25 + k * 51
+        if (block - E2E_START_BLOCK) % 25 == 24:
+            block += 1
+        params.append((NEGRISK_CTF_EXCHANGE, block, 0, 10**20 + k, 0, 3 * 10**6, (k + 1) * 10**6, 2000 + k))
+    return params
+
+
+def build_fpmm_addresses():
+    return ["0x" + "aa" * 19 + "01", "0x" + "aa" * 19 + "02", "0x" + "aa" * 19 + "03"]
+
+
+def build_fpmm_trade_params():
+    """(fpmm_address, block, log_index, is_buy, amount, fee_amount, outcome_index, outcome_tokens)."""
+    addresses = build_fpmm_addresses()
+    params = []
+    for k in range(40):
+        block = E2E_START_BLOCK + 10 + k * 77
+        params.append(
+            (
+                addresses[k % 3],
+                block,
+                0,
+                k % 2 == 0,
+                (k + 1) * 10**6,
+                10**4 + k,
+                k % 2,
+                (k + 1) * 10**18,
+            )
+        )
+    return params
+
+
+RESOLUTION_PAYOUTS = [[1, 0], [0, 1], [1, 1], [0, 3, 1]]
+
+
+def build_resolution_params():
+    """(block, log_index, condition_id, question_id, payout_numerators)."""
+    params = []
+    for k in range(12):
+        block = E2E_START_BLOCK + 50 + k * 250
+        condition_id = featured_condition_id(k) if k < FEATURED_COUNT else "0x" + format(0xD00D00 + k, "064x")
+        question_id = "0x" + format(0x9E570000 + k, "064x")
+        params.append((block, k % 3, condition_id, question_id, RESOLUTION_PAYOUTS[k % len(RESOLUTION_PAYOUTS)]))
+    return params
+
+
+def build_logs():
+    """The full canned log store served by eth_getLogs."""
+    logs = []
+    tx_seq = 0
+    for (
+        contract,
+        block,
+        log_index,
+        maker_asset,
+        taker_asset,
+        maker_amount,
+        taker_amount,
+        fee,
+    ) in build_ctf_trade_params():
+        tx_seq += 1
+        logs.append(
+            _order_filled_log(
+                contract, block, log_index, tx_seq, maker_asset, taker_asset, maker_amount, taker_amount, fee
+            )
+        )
+    # One undecodable OrderFilled log (truncated data) that the indexer must skip.
+    tx_seq += 1
+    logs.append(
+        _log(
+            CTF_EXCHANGE,
+            [ORDER_FILLED_TOPIC, "0x" + _word(0xBAD), _addr_topic(MAKER_ADDR), _addr_topic(TAKER_ADDR)],
+            "0x1234",
+            E2E_START_BLOCK + 3,
+            9,
+            tx_seq,
+        )
+    )
+    for fpmm, block, log_index, is_buy, amount, fee_amount, outcome_index, outcome_tokens in build_fpmm_trade_params():
+        tx_seq += 1
+        logs.append(
+            _log(
+                fpmm,
+                [
+                    FPMM_BUY_TOPIC if is_buy else FPMM_SELL_TOPIC,
+                    _addr_topic(TAKER_ADDR),
+                    "0x" + _word(outcome_index),
+                ],
+                _data(amount, fee_amount, outcome_tokens),
+                block,
+                log_index,
+                tx_seq,
+            )
+        )
+    for block, log_index, condition_id, question_id, payouts in build_resolution_params():
+        tx_seq += 1
+        head = [len(payouts), 0x40, len(payouts)] + payouts
+        # outcomeSlotCount word, offset word to the dynamic array, then its length + items
+        logs.append(
+            _log(
+                CONDITIONAL_TOKENS,
+                [CONDITION_RESOLUTION_TOPIC, condition_id, _addr_topic(ORACLE_ADDR), question_id],
+                _data(*head),
+                block,
+                log_index,
+                tx_seq,
+            )
+        )
+    return logs
+
+
+# ---------------------------------------------------------------------------
+# eth_call fixtures (FPMM collateral lookup)
+# ---------------------------------------------------------------------------
+
+TOKEN_USDC = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
+TOKEN_NO_SYMBOL = "0x" + "bb" * 19 + "01"  # symbol() reverts -> UNKNOWN fallback
+
+SELECTOR_COLLATERAL_TOKEN = "0xb2016bd4"
+SELECTOR_SYMBOL = "0x95d89b41"
+
+
+def build_collateral_map():
+    a, b, c = build_fpmm_addresses()
+    return {a: TOKEN_USDC, b: TOKEN_USDC, c: TOKEN_NO_SYMBOL}
+
+
+def encode_address(address):
+    return "0x" + "0" * 24 + address[2:].lower()
+
+
+def encode_string(value):
+    raw = value.encode()
+    padded_len = -(-len(raw) // 32) * 32
+    return "0x" + _word(0x20) + _word(len(raw)) + raw.hex().ljust(padded_len * 2, "0")
+
+
+# ---------------------------------------------------------------------------
+# CLOB WebSocket market channel script
+# ---------------------------------------------------------------------------
+
+WS_BOOK_TS_MS = "1704067200000"
+WS_BOOK_BIDS = [{"price": "0.45", "size": "100.5"}, {"price": "0.44", "size": "200"}]
+WS_BOOK_ASKS = [{"price": "0.55", "size": "50"}, {"price": "0.56", "size": "75"}]
+
+
+def ws_book_message(token_id):
+    for i in range(FEATURED_COUNT):
+        if token_id in featured_token_ids(i):
+            condition_id = featured_condition_id(i)
+            break
+    else:
+        condition_id = "0x" + "0" * 64
+    return {
+        "event_type": "book",
+        "asset_id": token_id,
+        "market": condition_id,
+        "timestamp": WS_BOOK_TS_MS,
+        "hash": f"bookhash-{token_id[-4:]}",
+        "bids": WS_BOOK_BIDS,
+        "asks": WS_BOOK_ASKS,
+    }
+
+
+def ws_price_change_conn1(token_id):
+    return {
+        "event_type": "price_change",
+        "market": featured_condition_id(0),
+        "timestamp": "1704067201000",
+        "price_changes": [
+            {
+                "asset_id": token_id,
+                "price": "0.46",
+                "size": "25",
+                "side": "BUY",
+                "hash": "pc1",
+                "best_bid": "0.46",
+                "best_ask": "0.55",
+            },
+            {
+                "asset_id": token_id,
+                "price": "0.55",
+                "size": "10",
+                "side": "SELL",
+                "hash": "pc2",
+                "best_bid": "0.46",
+                "best_ask": "0.55",
+            },
+        ],
+    }
+
+
+def ws_price_change_conn2(token_id):
+    return {
+        "event_type": "price_change",
+        "market": featured_condition_id(0),
+        "timestamp": "1704067202000",
+        "price_changes": [
+            {
+                "asset_id": token_id,
+                "price": "0.44",
+                "size": "0",
+                "side": "BUY",
+                "hash": "pc3",
+                "best_bid": "0.45",
+                "best_ask": "0.55",
+            },
+            {
+                "asset_id": token_id,
+                "price": "0.47",
+                "size": "40",
+                "side": "BUY",
+                "hash": "pc4",
+                "best_bid": "0.47",
+                "best_ask": "0.55",
+            },
+        ],
+    }
+
+
+def ws_legacy_change_conn2(token_id):
+    return {
+        "event_type": "price_change",
+        "market": featured_condition_id(0),
+        "asset_id": token_id,
+        "hash": "legacy1",
+        "timestamp": "1704067203000",
+        "changes": [
+            {"price": "0.56", "size": "0", "side": "SELL", "best_bid": "0.47", "best_ask": "0.57"},
+        ],
+    }
+
+
+# Rows persisted to the price_changes table per connection, per the script above.
+WS_CONN1_DELTA_ROWS = 2
+WS_CONN2_DELTA_ROWS = 3

--- a/tests/e2e/runner.Dockerfile
+++ b/tests/e2e/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Test-runner image: Python 3.9 + the exact repository dependency lock.
+FROM ghcr.io/astral-sh/uv:python3.9-bookworm-slim
+
+WORKDIR /app
+
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+# Install dependencies from the lock first so code changes reuse this layer.
+COPY pyproject.toml uv.lock .python-version ./
+RUN uv sync --frozen --group dev
+
+COPY . .
+
+CMD ["uv", "run", "--frozen", "pytest", "tests/e2e", "-m", "e2e", "-v"]

--- a/tests/e2e/test_e2e_blockchain.py
+++ b/tests/e2e/test_e2e_blockchain.py
@@ -1,0 +1,128 @@
+"""Polygon JSON-RPC scenarios driven through the real web3 provider: CTF
+trades, FPMM trades with too-large bisection, block sampling/interpolation,
+and condition resolutions."""
+
+import json
+from datetime import datetime, timezone
+
+import duckdb
+import pandas as pd
+
+
+def test_ctf_trades_backfill_decodes_real_logs(workdir, admin, fx):
+    from src.indexers.polymarket.trades import PolymarketTradesIndexer
+
+    PolymarketTradesIndexer().run()
+
+    params = fx.build_ctf_trade_params()
+    df = pd.concat(pd.read_parquet(f) for f in (workdir / "data/polymarket/trades").glob("trades_*.parquet"))
+
+    # The undecodable fixture log is skipped; every valid log decodes exactly once.
+    assert len(df) == len(params)
+    assert df[["transaction_hash", "log_index", "_contract"]].drop_duplicates().shape[0] == len(params)
+    assert set(df["_contract"]) == {"CTF Exchange", "NegRisk CTF Exchange"}
+
+    expected = sorted(
+        (block, maker_amount, taker_amount, fee) for _, block, _, _, _, maker_amount, taker_amount, fee in params
+    )
+    actual = sorted(zip(df["block_number"], df["maker_amount"], df["taker_amount"], df["fee"]))
+    assert actual == expected
+
+    # Large asset IDs are persisted as strings to avoid parquet overflow.
+    assert df["maker_asset_id"].map(lambda v: isinstance(v, str)).all()
+    assert df["taker_asset_id"].map(lambda v: isinstance(v, str)).all()
+    assert {a.lower() for a in df["maker"]} == {fx.MAKER_ADDR}
+    assert {a.lower() for a in df["taker"]} == {fx.TAKER_ADDR}
+
+    assert not (workdir / "data/polymarket/.backfill_block_cursor").exists()
+
+
+def test_fpmm_trades_bisect_too_large_log_ranges(workdir, admin, fx):
+    from src.indexers.polymarket.fpmm_trades import PolymarketLegacyTradesIndexer
+
+    PolymarketLegacyTradesIndexer(
+        from_block=fx.E2E_START_BLOCK, to_block=fx.HEAD_BLOCK, chunk_size=1000, max_workers=4
+    ).run()
+
+    params = fx.build_fpmm_trade_params()
+    df = pd.concat(pd.read_parquet(f) for f in (workdir / "data/polymarket/legacy_trades").glob("trades_*.parquet"))
+
+    assert len(df) == len(params)
+    expected = sorted(
+        (block, fpmm, is_buy, str(amount), outcome_index, str(tokens))
+        for fpmm, block, _, is_buy, amount, _, outcome_index, tokens in params
+    )
+    actual = sorted(
+        (row.block_number, row.fpmm_address.lower(), row.is_buy, row.amount, row.outcome_index, row.outcome_tokens)
+        for row in df.itertuples()
+    )
+    assert actual == expected
+
+    # The FPMM indexer filters by topic only (no address); the mock rejects
+    # topic-only spans wider than TOPIC_ONLY_MAX_SPAN, so each of the three
+    # full-size chunks must be bisected once per topic: 2 topics * (3 chunks *
+    # 3 requests + 1 short final chunk) = 20 getLogs calls.
+    assert admin.count("rpc:eth_getLogs") == 20
+    spans = [r["meta"]["span"] for r in admin.events("rpc:eth_getLogs")]
+    assert max(spans) == 1000
+    assert spans.count(1000) == 6  # each too-large attempt, before its two halves
+
+    assert not (workdir / "data/polymarket/.legacy_backfill_block_cursor").exists()
+
+
+def test_blocks_indexer_samples_and_interpolates_timestamps(workdir, admin, fx):
+    from src.indexers.polymarket.blocks import PolymarketBlocksIndexer
+
+    # Seed the resume point: the blocks indexer derives it from existing
+    # filenames, so a prior bucket file makes the run start at E2E_START_BLOCK.
+    blocks_dir = workdir / "data/polymarket/blocks"
+    blocks_dir.mkdir(parents=True)
+    pd.DataFrame([{"block_number": fx.E2E_START_BLOCK - 1, "timestamp": "2023-01-01T00:00:00Z"}]).to_parquet(
+        blocks_dir / f"blocks_{fx.E2E_START_BLOCK - 100000}_{fx.E2E_START_BLOCK}.parquet"
+    )
+
+    PolymarketBlocksIndexer().run()
+
+    new_file = blocks_dir / f"blocks_{fx.E2E_START_BLOCK}_{fx.HEAD_BLOCK + 1}.parquet"
+    assert new_file.exists()
+    df = pd.read_parquet(new_file)
+
+    assert list(df["block_number"]) == list(range(fx.E2E_START_BLOCK, fx.HEAD_BLOCK + 1))
+    # The chain's block time is exactly linear, so interpolation between the
+    # sampled points must reproduce every timestamp exactly.
+    expected = [
+        datetime.fromtimestamp(fx.block_timestamp(block), tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for block in range(fx.E2E_START_BLOCK, fx.HEAD_BLOCK + 1)
+    ]
+    assert list(df["timestamp"]) == expected
+
+    # Only every 100th block was fetched over RPC.
+    assert admin.count("rpc:eth_getBlockByNumber") == (fx.HEAD_BLOCK - fx.E2E_START_BLOCK) // 100 + 1
+
+
+def test_resolutions_backfill_decodes_payout_arrays(workdir, admin, fx):
+    from src.indexers.polymarket.resolutions import PolymarketResolutionsIndexer
+
+    PolymarketResolutionsIndexer(chunk_size=500).run()
+
+    params = fx.build_resolution_params()
+    df = pd.concat(pd.read_parquet(f) for f in (workdir / "data/polymarket/resolutions").glob("resolutions_*.parquet"))
+
+    assert len(df) == len(params)
+    expected = sorted((block, cid, qid, len(payouts), json.dumps(payouts)) for block, _, cid, qid, payouts in params)
+    actual = sorted(
+        (row.block_number, row.condition_id, row.question_id, row.outcome_slot_count, row.payout_numerators)
+        for row in df.itertuples()
+    )
+    assert actual == expected
+    assert {a.lower() for a in df["oracle"]} == {fx.ORACLE_ADDR}
+
+    duplicates = duckdb.sql(
+        "SELECT COUNT(*) - COUNT(DISTINCT (transaction_hash, log_index)) "
+        "FROM 'data/polymarket/resolutions/resolutions_*.parquet'"
+    ).fetchone()[0]
+    assert duplicates == 0
+
+    assert not (workdir / "data/polymarket/.resolutions_block_cursor").exists()
+    # ceil(3101 / 500) chunked ranges, each one getLogs call.
+    assert admin.count("rpc:eth_getLogs") == 7

--- a/tests/e2e/test_e2e_client_surfaces.py
+++ b/tests/e2e/test_e2e_client_surfaces.py
@@ -1,0 +1,62 @@
+"""Client-level wire scenarios: CLOB REST parsing, keyset chaining, the
+15-day price-history cap, and the no-egress canary."""
+
+import os
+
+import httpx
+import pytest
+
+
+def test_clob_rest_surfaces_parse_string_payloads(admin, fx):
+    from src.indexers.polymarket.client import PolymarketClient
+
+    token = fx.all_featured_token_ids()[0]
+    with PolymarketClient() as client:
+        book = client.get_order_book(token)
+        assert book.token_id == token
+        assert book.timestamp == int(fx.WS_BOOK_TS_MS)
+        assert [(level.price, level.size) for level in book.bids] == [(0.45, 100.5), (0.44, 200.0)]
+        assert [(level.price, level.size) for level in book.asks] == [(0.55, 50.0), (0.56, 75.0)]
+        assert book.min_order_size == 5.0
+        assert book.tick_size == 0.01
+
+        assert client.get_midpoint(token) == 0.5
+        assert client.get_spread(token) == 0.1
+        assert client.get_price(token, "BUY") == 0.45
+        assert client.get_price(token, "SELL") == 0.55
+
+
+def test_markets_keyset_pages_chain_via_cursor(admin, fx):
+    from src.indexers.polymarket.client import PolymarketClient
+
+    with PolymarketClient() as client:
+        first_page, cursor = client.get_markets_keyset(limit=100)
+        assert len(first_page) == 100
+        assert cursor is not None
+
+        second_page, _ = client.get_markets_keyset(limit=100, after_cursor=cursor)
+        assert len(second_page) == 100
+        assert {m.id for m in first_page}.isdisjoint({m.id for m in second_page})
+
+
+def test_price_history_rejects_windows_longer_than_15_days(admin, fx):
+    from src.indexers.polymarket.client import PolymarketClient
+
+    token = fx.all_featured_token_ids()[0]
+    with PolymarketClient() as client:
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
+            client.get_price_history(
+                token,
+                interval=None,
+                fidelity=60,
+                start_ts=fx.MARKETS_BASE_TS,
+                end_ts=fx.MARKETS_BASE_TS + 16 * fx.DAY,
+            )
+    assert excinfo.value.response.status_code == 400
+
+
+def test_no_external_egress_is_possible():
+    if not os.environ.get("E2E_EXPECT_NO_EGRESS"):
+        pytest.skip("canary only applies inside the Compose internal network")
+    with pytest.raises(httpx.TransportError):
+        httpx.get("https://gamma-api.polymarket.com/markets", timeout=5.0)

--- a/tests/e2e/test_e2e_collateral.py
+++ b/tests/e2e/test_e2e_collateral.py
@@ -1,0 +1,36 @@
+"""Collateral scenario: legacy-trades parquet -> eth_call lookups with symbol
+caching, UNKNOWN fallback on revert, and an idempotent second run."""
+
+import json
+
+
+def test_collateral_lookup_caches_symbols_and_is_idempotent(workdir, admin, fx):
+    from src.indexers.polymarket.collateral import PolymarketCollateralIndexer
+    from src.indexers.polymarket.fpmm_trades import PolymarketLegacyTradesIndexer
+
+    # Real cross-indexer dataflow: the collateral indexer reads the distinct
+    # FPMM addresses out of the parquet this run produces.
+    PolymarketLegacyTradesIndexer(
+        from_block=fx.E2E_START_BLOCK, to_block=fx.HEAD_BLOCK, chunk_size=1000, max_workers=4
+    ).run()
+
+    before = admin.count("rpc:eth_call")
+    PolymarketCollateralIndexer(max_workers=1).run()
+
+    # 3 collateralToken() calls + 2 symbol() calls: USDC is fetched once and
+    # cached, the no-symbol token reverts and is cached as UNKNOWN.
+    assert admin.count("rpc:eth_call") - before == 5
+
+    lookup_file = workdir / "data/polymarket/fpmm_collateral_lookup.json"
+    lookup = {k.lower(): v for k, v in json.loads(lookup_file.read_text()).items()}
+    fpmm_a, fpmm_b, fpmm_c = fx.build_fpmm_addresses()
+    assert set(lookup) == {fpmm_a, fpmm_b, fpmm_c}
+    for fpmm in (fpmm_a, fpmm_b):
+        assert lookup[fpmm]["collateral_address"].lower() == fx.TOKEN_USDC
+        assert lookup[fpmm]["collateral_symbol"] == "USDC"
+    assert lookup[fpmm_c]["collateral_address"].lower() == fx.TOKEN_NO_SYMBOL
+    assert lookup[fpmm_c]["collateral_symbol"] == "UNKNOWN"
+
+    # Second run: the lookup file is the cursor, so no address is re-resolved.
+    PolymarketCollateralIndexer(max_workers=1).run()
+    assert admin.count("rpc:eth_call") - before == 5

--- a/tests/e2e/test_e2e_data_api_trades.py
+++ b/tests/e2e/test_e2e_data_api_trades.py
@@ -1,0 +1,37 @@
+"""Data API trade-tape scenario: market scoping, the 10,000 offset cap with
+window bisection, malformed-row skipping, and composite-key dedup."""
+
+import duckdb
+
+COMPOSITE_KEY = "(transaction_hash, proxy_wallet, asset, side, timestamp, size, price)"
+
+
+def test_data_api_backfill_bisects_offset_cap_and_dedups(seeded_workdir, admin, fx):
+    from src.indexers.polymarket.data_api_trades import PolymarketDataApiTradesIndexer
+
+    PolymarketDataApiTradesIndexer(start=fx.DATA_START, end=fx.DATA_END).run()
+
+    total, distinct = duckdb.sql(
+        f"SELECT COUNT(*), COUNT(DISTINCT {COMPOSITE_KEY}) FROM 'data/polymarket/data_api_trades/trades_*.parquet'"
+    ).fetchone()
+    # The two malformed fixture rows are skipped at parse; everything else is
+    # persisted exactly once despite the full window overflowing the offset cap.
+    assert total == fx.DATA_TRADES_COUNT
+    assert distinct == fx.DATA_TRADES_COUNT
+
+    assert not (seeded_workdir / "data/polymarket/.data_api_trades_cursor").exists()
+
+    requests = admin.events("/data-api/trades")
+    windows = {(r["meta"]["start"], r["meta"]["end"]) for r in requests}
+    mid = (fx.DATA_START + fx.DATA_END) // 2
+    # The full window trips the offset cap, so the indexer must bisect it.
+    assert (fx.DATA_START, fx.DATA_END) in windows
+    assert (fx.DATA_START, mid) in windows
+    assert (mid + 1, fx.DATA_END) in windows
+    # 11 pages to detect truncation, then 7 per non-truncated half.
+    assert len(requests) == 25
+
+    # Every request was scoped to the condition IDs from the markets dataset.
+    scopes = {r["meta"]["market"] for r in requests}
+    assert scopes == {",".join(fx.featured_condition_id(i) for i in range(fx.FEATURED_COUNT))}
+    assert max(r["meta"]["offset"] for r in requests) == 10000

--- a/tests/e2e/test_e2e_gamma.py
+++ b/tests/e2e/test_e2e_gamma.py
@@ -1,0 +1,66 @@
+"""Gamma REST scenarios: markets backfill, two-phase events walk, wire-level retry."""
+
+import duckdb
+
+
+def test_markets_backfill_chunks_and_clears_offset_cursor(workdir, admin, fx):
+    from src.indexers.polymarket.markets import PolymarketMarketsIndexer
+
+    PolymarketMarketsIndexer().run()
+
+    files = sorted(f.name for f in (workdir / "data/polymarket/markets").glob("markets_*.parquet"))
+    assert files == ["markets_0_10000.parquet", "markets_10000_20000.parquet", "markets_20000_25000.parquet"]
+
+    total, distinct, featured = duckdb.sql(
+        "SELECT COUNT(*), COUNT(DISTINCT id), COUNT(*) FILTER (WHERE condition_id <> '') "
+        "FROM 'data/polymarket/markets/markets_*.parquet'"
+    ).fetchone()
+    assert total == fx.TOTAL_MARKETS
+    assert distinct == fx.TOTAL_MARKETS
+    assert featured == fx.FEATURED_COUNT
+
+    # Clean completion removes the offset cursor.
+    assert not (workdir / "data/polymarket/.backfill_offset").exists()
+
+    # 50 full pages of 500 plus the final empty page.
+    assert admin.count("/gamma/markets") == fx.TOTAL_MARKETS // 500 + 1
+
+
+def test_events_two_phase_keyset_walk(workdir, admin, fx):
+    from src.indexers.polymarket.events import PolymarketEventsIndexer
+
+    PolymarketEventsIndexer().run()
+
+    total, distinct = duckdb.sql(
+        "SELECT COUNT(*), COUNT(DISTINCT id) FROM 'data/polymarket/events/events_*.parquet'"
+    ).fetchone()
+    assert total == fx.TOTAL_EVENTS
+    assert distinct == fx.TOTAL_EVENTS
+
+    open_count, closed_count = duckdb.sql(
+        "SELECT COUNT(*) FILTER (WHERE NOT closed), COUNT(*) FILTER (WHERE closed) "
+        "FROM 'data/polymarket/events/events_*.parquet'"
+    ).fetchone()
+    assert open_count == fx.OPEN_EVENTS
+    assert closed_count == fx.CLOSED_EVENTS
+
+    assert not (workdir / "data/polymarket/.events_backfill_cursor").exists()
+
+    # Both phases walked the keyset endpoint: two pages per closed value.
+    requests = admin.events("/gamma/events/keyset")
+    assert [r["meta"]["closed"] for r in requests] == ["false", "false", "true", "true"]
+    assert [r["meta"]["cursor"] for r in requests] == [0, 500, 0, 500]
+
+
+def test_transient_500_is_retried_through_real_httpx(workdir, admin, fx):
+    from src.indexers.polymarket.events import PolymarketEventsIndexer
+
+    admin.fail_next("/gamma/events/keyset", status=500, times=1)
+
+    PolymarketEventsIndexer().run()
+
+    total = duckdb.sql("SELECT COUNT(*) FROM 'data/polymarket/events/events_*.parquet'").fetchone()[0]
+    assert total == fx.TOTAL_EVENTS
+
+    # 4 successful pages plus the one injected failure that tenacity retried.
+    assert admin.count("/gamma/events/keyset") == 5

--- a/tests/e2e/test_e2e_interrupt_resume.py
+++ b/tests/e2e/test_e2e_interrupt_resume.py
@@ -1,0 +1,118 @@
+"""Process-level interrupt/resume: a real subprocess is killed with a real
+SIGINT mid-run, then relaunched, and the combined dataset must be complete
+and duplicate-free. Covers the offset-cursor (markets), block-cursor (CTF
+trades), and composite-cursor (Data API trades) families."""
+
+import shutil
+
+import duckdb
+
+MARKETS_CODE = "from src.indexers.polymarket.markets import PolymarketMarketsIndexer; PolymarketMarketsIndexer().run()"
+
+TRADES_CODE_FIRST = (
+    "from src.indexers.polymarket.trades import PolymarketTradesIndexer; "
+    "PolymarketTradesIndexer(from_block={start}, to_block={end}, chunk_size=25).run()"
+)
+# The resume leg omits from_block so the indexer reads the block cursor.
+TRADES_CODE_RESUME = (
+    "from src.indexers.polymarket.trades import PolymarketTradesIndexer; "
+    "PolymarketTradesIndexer(to_block={end}, chunk_size=25).run()"
+)
+
+DATA_API_CODE = (
+    "from src.indexers.polymarket.data_api_trades import PolymarketDataApiTradesIndexer; "
+    "PolymarketDataApiTradesIndexer(start={start}, end={end}).run()"
+)
+
+
+def test_markets_sigint_preserves_offset_cursor_and_resumes(
+    workdir, admin, fx, run_indexer, wait_until, interrupt_and_wait
+):
+    offset_file = workdir / "data/polymarket/.backfill_offset"
+
+    proc = run_indexer(MARKETS_CODE, workdir)
+    wait_until(offset_file.exists, message="offset cursor file")
+    output = interrupt_and_wait(proc)
+    assert proc.returncode == 0
+    assert "Interrupted" in output
+
+    # The cursor and the flushed partial chunk both survived the interrupt.
+    assert offset_file.exists()
+    assert int(offset_file.read_text()) >= 500
+    assert list((workdir / "data/polymarket/markets").glob("markets_*.parquet"))
+
+    resume = run_indexer(MARKETS_CODE, workdir)
+    resume_output, _ = resume.communicate(timeout=120)
+    assert resume.returncode == 0
+    assert "Resuming from offset" in resume_output
+    assert not offset_file.exists()
+
+    total, distinct = duckdb.sql(
+        "SELECT COUNT(*), COUNT(DISTINCT id) FROM 'data/polymarket/markets/markets_*.parquet'"
+    ).fetchone()
+    assert total == fx.TOTAL_MARKETS
+    assert distinct == fx.TOTAL_MARKETS
+
+
+def test_trades_sigint_preserves_block_cursor_and_resumes(
+    workdir, admin, fx, run_indexer, wait_until, interrupt_and_wait
+):
+    # Stretch each getLogs call so the interrupt deterministically lands
+    # inside a fetch, never between a chunk's append and its cursor write.
+    admin.set_latency("rpc:eth_getLogs", 0.1)
+    end_block = fx.E2E_START_BLOCK + 199
+    cursor_file = workdir / "data/polymarket/.backfill_block_cursor"
+
+    proc = run_indexer(TRADES_CODE_FIRST.format(start=fx.E2E_START_BLOCK, end=end_block), workdir)
+    wait_until(cursor_file.exists, message="block cursor file")
+    output = interrupt_and_wait(proc)
+    assert proc.returncode == 0
+    assert "Interrupted" in output
+    assert cursor_file.exists()
+
+    resume = run_indexer(TRADES_CODE_RESUME.format(end=end_block), workdir)
+    resume_output, _ = resume.communicate(timeout=120)
+    assert resume.returncode == 0
+    assert "Resuming from block" in resume_output
+    assert not cursor_file.exists()
+
+    expected = [p for p in fx.build_ctf_trade_params() if p[1] <= end_block]
+    total, distinct = duckdb.sql(
+        "SELECT COUNT(*), COUNT(DISTINCT (transaction_hash, log_index, _contract)) "
+        "FROM 'data/polymarket/trades/trades_*.parquet'"
+    ).fetchone()
+    assert total == len(expected)
+    assert distinct == len(expected)
+
+
+def test_data_api_sigint_resumes_from_window_cursor(
+    workdir, seeded_markets_dir, admin, fx, run_indexer, wait_until, interrupt_and_wait
+):
+    shutil.copytree(seeded_markets_dir / "data/polymarket/markets", workdir / "data/polymarket/markets")
+    cursor_file = workdir / "data/polymarket/.data_api_trades_cursor"
+    code = DATA_API_CODE.format(start=fx.DATA_START, end=fx.DATA_END)
+
+    proc = run_indexer(code, workdir)
+    # Interrupt inside a market's window walk: the cursor holds
+    # "<market index>,<window timestamp>" once the first bisected leaf is done.
+    wait_until(
+        lambda: cursor_file.exists() and "," in cursor_file.read_text(),
+        message="composite window cursor",
+    )
+    output = interrupt_and_wait(proc)
+    assert proc.returncode == 0
+    assert "Interrupted" in output
+    assert "," in cursor_file.read_text()
+
+    resume = run_indexer(code, workdir)
+    resume_output, _ = resume.communicate(timeout=120)
+    assert resume.returncode == 0
+    assert "Resuming from market 0 at timestamp" in resume_output
+    assert not cursor_file.exists()
+
+    total, distinct = duckdb.sql(
+        "SELECT COUNT(*), COUNT(DISTINCT (transaction_hash, proxy_wallet, asset, side, timestamp, size, price)) "
+        "FROM 'data/polymarket/data_api_trades/trades_*.parquet'"
+    ).fetchone()
+    assert total == fx.DATA_TRADES_COUNT
+    assert distinct == fx.DATA_TRADES_COUNT

--- a/tests/e2e/test_e2e_orderbook_ws.py
+++ b/tests/e2e/test_e2e_orderbook_ws.py
@@ -1,0 +1,77 @@
+"""Orderbook scenario: Gamma token discovery, then the real websockets client
+against the mock's scripted market channel - subscribe, book snapshots,
+price_change deltas (including size-"0" removals and the legacy `changes`
+shape), PING/PONG heartbeats, and a forced disconnect/reconnect/resubscribe."""
+
+import asyncio
+import json
+import os
+import threading
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_recorder_survives_disconnect_and_persists_raw_stream(workdir, admin, fx, wait_until):
+    from src.indexers.polymarket.client import PolymarketClient
+    from src.indexers.polymarket.orderbook import OrderBookRecorder, OrderBookWriter, discover_token_ids
+
+    # Token discovery through the real Gamma client (order=volume descending).
+    with PolymarketClient() as client:
+        tokens = discover_token_ids(client)
+    assert tokens == fx.all_featured_token_ids()
+
+    writer = OrderBookWriter(data_dir=Path("data/polymarket/orderbook"))
+    recorder = OrderBookRecorder(
+        tokens,
+        writer,
+        ws_url=os.environ["POLYMARKET_WS_URL"],
+        ping_interval=0.3,
+        initial_reconnect_delay=0.2,
+    )
+    thread = threading.Thread(target=lambda: asyncio.run(recorder.record()), daemon=True)
+    thread.start()
+    try:
+        # The mock closes the first connection mid-stream; wait until the
+        # recorder has reconnected and heartbeated on the second one.
+        wait_until(
+            lambda: admin.ws_state()["connections"] >= 2 and admin.ws_state()["pings"] >= 2,
+            timeout=30,
+            message="reconnect plus two PING heartbeats",
+        )
+    finally:
+        recorder.stop()
+        thread.join(timeout=30)
+    assert not thread.is_alive()
+
+    state = admin.ws_state()
+    assert state["connections"] == 2
+    assert state["invalid_subscribes"] == 0
+    # The recorder re-subscribed with the same asset IDs after the forced drop.
+    assert state["subscriptions"] == [{"assets_ids": tokens, "type": "market"}] * 2
+
+    books_dir = workdir / "data/polymarket/orderbook/books"
+    books = pd.concat(pd.read_parquet(f) for f in books_dir.glob("books_*.parquet"))
+    # One snapshot per token per connection: the server re-sends the full book
+    # on every subscribe, which is what makes reconnects replay-safe.
+    assert len(books) == 2 * len(tokens)
+    assert books["token_id"].value_counts().eq(2).all()
+    assert set(books["timestamp"]) == {int(fx.WS_BOOK_TS_MS)}
+    assert set(books["bids"]) == {json.dumps(fx.WS_BOOK_BIDS)}
+    assert set(books["asks"]) == {json.dumps(fx.WS_BOOK_ASKS)}
+
+    deltas_dir = workdir / "data/polymarket/orderbook/price_changes"
+    deltas = pd.concat(pd.read_parquet(f) for f in deltas_dir.glob("price_changes_*.parquet"))
+    assert len(deltas) == fx.WS_CONN1_DELTA_ROWS + fx.WS_CONN2_DELTA_ROWS
+    # Raw string prices and sizes are preserved, including "0" removals.
+    assert sorted(zip(deltas["price"], deltas["size"])) == [
+        ("0.44", "0"),
+        ("0.46", "25"),
+        ("0.47", "40"),
+        ("0.55", "10"),
+        ("0.56", "0"),
+    ]
+    legacy = deltas[deltas["hash"] == "legacy1"]
+    assert len(legacy) == 1
+    assert legacy.iloc[0]["token_id"] == tokens[0]
+    assert legacy.iloc[0]["side"] == "SELL"

--- a/tests/e2e/test_e2e_price_history.py
+++ b/tests/e2e/test_e2e_price_history.py
@@ -1,0 +1,43 @@
+"""Price-history scenario: cross-indexer dataflow (markets parquet -> token
+discovery), 15-day windowing, boundary dedup, and resume-skip."""
+
+import duckdb
+
+
+def test_price_history_windows_dedups_and_resumes(seeded_workdir, admin, fx):
+    from src.indexers.polymarket.price_history import PolymarketPriceHistoryIndexer
+
+    PolymarketPriceHistoryIndexer(max_workers=4).run()
+
+    # Tokens were discovered from the markets parquet written by the real
+    # markets indexer; every request respected the API's 15-day cap (the mock
+    # 400s anything longer) and the per-token window math matched.
+    requests = admin.events("/clob/prices-history")
+    assert len(requests) == 2 * sum(fx.expected_price_requests(i) for i in range(fx.FEATURED_COUNT))
+    assert max(r["meta"]["span"] for r in requests) <= fx.PRICE_WINDOW_DAYS * fx.DAY
+
+    rows = duckdb.sql(
+        "SELECT token_id, COUNT(*), COUNT(DISTINCT timestamp) "
+        "FROM 'data/polymarket/price_history/prices_*.parquet' GROUP BY token_id"
+    ).fetchall()
+    expected = {
+        token: fx.expected_price_rows(i) for i in range(fx.FEATURED_COUNT) for token in fx.featured_token_ids(i)
+    }
+    # Window-boundary points are served by both adjacent windows; the indexer
+    # must persist each timestamp exactly once per token.
+    assert {token: total for token, total, _ in rows} == expected
+    assert all(total == distinct for _, total, distinct in rows)
+
+    # Deterministic values straight from the wire format.
+    sample_token = fx.featured_token_ids(0)[0]
+    ts, price = duckdb.sql(
+        "SELECT timestamp, price FROM 'data/polymarket/price_history/prices_*.parquet' "
+        f"WHERE token_id = '{sample_token}' ORDER BY timestamp LIMIT 1"
+    ).fetchone()
+    assert ts == fx.featured_created_ts(0)
+    assert price == fx.price_at(sample_token, ts)
+
+    # Second run: every token is already persisted, so resume skips all work.
+    before = admin.count("/clob/prices-history")
+    PolymarketPriceHistoryIndexer(max_workers=4).run()
+    assert admin.count("/clob/prices-history") == before

--- a/tests/test_env_url_defaults.py
+++ b/tests/test_env_url_defaults.py
@@ -1,0 +1,31 @@
+"""The API URL constants must resolve to the production endpoints whenever no
+environment overrides are set (the overrides exist for the e2e mock harness)."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CHECK = """
+from src.indexers.polymarket import client, orderbook
+
+assert client.GAMMA_API_URL == "https://gamma-api.polymarket.com", client.GAMMA_API_URL
+assert client.CLOB_API_URL == "https://clob.polymarket.com", client.CLOB_API_URL
+assert client.DATA_API_URL == "https://data-api.polymarket.com", client.DATA_API_URL
+assert orderbook.WS_MARKET_URL == "wss://ws-subscriptions-clob.polymarket.com/ws/market", orderbook.WS_MARKET_URL
+"""
+
+
+def test_url_constants_default_to_production_endpoints(tmp_path):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("POLYMARKET_")}
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        [sys.executable, "-c", CHECK],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## What changed? Why?

the PR stack (#51-#59) ships ~1,900 lines of unit tests, but every one of them swaps the network out for in-process fakes; nothing exercised the real `HttpClient` (httpx + tenacity), the real `web3.HTTPProvider` round-trips, the real `websockets` connect/subscribe/reconnect loop, cross-indexer parquet dataflow, or process-level interrupt/resume. this PR adds a Docker Compose e2e harness that removes the fakes from the loop entirely.

**production diff (~8 lines).** `GAMMA_API_URL`, `CLOB_API_URL`, `DATA_API_URL` (`src/indexers/polymarket/client.py`) and `WS_MARKET_URL` (`src/indexers/polymarket/orderbook.py`) are now `os.getenv(...)` with the exact production URLs as defaults, mirroring the existing `POLYGON_RPC` idiom. every zero-arg `PolymarketClient()` call site becomes mock-pointable with no call-site edits. a new unit test asserts the defaults still resolve to the production endpoints when no env vars are set. `.env.example` documents the (commented-out) overrides.

**mock service (`tests/e2e/mock/`).** one FastAPI container serves all five surfaces on path prefixes, with behavioral rules rather than canned responses:

- gamma REST: offset and keyset pagination that actually slices a 25k-market / 1,400-event corpus, `closed` filtering (so the events indexer's two-phase walk is real), `order=volume` sorting for orderbook token discovery
- CLOB REST: `/prices-history` returns HTTP 400 when `endTs - startTs` > 15 days (replicating the undocumented production cap) and otherwise serves a deterministic hourly series with shared boundary points; `/book`, `/midpoint`, `/spread`, `/price` with string-typed payloads as production sends
- data API: `/trades` honoring `market` (comma-split condition IDs) and `start`/`end` scoping, `limit`/`offset` slicing, the 10,000 offset cap, and two malformed rows to exercise skip-at-parse
- polygon JSON-RPC: `eth_getLogs` with real address + topic filtering over an ABI-encoded canned log store (OrderFilled, FPMMBuy/Sell, ConditionResolution, plus one undecodable log), a "block range too large" error for topic-only queries wider than 600 blocks (forces the FPMM bisection path), POA-shaped 97-byte `extraData` blocks (exercises `ExtraDataToPOAMiddleware`), and `eth_call` selector dispatch for `collateralToken()` / `symbol()` including a reverting token
- CLOB market websocket: subscribe validation, per-token `book` snapshots on every subscribe, scripted `price_change` frames (including `size: "0"` removals and the legacy `changes` shape), literal PING/PONG, and a forced mid-stream disconnect on the first connection
- `/admin/*`: request accounting, one-shot failure injection, and per-endpoint latency control for deterministic interrupt timing

the mock image installs only fastapi/uvicorn/websockets; no production dependency leaks into it, and no mock dependency leaks into the repo lock.

**compose harness.** `compose.e2e.yaml` runs mock + runner on an `internal: true` network (no external egress is possible; a canary test asserts the production gamma host is unreachable), gates the runner on the mock healthcheck, mounts a tmpfs at `/app/data`, and the runner image installs the exact `uv.lock` on python 3.9. `make e2e` wraps the compose invocation and cleans up afterwards.

**e2e suite (`tests/e2e/`, 18 tests, ~41s).** all scenarios drive real production classes over real sockets, and assert on persisted parquet/JSON/cursor artifacts:

- markets: 25k rows across 3 chunk files, offset cursor removed on completion
- events: two-phase keyset walk (`closed=false` then `true`), phase cursor transitions observed on the wire
- price history: tokens discovered from the markets parquet written by the real markets indexer (cross-indexer dataflow), every request within the 15-day cap, boundary-timestamp dedup, re-run issues zero new requests
- data API trades: full window overflows the offset cap and is bisected; 12,000 rows persisted duplicate-free by composite key; malformed rows skipped
- CTF trades, FPMM trades (too-large bisection), blocks (sampling + exact interpolation), resolutions (payout-array decode): decoded parquet compared field-by-field against the fixture log store
- collateral: consumes the FPMM run's parquet, `UNKNOWN` fallback on revert, symbol caching, idempotent second run performs zero `eth_call`s
- orderbook: real `websockets` client against the scripted channel; forced disconnect, reconnect + re-subscribe, >=2 PING/PONG round-trips, raw string prices and `size="0"` rows persisted in both parquet tables
- interrupt/resume: real subprocesses killed with real SIGINT for the offset-cursor (markets), block-cursor (CTF trades), and composite-cursor (data API) families; resumed runs complete with duplicate-free datasets (asserted via duckdb)
- retry: injected 500 on gamma keyset is retried through real httpx/tenacity and the run completes
- client surfaces: `/book`/`/midpoint`/`/spread`/`/price` string parsing, keyset cursor chaining, the >15-day 400

a new `e2e` pytest marker keeps these out of the default run (`addopts = -m "not e2e"`), so `make test` and CI are unchanged.

## Notes to reviewers

key files:

- `src/indexers/polymarket/client.py`, `src/indexers/polymarket/orderbook.py`: the entire production diff (env-driven URL constants)
- `tests/e2e/mock/fixtures.py`: the deterministic corpus, shared between the mock and the tests (tests import it to derive expected values, so assertions and served data can never drift apart)
- `tests/e2e/mock/app.py`: the mock service
- `compose.e2e.yaml`, `tests/e2e/runner.Dockerfile`, `tests/e2e/mock/Dockerfile`, `Makefile` (`e2e` target)
- `tests/e2e/test_e2e_*.py`, `tests/e2e/conftest.py`, `tests/test_env_url_defaults.py`

things worth knowing:

- SIGINT timing is made deterministic by construction, not by sleeps: tests poll for the cursor file and interrupt during a stretched fetch (an admin latency knob widens the getLogs window), and the CTF fixture places CTF-exchange fills only in blocks that a resumed run never re-fetches. while building that I noticed the trades indexer resumes *at* the cursor block (`from_block = cursor`) rather than `cursor + 1` like resolutions, so production resume can re-fetch one already-processed block; a fill in exactly that block would be duplicated. the harness works around it via fixture placement rather than hiding it; worth a follow-up fix.
- the mock's keyset cursors are opaque offset strings, not real id-based cursors; the client treats them as opaque either way.
- limitations: the harness verifies our code against the recorded contract, so production API contract drift and true rate-limit/latency behavior remain out of scope (that is inherent to any local mock). mock-image deps are pinned by range, not lock, since the mock is not production code. the egress canary only runs inside the compose network (it is skipped on host runs, where egress exists).
- the runner needs docker compose with buildx >= 0.17 (compose v5 requirement).

## How has it been tested?

- `docker compose -f compose.e2e.yaml up --build --abort-on-container-exit --exit-code-from runner`: `18 passed, 1 warning in 41.38s`, runner exit code 0, including the no-egress canary. a second consecutive run passed identically (`18 passed in 40.42s`), confirming determinism. containers, images, volumes, and the network were removed afterwards.
- `uv run ruff check .` and `uv run ruff format --check .`: clean.
- `uv run pytest tests/ -v`: 205 passed, 18 deselected (the e2e suite is deselected by marker, so the default suite is unchanged plus the new URL-defaults unit test).
- the full e2e suite was also run against a local (non-container) mock during development: 17 passed, 1 skipped (the egress canary, by design outside compose).
