### PR TITLE
docs: add Morgan Stanley Wisdom of Crowds citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,6 @@ If you've found an issue or have a question, please open an issue [here](https:/
 - Bartlett, R., O'Hara, M. (2026). _Adverse Selection in Prediction Markets: Evidence from Kalshi_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6615739
 - Luong, K. L., Heesen, G. (2026). _The Wisdom of the Few: Skilled Traders and Prediction Market Accuracy_. SSRN. https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6758662
 - Adegbenro, A. (2026). _What Prediction Markets Can See: Market Formation, Settlement Legibility, and the Geography of Tradable Uncertainty in Africa and Latin America_. arXiv. https://arxiv.org/abs/2606.17503
+- Mauboussin, M. J., Callahan, D. (2026). _The Wisdom of Crowds in Markets: Crowd Behavior in Prediction, Betting, and Stock Markets_. Morgan Stanley. https://www.morganstanley.com/content/dam/im/assets/publication/thought-leadership/consilient-observer/article_thewisdomofcrowds_ltr.pdf?1786370649511
 
 If you have used or plan to use this dataset in your research, please reach out via [email](mailto:jonathan@jbecker.dev) or [Twitter](https://x.com/BeckerrJon) -- i'd love to hear about what you're using the data for! Additionally, feel free to open a PR and update this section with a link to your paper.


### PR DESCRIPTION
## What changed? Why?

Adds the Morgan Stanley Counterpoint Global Insights report "The Wisdom of Crowds in Markets: Crowd Behavior in Prediction, Betting, and Stock Markets" (Mauboussin & Callahan, Consilient Observer, August 5, 2026) to the Research & Citations section of the README. This extends the project's bibliography of prediction-market literature.

## Notes to reviewers

- `README.md` — one new bibliography entry appended to the Research & Citations list, following the existing citation format.

## How has it been tested?

Ran `make lint` (ruff check + format check) locally; all checks passed. The change is documentation-only and touches no code.
