### PR TITLE
docs: add Adamczewski UFC prediction markets citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618
 - Brown, A. (2026). _Cassandra Or the Boy Who Cried Wolf? Are Prediction Markets Effective Early Warning Systems?_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6381538
 - Cao, D. (2026). _Retail-Adjusted Expected Value in Prediction Markets: Calibration, Longshot Bias, and Consumer Welfare_. SSRN. https://papers.ssrn.com/sol3/Delivery.cfm/7049119.pdf?abstractid=7049119&mirid=1
+- Adamczewski, M. (2026). _Integration Without Leadership: Cross-Venue Price Discovery in UFC Prediction Markets_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7194218
 - Reichenbach, F., Walther, M. (2025). _Exploring Decentralized Prediction Markets: Accuracy, Skill, and Bias on Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5910522
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662


### PR DESCRIPTION
## What changed? Why?

Added the confirmed SSRN citation for Michał Adamczewski's 2026 paper, _Integration Without Leadership: Cross-Venue Price Discovery in UFC Prediction Markets_, to the Research & Citations list in README.md. This keeps the project bibliography current and makes the paper discoverable to dataset users.

## Notes to reviewers

Only README.md changed. The existing SSRN 5910522 citation remains unchanged and is not duplicated.

## How has it been tested?

- `git diff --check`
- `make lint`
- `make test` (111 passed)