### PR TITLE
docs(research): add becker wealth transfer paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If you've found an issue or have a question, please open an issue [here](https:/
 ## Research & Citations
 
 - Becker, J. (2026). _The Microstructure of Wealth Transfer in Prediction Markets_. Jbecker. https://jbecker.dev/research/prediction-market-microstructure
+- Becker, J. (2026). _The Microstructure of Wealth Transfer in Prediction Markets_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7217640
 - Le, N. A. (2026). _Decomposing Crowd Wisdom: Domain-Specific Calibration Dynamics in Prediction Markets_. arXiv. https://arxiv.org/abs/2602.19520
 - Akey P., Gregoire, V., Harvie, N., Martineau, C. (2026). _Who Wins and Who Loses In Prediction Markets? Evidence from Polymarket_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6443103
 - Vedova, J. (2026). _Who Profits from Prediction Markets? Execution, not Information_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6191618


### PR DESCRIPTION
## What changed? Why?

Adds the SSRN publication record for Jonathan Becker's paper _The Microstructure of Wealth Transfer in Prediction Markets_ (2026) to the **Research & Citations** section of `README.md`, following the repository's established one-line citation convention (`Author (Year). _Title_. Venue. URL`).

The paper analyzes 72.1M Kalshi transactions (Jun 2021–Nov 2025) and shows that aggregate calibration conceals a persistent internal wealth transfer — an "optimism tax" paid by liquidity takers (−1.12%/trade) to makers (+1.12%/trade) — directly relevant to this repo's Kalshi/Polymarket microstructure datasets and analyses.

Note: a self-hosted (jbecker.dev) record for this same paper already exists as the first entry in the list. Per the task scope, that existing record was left untouched; this PR only appends the SSRN record adjacent to it. No metadata was invented beyond the supplied author, title, year, venue (SSRN), and SSRN abstract URL.

## Notes to reviewers

- `README.md` — one line added under `## Research & Citations` (SSRN entry for the Becker paper).

No source code changed; this is a docs-only citation addition.

## How has it been tested?

- `make lint` → `ruff check` + `ruff format --check`: **All checks passed!** (61 files already formatted)
- `make test` → `pytest tests/ -v`: **111 passed, 4 warnings in 14.42s**
