### PR TITLE
docs: add cao (2026) citing paper to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Akey P., Gregoire, V., Harvie, N., Martineau, C. (2026). _Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6443103
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
 - Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
+- Cao, D. (2026). _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN. https://papers.ssrn.com/sol3/Delivery.cfm/7049119.pdf?abstractid=7049119&mirid=1
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662


### PR DESCRIPTION
## What changed? Why?

Added the following citing paper to the **Research & Citations** section of `README.md`, inserted in alphabetical order by author surname:

- Cao, D. (2026). _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN.

This paper cites Jonathan Becker's "The Microstructure of Wealth Transfer in Prediction Markets" and the prediction-market-analysis repository, so it belongs in the bibliography.

## Notes to reviewers

- Single-line insertion in `README.md` (the citations list); no other tracked files changed.
- Entry placed after "Brown, A." to keep it alphabetical by surname (C follows B).

## How has it been tested?

- `git diff` confirms exactly one added line and zero removals.
- `git diff --check` passes (no whitespace errors).
- Markdown list formatting matches the surrounding entries.
