### PR TITLE
docs: append Cao and Adegbenro (2026) SSRN citations to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Akey P., Gregoire, V., Harvie, N., Martineau, C. (2026). _Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6443103
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
 - Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
-- Cao, D. (2026). _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN. https://papers.ssrn.com/sol3/Delivery.cfm/7049119.pdf?abstractid=7049119&mirid=1
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662
-- Adegbenro, A. (2026). _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. arXiv. https://arxiv.org/abs/2606.17503
+- Cao, D. (2026). _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7049119
+- Adegbenro, A. (2026). _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6923459
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

Appended the two confirmed SSRN research citations as the final two bullets under `## Research & Citations` in `README.md`, preserving the existing bullet style:

- **Cao, D. (2026)** — _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7049119
- **Adegbenro, A. (2026)** — _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6923459

Both authors previously appeared in the list via different/older source links (a SSRN PDF-delivery URL for Cao, and an arXiv preprint for Adegbenro). To avoid duplicating a citation, those prior entries were relocated to become these two appended bullets with the canonical SSRN links, so each paper is listed exactly once.

## Notes to reviewers

- `README.md` — only file changed. The two citations now appear once each, as the last two bullets in the list.

## How has it been tested?

- `git diff --name-only origin/main...HEAD` confirms `README.md` is the only changed file.
- `grep -c` confirms exactly one occurrence each of the Cao and Adegbenro citations (no duplicates).
